### PR TITLE
fix(tasty): allow to extend components with required props

### DIFF
--- a/.changeset/spotty-keys-give.md
+++ b/.changeset/spotty-keys-give.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Allow `tasty` to extend components with required properties.

--- a/src/tasty/tasty.tsx
+++ b/src/tasty/tasty.tsx
@@ -23,7 +23,7 @@ export type TastyProps<K extends StyleList, DefaultProps = Props> = {
   /** The list of styles that can be provided by props */
   styleProps?: K;
   element?: BaseProps['element'];
-} & Omit<DefaultProps, 'as' | 'styles' | 'styleProps'>;
+} & Partial<Omit<DefaultProps, 'as' | 'styles' | 'styleProps'>>;
 
 export interface GlobalTastyProps {
   breakpoints?: number[];

--- a/src/type-checks.tsx
+++ b/src/type-checks.tsx
@@ -1,0 +1,9 @@
+import { tasty } from './tasty';
+import { RadioButton } from './components/forms/RadioGroup/Radio';
+
+tasty(RadioButton, {
+  // value is required
+  inputStyles: {
+    fill: '#clear',
+  },
+});


### PR DESCRIPTION
### Describe changes

Allow `tasty` to extend components with required properties.