### PR TITLE
[CC-1327] Trigger onDismiss on Esc press 

### DIFF
--- a/.changeset/friendly-swans-build.md
+++ b/.changeset/friendly-swans-build.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+[CC-1327](https://cubedevinc.atlassian.net/browse/CC-1327): Fixed bug when `onDismiss` doesn't trigger on `ESC` press within `AlertDialog`

--- a/src/components/overlays/AlertDialog/AlertDialogApiProvider.tsx
+++ b/src/components/overlays/AlertDialog/AlertDialogApiProvider.tsx
@@ -27,12 +27,13 @@ export function AlertDialogApiProvider(props) {
   const api = useMemo<DialogApi>(
     () => ({
       open: (dialogProps, params = {}) => {
+        const { onDismiss, ...restProps } = dialogProps;
         const { cancelToken } = params;
         const currentId = ++id.current;
         const currentDialog = {
-          props: dialogProps,
+          props: null,
           meta: { id: currentId, isClosed: false, isVisible: true },
-        } as Dialog;
+        } as unknown as Dialog;
 
         const close = () => {
           if (currentDialog.meta.isClosed) return;
@@ -72,6 +73,14 @@ export function AlertDialogApiProvider(props) {
             reject(reason);
           };
         });
+
+        currentDialog.props = {
+          ...restProps,
+          onDismiss: (e) => {
+            onDismiss?.(e);
+            currentDialog.meta.reject(undefined);
+          },
+        };
 
         setOpenedDialog((openedDialog) => {
           // we already have opened dialog, so we reject opening another

--- a/src/components/overlays/AlertDialog/AlertDialogZone.tsx
+++ b/src/components/overlays/AlertDialog/AlertDialogZone.tsx
@@ -74,7 +74,7 @@ export function AlertDialogZone(props: DialogZoneProps): JSX.Element {
         isOpen={isVisible}
         isDismissable={isDismissable}
         type={type}
-        onDismiss={resolve}
+        onDismiss={onDismiss}
       >
         <AlertDialog
           noActions={dialogType === 'form'}

--- a/src/components/overlays/AlertDialog/tests/use-alert-dialog-api.test.tsx
+++ b/src/components/overlays/AlertDialog/tests/use-alert-dialog-api.test.tsx
@@ -1,52 +1,92 @@
-import { setTimeout } from 'node:timers/promises';
-
-import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { renderWithRoot } from '../../../../test/render';
+import { act, renderWithRoot } from '../../../../test';
 import { useAlertDialogAPI } from '../AlertDialogApiProvider';
+import { Button } from '../../../actions';
+import { DialogProps } from '../types';
 
-describe('useAlertDialogApi', () => {
+describe('useAlertDialogApi()', () => {
   let prevDialogPromise: Promise<string> | null = null;
   let dialogPromise: Promise<string> | null = null;
   let abortController: AbortController | null = null;
 
-  function TestComponent() {
+  const onResolve = jest.fn();
+  const onReject = jest.fn();
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function TestComponent(props: Partial<DialogProps>) {
+    const {
+      content = <>Lorem ipsum dolor sit amet</>,
+      title = 'Test Dialog',
+      ...rest
+    } = props;
     const { open } = useAlertDialogAPI();
 
     return (
-      <div
-        onClick={() => {
+      <Button
+        onPress={() => {
           abortController = new AbortController();
           prevDialogPromise = dialogPromise;
           dialogPromise = null;
 
           dialogPromise = open(
             {
-              content: <>Lorem ipsum dolor sit amet</>,
-              title: 'Test Dialog',
+              content,
+              title,
+              ...rest,
             },
             { cancelToken: abortController.signal },
           );
+
+          dialogPromise.then(onResolve).catch(onReject);
         }}
       >
         Open Dialog
-      </div>
+      </Button>
     );
   }
 
   it('should close dialog by abort controller', async () => {
-    const { getByText, getByRole } = renderWithRoot(<TestComponent />);
+    const { getByRole } = renderWithRoot(<TestComponent />);
 
-    const showDialogButton = getByText(/Open Dialog/);
+    const showDialogButton = getByRole('button');
 
-    await act(() => userEvent.click(showDialogButton));
-    await act(async () => {
+    await userEvent.click(showDialogButton);
+
+    jest.useFakeTimers('modern');
+
+    act(() => {
       abortController?.abort();
-      await setTimeout(350);
+      jest.runAllTimers();
     });
-    await act(() => userEvent.click(showDialogButton));
+
+    jest.useRealTimers();
+
+    await userEvent.click(showDialogButton);
 
     expect(getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('should reject on onDismiss', async () => {
+    const onDismiss = jest.fn();
+
+    const { getByRole } = renderWithRoot(
+      <TestComponent onDismiss={onDismiss} />,
+    );
+    const showDialogButton = getByRole('button');
+
+    await userEvent.click(showDialogButton);
+    await userEvent.keyboard('{Escape}');
+
+    expect(onDismiss).toHaveBeenCalled();
+    expect(onReject).toHaveBeenCalled();
+    await expect(dialogPromise).rejects.toEqual(undefined);
   });
 });


### PR DESCRIPTION
### Describe changes

This PR fixes a bug when `onDismiss` didn't trigger on `ESC` press.

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: CC-1327

#

### Other information
