### PR TITLE
[CC-1364] Prevent calling useNotificationObserver callback if notification is already removed

### DIFF
--- a/.changeset/unlucky-chicken-greet.md
+++ b/.changeset/unlucky-chicken-greet.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+[CC-1364](https://cubedevinc.atlassian.net/browse/CC-1364) - fixed bug when useNotificationObserver calls callback with already removed notification

--- a/src/_internal/hooks/use-timer/use-timer.test.ts
+++ b/src/_internal/hooks/use-timer/use-timer.test.ts
@@ -1,21 +1,29 @@
 import { renderHook } from '@testing-library/react-hooks';
 
-import { wait } from '../../../test';
-
 import { useTimer } from './use-timer';
 import { Timer } from './timer';
 
 describe('useTimer', () => {
   const callback = jest.fn();
 
-  beforeEach(jest.resetAllMocks);
+  beforeAll(() => {
+    jest.useFakeTimers('modern');
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   it('should trigger callback', async () => {
     const { result } = renderHook(useTimer, {
       initialProps: { callback, delay: 100 },
     });
 
-    await wait(250);
+    jest.runAllTimers();
 
     expect(callback).toBeCalledTimes(1);
     expect(result.current.timer?.status).toBe('stopped');
@@ -33,7 +41,7 @@ describe('useTimer', () => {
       },
     });
 
-    await wait(300);
+    jest.runAllTimers();
 
     expect(result.current.timer).toBe(timer);
     expect(dummyCallback).not.toBeCalled();
@@ -46,7 +54,8 @@ describe('useTimer', () => {
     });
 
     unmount();
-    await wait(20);
+
+    jest.runAllTimers();
 
     expect(result.current.timer?.status).toBe('stopped');
     expect(callback).toBeCalledTimes(0);
@@ -59,7 +68,7 @@ describe('useTimer', () => {
 
     expect(result.current.timer?.status).toBe('stopped');
 
-    await wait(30);
+    jest.runAllTimers();
 
     expect(callback).not.toBeCalled();
     expect(result.current.timer?.status).toBe('stopped');
@@ -74,7 +83,7 @@ describe('useTimer', () => {
 
     rerender({ isDisabled: true });
 
-    await wait(30);
+    jest.runAllTimers();
 
     expect(callback).not.toBeCalled();
     expect(result.current.timer?.status).toBe('stopped');

--- a/src/components/overlays/NewNotifications/Bar/__tests__/notifications-bar.test.tsx
+++ b/src/components/overlays/NewNotifications/Bar/__tests__/notifications-bar.test.tsx
@@ -60,6 +60,7 @@ describe('<NotificationsBar />', () => {
       (el) => el.getAttribute('data-id'),
     );
 
+    expect(onRemoveToast).toBeCalledTimes(2);
     expect(renderedIds).toHaveLength(5);
     expect(renderedIds).toEqual(['7', '6', '5', '4', '3']);
   });

--- a/src/components/overlays/NewNotifications/Notification.tsx
+++ b/src/components/overlays/NewNotifications/Notification.tsx
@@ -33,6 +33,8 @@ export function Notification(props: NotificationProps) {
 
   useEffect(() => {
     notify({ id, ...props });
+    // We can safety ignore props, bc we update notification in the another effect, this effect only mounts a notification.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
   useEffect(() => () => removeNotification(id), [id, removeNotification]);
   useEffect(() => update(id, props));

--- a/src/components/overlays/NewNotifications/Notifications.stories.tsx
+++ b/src/components/overlays/NewNotifications/Notifications.stories.tsx
@@ -14,9 +14,7 @@ import { Header } from '../../content/Header';
 import { Content } from '../../content/Content';
 import { Footer } from '../../content/Footer';
 import { Title } from '../../content/Title';
-import { range } from '../../../utils/range';
 import { wait } from '../../../test';
-import { random } from '../../../utils/random';
 
 import { NotificationsDialog, NotificationsDialogTrigger } from './Dialog';
 import { NotificationsList } from './NotificationsList';
@@ -456,12 +454,13 @@ WithWidget.play = ActionTemplate.play;
 
 export const NotificationsQueue = ActionTemplate.bind({});
 NotificationsQueue.play = async ({ canvasElement }) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  for await (const _ of range(10)) {
-    const { getByTestId } = within(canvasElement);
+  const timeouts = [780, 580, 480, 494, 743, 749, 680, 750, 569, 510];
 
-    const button = getByTestId('ClickMeButton');
+  const { getByTestId } = within(canvasElement);
+  const button = getByTestId('ClickMeButton');
+
+  for await (const timeout of timeouts) {
     await userEvent.click(button);
-    await wait(random(400, 800));
+    await wait(timeout);
   }
 };

--- a/src/components/overlays/NewNotifications/NotificationsContext/use-notifications.ts
+++ b/src/components/overlays/NewNotifications/NotificationsContext/use-notifications.ts
@@ -93,6 +93,10 @@ export function useNotifications(
   const onDismissNotification = useEvent((id: Key) => {
     const toast = notifications.get(id);
 
+    if (toast == null) {
+      return;
+    }
+
     if (toast?.putNotificationInDropdownOnDismiss !== false) {
       rootRef?.current?.dispatchEvent(
         new CustomEvent(DISMISS_EVENT_NAME, { detail: toast }),


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: CC-1364

#

### Other information
