### PR TITLE
fix: menu behavior when inside modal

### DIFF
--- a/.changeset/weak-dolls-move.md
+++ b/.changeset/weak-dolls-move.md
@@ -2,4 +2,4 @@
 "@cube-dev/ui-kit": patch
 ---
 
-fix(menu): menu trigger behavior when inside modal
+fix(menu): Fixed bug when menu doesn't open within a modal

--- a/.changeset/weak-dolls-move.md
+++ b/.changeset/weak-dolls-move.md
@@ -2,4 +2,4 @@
 "@cube-dev/ui-kit": patch
 ---
 
-fix(menu): Fixed bug when menu doesn't open within a modal
+Fixed bug when menu doesn't open within a modal

--- a/.changeset/weak-dolls-move.md
+++ b/.changeset/weak-dolls-move.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+fix(menu): menu trigger behavior when inside modal

--- a/src/components/pickers/Menu/Menu.stories.tsx
+++ b/src/components/pickers/Menu/Menu.stories.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../../index';
 import { baseProps } from '../../../stories/lists/baseProps';
 import { action } from '@storybook/addon-actions';
+import { userEvent, waitFor, within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
 
 export default {
   title: 'Pickers/Menu',
@@ -99,9 +101,15 @@ export const InsideModal = () => {
             <Button
               size="small"
               icon={<MoreOutlined />}
+              data-qa="contextMenuButton"
               aria-label="Open Context Menu"
             />
-            <Menu id="menu" width="220px" selectionMode="multiple">
+            <Menu
+              data-qa="contextMenuList"
+              id="menu"
+              width="220px"
+              selectionMode="multiple"
+            >
               <Menu.Item key="red" postfix="Ctr+C" onPress={action('Ctr+C')}>
                 Copy
               </Menu.Item>
@@ -117,6 +125,17 @@ export const InsideModal = () => {
       />
     </DialogContainer>
   );
+};
+
+InsideModal.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const button = await canvas.findByTestId('contextMenuButton');
+
+  await userEvent.click(button);
+
+  const list = await canvas.findByTestId('contextMenuList');
+
+  await waitFor(() => expect(list).toBeInTheDocument());
 };
 
 export const Sections = (props) => {

--- a/src/components/pickers/Menu/Menu.stories.tsx
+++ b/src/components/pickers/Menu/Menu.stories.tsx
@@ -12,6 +12,8 @@ import {
   Text,
   Root,
   Space,
+  AlertDialog,
+  DialogContainer,
 } from '../../../index';
 import { baseProps } from '../../../stories/lists/baseProps';
 import { action } from '@storybook/addon-actions';
@@ -85,6 +87,35 @@ export const Default = ({ ...props }) => {
         </MenuTrigger>
       </Space>
     </Root>
+  );
+};
+
+export const InsideModal = () => {
+  return (
+    <DialogContainer>
+      <AlertDialog
+        content={
+          <MenuTrigger>
+            <Button
+              size="small"
+              icon={<MoreOutlined />}
+              aria-label="Open Context Menu"
+            />
+            <Menu id="menu" width="220px" selectionMode="multiple">
+              <Menu.Item key="red" postfix="Ctr+C" onPress={action('Ctr+C')}>
+                Copy
+              </Menu.Item>
+              <Menu.Item key="orange" postfix="Ctr+V" onPress={action('Ctr+C')}>
+                Paste
+              </Menu.Item>
+              <Menu.Item key="yellow" postfix="Ctr+X" onPress={action('Ctr+C')}>
+                Cut
+              </Menu.Item>
+            </Menu>
+          </MenuTrigger>
+        }
+      />
+    </DialogContainer>
   );
 };
 

--- a/src/components/pickers/Menu/MenuTrigger.tsx
+++ b/src/components/pickers/Menu/MenuTrigger.tsx
@@ -1,19 +1,14 @@
 import React, { ReactNode, forwardRef, Fragment, useRef } from 'react';
-import {
-  unwrapDOMRef,
-  useDOMRef,
-  useIsMobileDevice,
-} from '@react-spectrum/utils';
+import { useDOMRef, useIsMobileDevice } from '@react-spectrum/utils';
 import { DismissButton, useOverlayPosition } from '@react-aria/overlays';
-import { DOMRef, DOMRefValue } from '@react-types/shared';
-import { FocusScope } from '@react-aria/focus';
+import { DOMRef } from '@react-types/shared';
 import { Placement, PositionProps } from '@react-types/overlays';
 import { PressResponder } from '@react-aria/interactions';
 import { MenuTriggerProps as BaseTriggerProps } from '@react-types/menu';
 import { useMenuTrigger } from '@react-aria/menu';
 import { useMenuTriggerState } from '@react-stately/menu';
 import { Popover, Tray } from '../../overlays/Modal';
-import { mergeProps, SlotProvider } from '../../../utils/react';
+import { SlotProvider } from '../../../utils/react';
 import { MenuContext, MenuContextValue } from './context';
 
 export type CubeMenuTriggerProps = BaseTriggerProps &
@@ -120,7 +115,7 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
         placement={placement}
         hideArrow
         onClose={state.close}
-        shouldCloseOnBlur
+        isNonModal
       >
         {contents}
       </Popover>


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

When using MenuTrigger inside DialogContainer or any Popover it doesn't work properly.
