### PR TITLE
fix(Menu): custom properties bindings

### DIFF
--- a/.changeset/hungry-books-help.md
+++ b/.changeset/hungry-books-help.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix incorrect custom property binding in Menu component.

--- a/src/components/pickers/Menu/Menu.tsx
+++ b/src/components/pickers/Menu/Menu.tsx
@@ -14,6 +14,7 @@ import {
   CONTAINER_STYLES,
   ContainerStyleProps,
   extractStyles,
+  filterBaseProps,
   Styles,
 } from '../../../tasty';
 import { mergeProps } from '../../../utils/react';
@@ -52,7 +53,7 @@ function Menu<T extends object>(
   const { menuProps } = useMenu(completeProps, state, domRef);
   const styles = extractStyles(completeProps, CONTAINER_STYLES);
 
-  const baseProps = {
+  const defaultProps = {
     qa,
     styles,
     mods: {
@@ -66,7 +67,7 @@ function Menu<T extends object>(
 
   return (
     <StyledMenu
-      {...mergeProps(menuProps, completeProps, baseProps)}
+      {...mergeProps(defaultProps, menuProps, filterBaseProps(completeProps))}
       ref={domRef}
     >
       {header && <StyledMenuHeader>{header}</StyledMenuHeader>}


### PR DESCRIPTION
Fixes error with direct `onAction` handler binding to the Menu root element. This handler shouldn't be bonded to the element itself.