### PR TITLE
Add ability to specify if Notification should be removed on unmount

### DIFF
--- a/.changeset/heavy-cooks-train.md
+++ b/.changeset/heavy-cooks-train.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Add `disableRemoveOnUnmount` prop in `<Notificaiton />` and `<Toast />` components

--- a/src/components/content/Alert/alert.test.tsx
+++ b/src/components/content/Alert/alert.test.tsx
@@ -2,6 +2,15 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useAlert } from './use-alert';
 
 describe('<Alert /> component', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'group').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should correctly render disabled', () => {
     const { result } = renderHook(() =>
       useAlert({ theme: 'danger', isDisabled: true }),

--- a/src/components/overlays/NewNotifications/Notification.tsx
+++ b/src/components/overlays/NewNotifications/Notification.tsx
@@ -3,34 +3,50 @@ import { useNotificationsApi } from './hooks';
 import { CubeNotifyApiProps } from './types';
 import { useId } from '../../../utils/react/useId';
 
-export function Notification(props: CubeNotifyApiProps) {
-  const { id: propsId } = props;
-  const { notify, update } = useNotificationsApi();
+export type NotificationProps = {
+  /**
+   * If set to true, when the component gets unmounted, notifications will not be removed from the bar
+   *
+   * @default false
+   */
+  disableRemoveOnUnmount?: boolean;
+} & CubeNotifyApiProps;
+
+export function Notification(props: NotificationProps) {
+  const { id: propsId, disableRemoveOnUnmount = false } = props;
+
+  const { notify, update, remove } = useNotificationsApi();
   const defaultId = useId();
 
   const id = propsId ?? defaultId;
 
   useEffect(() => {
-    const { remove } = notify({ id, ...props });
-
-    return remove;
+    notify({ id, ...props });
   }, [id]);
+
+  useEffect(() => {
+    if (disableRemoveOnUnmount) {
+      return;
+    }
+
+    return () => remove(id);
+  }, []);
 
   useEffect(() => update(id, props));
 
   return null;
 }
 
-Notification.Success = function NotificationSuccess(props: CubeNotifyApiProps) {
+Notification.Success = function NotificationSuccess(props: NotificationProps) {
   return <Notification type="success" {...props} />;
 };
 
-Notification.Danger = function NotificationDanger(props: CubeNotifyApiProps) {
+Notification.Danger = function NotificationDanger(props: NotificationProps) {
   return <Notification type="danger" {...props} />;
 };
 
 Notification.Attention = function NotificationAttention(
-  props: CubeNotifyApiProps,
+  props: NotificationProps,
 ) {
   return <Notification type="attention" {...props} />;
 };

--- a/src/components/overlays/NewNotifications/notification.test.tsx
+++ b/src/components/overlays/NewNotifications/notification.test.tsx
@@ -1,0 +1,38 @@
+import { renderWithRoot } from '../../../test';
+import { Notification } from './Notification';
+
+const TestComponent = ({ renderNotification = true, ...notificationProps }) =>
+  renderNotification ? (
+    <Notification description="Test" {...notificationProps} />
+  ) : null;
+
+describe('<Notification />', () => {
+  beforeEach(() => jest.useFakeTimers('modern'));
+  afterEach(() => jest.useRealTimers());
+
+  it('should unmount component by default', () => {
+    const { getByTestId, rerender } = renderWithRoot(<TestComponent />);
+
+    const notification = getByTestId('floating-notification');
+
+    rerender(
+      <TestComponent disableRemoveOnUnmount renderNotification={false} />,
+    );
+
+    expect(notification).not.toBeInTheDocument();
+  });
+
+  it('should keep notification if disableRemoveOnUnmount set to true', () => {
+    const { rerender, getByTestId } = renderWithRoot(
+      <TestComponent disableRemoveOnUnmount />,
+    );
+
+    const notification = getByTestId('floating-notification');
+
+    rerender(
+      <TestComponent disableRemoveOnUnmount renderNotification={false} />,
+    );
+
+    expect(notification).toBeInTheDocument();
+  });
+});

--- a/src/components/overlays/Toasts/Toast.tsx
+++ b/src/components/overlays/Toasts/Toast.tsx
@@ -1,37 +1,49 @@
 import { useEffect } from 'react';
 import { useToastsApi } from './use-toasts-api';
 import { CubeToastsApiProps } from './types';
-import { CubeNotifyApiProps } from '../NewNotifications';
 import { useId } from '../../../utils/react/useId';
 
-export function Toast(props: CubeToastsApiProps) {
-  const { id: propsId } = props;
+export type ToastProps = {
+  /**
+   * If set to true, when the component gets unmounted, notifications will not be removed from the bar
+   *
+   * @default false
+   */
+  disableRemoveOnUnmount?: boolean;
+} & CubeToastsApiProps;
+
+export function Toast(props: ToastProps) {
+  const { id: propsId, disableRemoveOnUnmount } = props;
   const { toast, update, remove } = useToastsApi();
   const defaultId = useId();
 
   const id = propsId ?? defaultId;
 
   useEffect(() => {
-    toast({ ...props, id });
-
-    return () => remove(id);
+    toast({ id, ...props });
   }, [id]);
 
   useEffect(() => {
-    update(id, props as CubeNotifyApiProps);
-  });
+    if (disableRemoveOnUnmount) {
+      return;
+    }
+
+    return () => remove(id);
+  }, []);
+
+  useEffect(() => update(id, props));
 
   return null;
 }
 
-Toast.Success = function ToastSuccess(props: CubeToastsApiProps) {
+Toast.Success = function ToastSuccess(props: ToastProps) {
   return <Toast type="success" {...props} />;
 };
 
-Toast.Danger = function ToastDanger(props: CubeToastsApiProps) {
+Toast.Danger = function ToastDanger(props: ToastProps) {
   return <Toast type="danger" {...props} />;
 };
 
-Toast.Attention = function ToastAttention(props: CubeToastsApiProps) {
+Toast.Attention = function ToastAttention(props: ToastProps) {
   return <Toast type="attention" {...props} />;
 };

--- a/src/components/overlays/Toasts/Toast.tsx
+++ b/src/components/overlays/Toasts/Toast.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { Key, useEffect } from 'react';
 import { useToastsApi } from './use-toasts-api';
 import { CubeToastsApiProps } from './types';
+import { useEvent, useSyncRef } from '../../../_internal';
 import { useId } from '../../../utils/react/useId';
 
 export type ToastProps = {
@@ -14,23 +15,21 @@ export type ToastProps = {
 
 export function Toast(props: ToastProps) {
   const { id: propsId, disableRemoveOnUnmount } = props;
-  const { toast, update, remove } = useToastsApi();
+
   const defaultId = useId();
+  const disableRemoveOnUnmountRef = useSyncRef(disableRemoveOnUnmount);
+  const { toast, update, remove } = useToastsApi();
 
   const id = propsId ?? defaultId;
+
+  const removeNotification = useEvent((id: Key) =>
+    disableRemoveOnUnmountRef.current ? void 0 : remove(id),
+  );
 
   useEffect(() => {
     toast({ id, ...props });
   }, [id]);
-
-  useEffect(() => {
-    if (disableRemoveOnUnmount) {
-      return;
-    }
-
-    return () => remove(id);
-  }, []);
-
+  useEffect(() => () => removeNotification(id), [id]);
   useEffect(() => update(id, props));
 
   return null;

--- a/src/styled/styled.test.tsx
+++ b/src/styled/styled.test.tsx
@@ -4,6 +4,10 @@ import { Button } from '../components/actions';
 import { Block } from '../components/Block';
 
 describe('styled() API', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'group').mockImplementation(() => {});
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/src/tasty/tasty.test.tsx
+++ b/src/tasty/tasty.test.tsx
@@ -5,14 +5,6 @@ import { Block } from '../components/Block';
 import { CONTAINER_STYLES } from './styles/list';
 
 describe('tasty() API', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
-
   it('should provide defaults and give ability to override', () => {
     const SButton = tasty(Button, { type: 'primary' });
 

--- a/src/tasty/utils/filterBaseProps.ts
+++ b/src/tasty/utils/filterBaseProps.ts
@@ -48,7 +48,10 @@ interface PropsFilterOptions {
  * @param props - The component props to be filtered.
  * @param opts - Props to override.
  */
-export function filterBaseProps(props, opts: PropsFilterOptions = {}) {
+export function filterBaseProps(
+  props,
+  opts: PropsFilterOptions = {},
+): Record<string, any> {
   let { labelable, propNames, eventProps } = opts;
   let filteredProps = {};
 


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Pipeline is passed
- [x] Tests are added (including unit tests and stories in the storybook)
- [x] Tests are passed successfully
- [x] If you're adding a new component/new props, add stories that describe how this component/prop works
- [x] Changeset(s) is(are) added
- [x] You have passed the threshold of the library size
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information
