### PR TITLE
Add `hideOnClose` flag in `<DialogTrigger />`

### DIFF
--- a/.changeset/few-garlics-flash.md
+++ b/.changeset/few-garlics-flash.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+added ability to specify the way how we'd like to hide a dialog: by unmounting or by hiding in css

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -50,7 +50,7 @@ const config = {
     },
   ],
   webpackFinal: (config) => {
-    config.plugins.push(new webpack.DefinePlugin({ SC_DISABLE_SPEEDY: true }));
+    config.plugins.push(new webpack.DefinePlugin({ SC_DISABLE_SPEEDY: false }));
     config.performance.hints = false;
 
     return config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.SC_DISABLE_SPEEDY = 'false';
+
 /** @type {import('@jest/types').Config.InitialOptions} */
 const config = {
   coverageDirectory: './coverage/',

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "clsx": "^1.1.1",
     "email-validator": "^2.0.4",
     "prismjs": "^1.25.0",
+    "react-focus-lock": "^2.9.3",
     "react-is": "^17.0.0",
     "react-keyed-flatten-children": "1.3.0",
     "react-transition-group": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint:errors": "npm run eslint -- --quiet",
     "lint": "npm-run-all -p eslint prettier",
     "fix": "npm-run-all -p eslint:fix prettier:fix",
-    "storybook": "STORYBOOK_MODE=stories start-storybook -p 6006",
+    "storybook": "STORYBOOK_MODE=stories start-storybook -p 6060",
     "build-storybook": "STORYBOOK_MODE=stories build-storybook",
     "build-docs": "STORYBOOK_MODE=docs build-storybook --docs -o storybook-docs",
     "size": "size-limit",

--- a/src/components/overlays/AlertDialog/AlertDialog.stories.tsx
+++ b/src/components/overlays/AlertDialog/AlertDialog.stories.tsx
@@ -1,13 +1,16 @@
 import { expect } from '@storybook/jest';
 import { ComponentMeta, Story } from '@storybook/react';
-import { userEvent, within } from '@storybook/testing-library';
+import {
+  userEvent,
+  waitForElementToBeRemoved,
+  within,
+} from '@storybook/testing-library';
 import { action } from '@storybook/addon-actions';
 
 import { baseProps } from '../../../stories/lists/baseProps';
 import { DialogTrigger } from '../Dialog/DialogTrigger';
 import { Button } from '../../actions';
 import { Paragraph } from '../../content/Paragraph';
-import { wait } from '../../../test';
 
 import { DialogProps } from './types';
 import { useAlertDialogAPI } from './AlertDialogApiProvider';
@@ -46,9 +49,9 @@ const Template: Story<CubeAlertDialogProps> = (args) => {
 export const Default = Template.bind({});
 Default.args = {};
 Default.play = async ({ canvasElement }) => {
-  const { getByRole } = within(canvasElement);
-  await userEvent.click(getByRole('button'));
-  await expect(getByRole('alertdialog')).toBeInTheDocument();
+  const { findByRole } = within(canvasElement);
+  await userEvent.click(await findByRole('button'));
+  await expect(await findByRole('alertdialog')).toBeInTheDocument();
 };
 
 export const UsingApi: Story<DialogProps> = (args) => {
@@ -69,10 +72,10 @@ export const UsingApi: Story<DialogProps> = (args) => {
   );
 };
 UsingApi.play = async ({ canvasElement }) => {
-  const { getByRole } = within(canvasElement);
-  await userEvent.click(getByRole('button'));
+  const { findByRole } = within(canvasElement);
+  await userEvent.click(await findByRole('button'));
 
-  await expect(getByRole('alertdialog')).toBeInTheDocument();
+  await expect(await findByRole('alertdialog')).toBeInTheDocument();
 };
 
 export const UsingApiWithCancel: Story<DialogProps> = (args) => {
@@ -107,11 +110,16 @@ export const UsingApiWithCancel: Story<DialogProps> = (args) => {
   );
 };
 UsingApiWithCancel.play = async ({ canvasElement }) => {
-  const { getByRole, getByTestId, queryByRole } = within(canvasElement);
+  const { getByRole, getByTestId, queryByRole, findByRole } =
+    within(canvasElement);
 
   await userEvent.click(getByRole('button'));
-  await expect(queryByRole('alertdialog')).toBeInTheDocument();
+
+  const dialog = await findByRole('alertdialog');
+
+  await expect(dialog).toBeInTheDocument();
   await userEvent.click(getByTestId('CancelToken'));
-  await wait(300);
+  await waitForElementToBeRemoved(dialog);
+
   await expect(queryByRole('alertdialog')).not.toBeInTheDocument();
 };

--- a/src/components/overlays/AlertDialog/AlertDialog.stories.tsx
+++ b/src/components/overlays/AlertDialog/AlertDialog.stories.tsx
@@ -1,10 +1,6 @@
 import { expect } from '@storybook/jest';
 import { ComponentMeta, Story } from '@storybook/react';
-import {
-  userEvent,
-  waitForElementToBeRemoved,
-  within,
-} from '@storybook/testing-library';
+import { userEvent, within } from '@storybook/testing-library';
 import { action } from '@storybook/addon-actions';
 
 import { baseProps } from '../../../stories/lists/baseProps';
@@ -119,7 +115,6 @@ UsingApiWithCancel.play = async ({ canvasElement }) => {
 
   await expect(dialog).toBeInTheDocument();
   await userEvent.click(getByTestId('CancelToken'));
-  await waitForElementToBeRemoved(dialog);
 
   await expect(queryByRole('alertdialog')).not.toBeInTheDocument();
 };

--- a/src/components/overlays/Dialog/Dialog.tsx
+++ b/src/components/overlays/Dialog/Dialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../tasty';
 import { mergeProps, SlotProvider } from '../../../utils/react';
 import { Button } from '../../actions';
+import { useOpenTransitionContext } from '../Modal/OpenTransition';
 
 import { useDialogContext } from './context';
 
@@ -136,6 +137,33 @@ export const Dialog = forwardRef(function Dialog(
   props: CubeDialogProps,
   ref: DOMRef<HTMLDivElement>,
 ) {
+  const transitionContext = useOpenTransitionContext();
+
+  if (transitionContext) {
+    if (transitionContext.transitionState === 'entered') {
+      return (
+        <FocusScope key="focus" contain restoreFocus>
+          <DialogContent key="content" {...props} ref={ref} />
+        </FocusScope>
+      );
+    }
+
+    if (transitionContext.transitionState === 'exited') {
+      return <DialogContent key="content" {...props} ref={ref} />;
+    }
+  }
+
+  return (
+    <FocusScope key="focus" contain restoreFocus>
+      <DialogContent key="content" {...props} ref={ref} />
+    </FocusScope>
+  );
+});
+
+const DialogContent = forwardRef(function DialogContent(
+  props: CubeDialogProps,
+  ref: DOMRef<HTMLDivElement>,
+) {
   let { type = 'modal', ...contextProps } = useDialogContext();
 
   let {
@@ -160,8 +188,6 @@ export const Dialog = forwardRef(function Dialog(
     mergeProps(contextProps, props),
     domRef,
   );
-
-  // console.log(dialogProps);
 
   // If rendered in a popover or tray there won't be a visible dismiss button,
   // so we render a hidden one for screen readers.
@@ -216,35 +242,33 @@ export const Dialog = forwardRef(function Dialog(
   };
 
   return (
-    <FocusScope contain restoreFocus>
-      <DialogElement
-        ref={domRef}
-        data-id="Dialog"
-        data-qa={qa || 'Dialog'}
-        styles={styles}
-        as="section"
-        {...dialogProps}
-        mods={{ dismissable: isDismissable }}
-        style={{ '--dialog-size': `${sizePxMap[size] || 288}px` }}
-        data-type={type}
-        data-size={size}
-      >
-        {dismissButton}
+    <DialogElement
+      ref={domRef}
+      data-id="Dialog"
+      data-qa={qa || 'Dialog'}
+      styles={styles}
+      as="section"
+      {...dialogProps}
+      mods={{ dismissable: isDismissable }}
+      style={{ '--dialog-size': `${sizePxMap[size] || 288}px` }}
+      data-type={type}
+      data-size={size}
+    >
+      {dismissButton}
 
-        <SlotProvider slots={slots}>
-          {isDismissable && (
-            <Button
-              qa="ModalCloseButton"
-              type="neutral"
-              styles={CLOSE_BUTTON_STYLES}
-              icon={closeIcon || <CloseOutlined />}
-              label={formatMessage('dismiss')}
-              onPress={() => onDismiss && onDismiss()}
-            />
-          )}
-          {children}
-        </SlotProvider>
-      </DialogElement>
-    </FocusScope>
+      <SlotProvider slots={slots}>
+        {isDismissable && (
+          <Button
+            qa="ModalCloseButton"
+            type="neutral"
+            styles={CLOSE_BUTTON_STYLES}
+            icon={closeIcon || <CloseOutlined />}
+            label={formatMessage('dismiss')}
+            onPress={() => onDismiss && onDismiss()}
+          />
+        )}
+        {children}
+      </SlotProvider>
+    </DialogElement>
   );
 });

--- a/src/components/overlays/Dialog/Dialog.tsx
+++ b/src/components/overlays/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components';
 import { useDOMRef } from '@react-spectrum/utils';
 import { DismissButton } from '@react-aria/overlays';
 import { forwardRef, ReactElement } from 'react';
@@ -84,6 +85,10 @@ const DialogElement = tasty({
   },
 });
 
+const StyledFocusLock = styled(FocusLock)`
+  display: contents;
+`;
+
 const CLOSE_BUTTON_STYLES: Styles = {
   display: 'flex',
   position: 'absolute',
@@ -142,9 +147,9 @@ export const Dialog = forwardRef(function Dialog(
   const isEntered = transitionContext?.transitionState === 'entered';
 
   return (
-    <FocusLock returnFocus disabled={!isEntered}>
+    <StyledFocusLock returnFocus disabled={!isEntered}>
       <DialogContent key="content" {...props} ref={ref} />
-    </FocusLock>
+    </StyledFocusLock>
   );
 });
 

--- a/src/components/overlays/Dialog/Dialog.tsx
+++ b/src/components/overlays/Dialog/Dialog.tsx
@@ -1,11 +1,11 @@
 import { useDOMRef } from '@react-spectrum/utils';
 import { DismissButton } from '@react-aria/overlays';
-import { FocusScope } from '@react-aria/focus';
 import { forwardRef, ReactElement } from 'react';
 import { useDialog } from '@react-aria/dialog';
 import { useMessageFormatter } from '@react-aria/i18n';
 import { CloseOutlined } from '@ant-design/icons';
 import { DOMRef } from '@react-types/shared';
+import FocusLock from 'react-focus-lock';
 
 import {
   BASE_STYLES,
@@ -139,24 +139,12 @@ export const Dialog = forwardRef(function Dialog(
 ) {
   const transitionContext = useOpenTransitionContext();
 
-  if (transitionContext) {
-    if (transitionContext.transitionState === 'entered') {
-      return (
-        <FocusScope key="focus" contain restoreFocus>
-          <DialogContent key="content" {...props} ref={ref} />
-        </FocusScope>
-      );
-    }
-
-    if (transitionContext.transitionState === 'exited') {
-      return <DialogContent key="content" {...props} ref={ref} />;
-    }
-  }
+  const isEntered = transitionContext?.transitionState === 'entered';
 
   return (
-    <FocusScope key="focus" contain restoreFocus>
+    <FocusLock returnFocus disabled={!isEntered}>
       <DialogContent key="content" {...props} ref={ref} />
-    </FocusScope>
+    </FocusLock>
   );
 });
 

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -111,6 +111,7 @@ function DialogTrigger(props) {
     return (
       <PopoverTrigger
         {...positionProps}
+        closeBehavior={closeBehavior}
         state={state}
         targetRef={targetRef}
         trigger={trigger}
@@ -130,6 +131,7 @@ function DialogTrigger(props) {
       case 'modal':
         return (
           <Modal
+            closeBehavior={closeBehavior}
             isOpen={state.isOpen}
             isDismissable={isDismissable}
             type={type}
@@ -145,6 +147,7 @@ function DialogTrigger(props) {
       case 'tray':
         return (
           <Tray
+            closeBehavior={closeBehavior}
             isOpen={state.isOpen}
             isKeyboardDismissDisabled={isKeyboardDismissDisabled}
             styles={styles}
@@ -185,6 +188,7 @@ function PopoverTrigger(allProps) {
     hideArrow,
     onClose,
     isKeyboardDismissDisabled,
+    closeBehavior,
     ...props
   } = allProps;
 
@@ -220,6 +224,7 @@ function PopoverTrigger(allProps) {
   let overlay = (
     <Popover
       ref={overlayRef}
+      closeBehavior={closeBehavior}
       isOpen={state.isOpen}
       style={popoverProps.style}
       placement={placement}

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -4,14 +4,14 @@ import { PressResponder } from '@react-aria/interactions';
 import { useMediaQuery } from '@react-spectrum/utils';
 import { useOverlayPosition, useOverlayTrigger } from '@react-aria/overlays';
 
-import { Modal, Popover, Tray } from '../Modal';
+import { Modal, Popover, Tray, WithCloseBehavior } from '../Modal';
 import { Styles } from '../../../tasty';
 
 import { DialogContext } from './context';
 
 export type CubeDialogClose = (close: () => void) => ReactElement;
 
-export interface CubeDialogTriggerProps {
+export interface CubeDialogTriggerProps extends WithCloseBehavior {
   /** The Dialog and its trigger element. See the DialogTrigger [Content section](#content) for more information on what to provide as children. */
   children: [ReactElement, CubeDialogClose | ReactElement];
   /**
@@ -41,7 +41,6 @@ export interface CubeDialogTriggerProps {
   mobileViewport?: number;
   /** The style map for the overlay **/
   styles?: Styles;
-  closeBehavior?: 'hide' | 'remove';
 }
 
 function DialogTrigger(props) {
@@ -56,7 +55,7 @@ function DialogTrigger(props) {
     isKeyboardDismissDisabled,
     styles,
     mobileViewport = 700,
-    destroyOnClose,
+    hideOnClose,
     ...positionProps
   } = props;
 
@@ -111,7 +110,7 @@ function DialogTrigger(props) {
     return (
       <PopoverTrigger
         {...positionProps}
-        destroyOnClose={destroyOnClose}
+        hideOnClose={hideOnClose}
         state={state}
         targetRef={targetRef}
         trigger={trigger}
@@ -131,7 +130,7 @@ function DialogTrigger(props) {
       case 'modal':
         return (
           <Modal
-            destroyOnClose={destroyOnClose}
+            hideOnClose={hideOnClose}
             isOpen={state.isOpen}
             isDismissable={isDismissable}
             type={type}
@@ -147,7 +146,7 @@ function DialogTrigger(props) {
       case 'tray':
         return (
           <Tray
-            destroyOnClose={destroyOnClose}
+            hideOnClose={hideOnClose}
             isOpen={state.isOpen}
             isKeyboardDismissDisabled={isKeyboardDismissDisabled}
             styles={styles}
@@ -188,7 +187,7 @@ function PopoverTrigger(allProps) {
     hideArrow,
     onClose,
     isKeyboardDismissDisabled,
-    destroyOnClose,
+    hideOnClose,
     ...props
   } = allProps;
 
@@ -224,7 +223,7 @@ function PopoverTrigger(allProps) {
   let overlay = (
     <Popover
       ref={overlayRef}
-      destroyOnClose={destroyOnClose}
+      hideOnClose={hideOnClose}
       isOpen={state.isOpen}
       style={popoverProps.style}
       placement={placement}

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -41,6 +41,7 @@ export interface CubeDialogTriggerProps {
   mobileViewport?: number;
   /** The style map for the overlay **/
   styles?: Styles;
+  closeBehavior?: 'hide' | 'remove';
 }
 
 function DialogTrigger(props) {
@@ -55,6 +56,7 @@ function DialogTrigger(props) {
     isKeyboardDismissDisabled,
     styles,
     mobileViewport = 700,
+    closeBehavior,
     ...positionProps
   } = props;
 

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -56,7 +56,7 @@ function DialogTrigger(props) {
     isKeyboardDismissDisabled,
     styles,
     mobileViewport = 700,
-    closeBehavior,
+    destroyOnClose,
     ...positionProps
   } = props;
 
@@ -111,7 +111,7 @@ function DialogTrigger(props) {
     return (
       <PopoverTrigger
         {...positionProps}
-        closeBehavior={closeBehavior}
+        destroyOnClose={destroyOnClose}
         state={state}
         targetRef={targetRef}
         trigger={trigger}
@@ -131,7 +131,7 @@ function DialogTrigger(props) {
       case 'modal':
         return (
           <Modal
-            closeBehavior={closeBehavior}
+            destroyOnClose={destroyOnClose}
             isOpen={state.isOpen}
             isDismissable={isDismissable}
             type={type}
@@ -147,7 +147,7 @@ function DialogTrigger(props) {
       case 'tray':
         return (
           <Tray
-            closeBehavior={closeBehavior}
+            destroyOnClose={destroyOnClose}
             isOpen={state.isOpen}
             isKeyboardDismissDisabled={isKeyboardDismissDisabled}
             styles={styles}
@@ -188,7 +188,7 @@ function PopoverTrigger(allProps) {
     hideArrow,
     onClose,
     isKeyboardDismissDisabled,
-    closeBehavior,
+    destroyOnClose,
     ...props
   } = allProps;
 
@@ -224,7 +224,7 @@ function PopoverTrigger(allProps) {
   let overlay = (
     <Popover
       ref={overlayRef}
-      closeBehavior={closeBehavior}
+      destroyOnClose={destroyOnClose}
       isOpen={state.isOpen}
       style={popoverProps.style}
       placement={placement}

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -198,6 +198,7 @@ function PopoverTrigger(allProps) {
     overlayProps: popoverProps,
     placement,
     arrowProps,
+    updatePosition,
   } = useOverlayPosition({
     targetRef: targetRef || triggerRef,
     overlayRef: overlayRef,
@@ -230,6 +231,7 @@ function PopoverTrigger(allProps) {
       arrowProps={arrowProps}
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}
       hideArrow={hideArrow}
+      updatePosition={updatePosition}
       onClose={onClose}
     >
       {typeof content === 'function' ? content(state.close) : content}

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -1,4 +1,9 @@
-import { within, userEvent, waitFor } from '@storybook/testing-library';
+import {
+  within,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { Story } from '@storybook/react';
 
@@ -175,3 +180,45 @@ CloseBehaviorHidePanel.args = {
   closeBehavior: 'hide',
 };
 CloseBehaviorHidePanel.play = CloseBehaviorHideDialog.play;
+
+export const CloseOnEsc: typeof Template = Template.bind({});
+CloseOnEsc.play = async (context) => {
+  if (context.viewMode === 'docs') return;
+
+  const { findByRole } = within(context.canvasElement);
+
+  const trigger = await findByRole('button');
+
+  await userEvent.click(trigger);
+
+  const dialog = await findByRole('dialog');
+
+  await expect(dialog).toBeInTheDocument();
+  await expect(document.activeElement).toBe(dialog);
+
+  await userEvent.keyboard('{Escape}');
+
+  await waitFor(() => expect(document.activeElement).toBe(trigger));
+};
+
+export const CloseOnEscCloseBehaviorHide: typeof Template = Template.bind({});
+CloseOnEscCloseBehaviorHide.args = {
+  closeBehavior: 'hide',
+};
+CloseOnEscCloseBehaviorHide.play = CloseOnEsc.play;
+
+export const CloseOnOutsideClick: typeof Template = Template.bind({});
+CloseOnOutsideClick.play = async (context) => {
+  if (context.viewMode === 'docs') return;
+
+  await Default.play(context);
+
+  const { findByRole } = within(context.canvasElement);
+  const dialog = await findByRole('dialog');
+
+  await userEvent.click(document.body);
+
+  await waitForElementToBeRemoved(dialog);
+
+  expect(dialog).not.toBeInTheDocument();
+};

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -211,7 +211,7 @@ export const CloseOnOutsideClick: typeof Template = Template.bind({});
 CloseOnOutsideClick.play = async (context) => {
   if (context.viewMode === 'docs') return;
 
-  await Default.play(context);
+  await Default.play?.(context);
 
   const { findByRole } = within(context.canvasElement);
   const dialog = await findByRole('dialog');

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -189,7 +189,7 @@ CloseOnEsc.play = async (context) => {
   const dialog = await findByRole('dialog');
 
   await expect(dialog).toBeInTheDocument();
-  await expect(document.activeElement).toBe(dialog);
+  await expect(dialog.contains(document.activeElement)).toBe(true);
 
   await userEvent.keyboard('{Escape}');
 

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -1,9 +1,4 @@
-import {
-  within,
-  userEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@storybook/testing-library';
+import { within, userEvent, waitFor } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { Story } from '@storybook/react';
 
@@ -217,8 +212,6 @@ CloseOnOutsideClick.play = async (context) => {
   const dialog = await findByRole('dialog');
 
   await userEvent.click(document.body);
-
-  await waitForElementToBeRemoved(dialog);
 
   expect(dialog).not.toBeInTheDocument();
 };

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -1,5 +1,4 @@
-import { ModalProvider } from '@react-aria/overlays';
-import { within, userEvent } from '@storybook/testing-library';
+import { within, userEvent, waitFor } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { Story } from '@storybook/react';
 
@@ -33,39 +32,142 @@ const Template: Story<
   CubeDialogTriggerProps & { size: CubeDialogProps['size'] }
 > = ({ size, ...props }) => {
   return (
-    <ModalProvider>
-      <DialogTrigger {...props}>
-        <Button>Click me!</Button>
-        {(close) => (
-          <Dialog size={size}>
-            <Header>
-              <Title>Modal title</Title>
-              <Text>Header</Text>
-            </Header>
-            <Content>
-              <Paragraph>Test content</Paragraph>
-              <Paragraph>Test content</Paragraph>
-            </Content>
-            <Footer>
-              <Button.Group>
-                <Button type="primary" onPress={close}>
-                  Action
-                </Button>
-                <Button onPress={close}>Sec</Button>
-                <Button onPress={close}>Cancel</Button>
-              </Button.Group>
-              <Text>Footer</Text>
-            </Footer>
-          </Dialog>
-        )}
-      </DialogTrigger>
-    </ModalProvider>
+    <DialogTrigger {...props}>
+      <Button>Click me!</Button>
+      {(close) => (
+        <Dialog size={size}>
+          <Header>
+            <Title>Modal title</Title>
+            <Text>Header</Text>
+          </Header>
+          <Content>
+            <Paragraph>Test content</Paragraph>
+            <Paragraph>Test content</Paragraph>
+          </Content>
+          <Footer>
+            <Button.Group>
+              <Button type="primary" onPress={close}>
+                Action
+              </Button>
+              <Button onPress={close}>Sec</Button>
+              <Button onPress={close}>Cancel</Button>
+            </Button.Group>
+            <Text>Footer</Text>
+          </Footer>
+        </Dialog>
+      )}
+    </DialogTrigger>
   );
 };
 
-export const Default: typeof Template = Template.bind({});
+export const Default = Template.bind({});
 Default.play = async ({ canvasElement }) => {
-  const { getByRole } = within(canvasElement);
+  const { getByRole, findByRole } = within(canvasElement);
   await userEvent.click(getByRole('button'));
-  await expect(getByRole('dialog')).toBeInTheDocument();
+
+  await expect(await findByRole('dialog')).toBeInTheDocument();
 };
+
+export const Modal: typeof Template = Template.bind({});
+Modal.args = {
+  type: 'modal',
+};
+Modal.play = Default.play;
+
+export const Popover: typeof Template = Template.bind({});
+Popover.args = {
+  type: 'popover',
+};
+Popover.play = Default.play;
+
+export const Tray: typeof Template = Template.bind({});
+Tray.args = {
+  type: 'tray',
+};
+Tray.play = Default.play;
+
+export const Fullscreen: typeof Template = Template.bind({});
+Fullscreen.args = {
+  type: 'fullscreen',
+};
+Fullscreen.play = Default.play;
+
+export const FullscreenTakeover: typeof Template = Template.bind({});
+FullscreenTakeover.args = {
+  type: 'fullscreenTakeover',
+};
+FullscreenTakeover.play = Default.play;
+
+export const Panel: typeof Template = Template.bind({});
+Panel.args = {
+  type: 'panel',
+};
+Panel.play = Default.play;
+
+export const SizeSmall: typeof Template = Template.bind({});
+SizeSmall.args = {
+  size: 'small',
+};
+SizeSmall.play = Default.play;
+
+export const SizeMedium: typeof Template = Template.bind({});
+SizeMedium.args = {
+  size: 'medium',
+};
+SizeMedium.play = Default.play;
+
+export const SizeLarge: typeof Template = Template.bind({});
+SizeLarge.args = {
+  size: 'large',
+};
+SizeLarge.play = Default.play;
+
+export const CloseBehaviorHideDialog: typeof Template = Template.bind({});
+CloseBehaviorHideDialog.args = {
+  closeBehavior: 'hide',
+};
+CloseBehaviorHideDialog.play = async ({ canvasElement }) => {
+  const { getByRole, findByRole } = within(canvasElement);
+
+  await userEvent.click(getByRole('button'));
+  await waitFor(() => expect(getByRole('dialog')).toBeVisible());
+  await expect(await findByRole('dialog')).toBeVisible();
+
+  await userEvent.click(getByRole('button', { name: 'Cancel' }));
+};
+
+export const CloseBehaviorHidePopover: typeof Template = Template.bind({});
+CloseBehaviorHidePopover.args = {
+  type: 'popover',
+  closeBehavior: 'hide',
+};
+CloseBehaviorHidePopover.play = CloseBehaviorHideDialog.play;
+
+export const CloseBehaviorHideTray: typeof Template = Template.bind({});
+CloseBehaviorHideTray.args = {
+  type: 'tray',
+  closeBehavior: 'hide',
+};
+CloseBehaviorHideTray.play = CloseBehaviorHideDialog.play;
+
+export const CloseBehaviorHideFullscreen: typeof Template = Template.bind({});
+CloseBehaviorHideFullscreen.args = {
+  type: 'fullscreen',
+  closeBehavior: 'hide',
+};
+CloseBehaviorHideFullscreen.play = CloseBehaviorHideDialog.play;
+
+export const CloseBehaviorHideFullscreenTakeover: typeof Template =
+  Template.bind({});
+CloseBehaviorHideFullscreenTakeover.args = {
+  type: 'fullscreenTakeover',
+  closeBehavior: 'hide',
+};
+CloseBehaviorHideFullscreenTakeover.play = CloseBehaviorHideDialog.play;
+
+export const CloseBehaviorHidePanel: typeof Template = Template.bind({});
+CloseBehaviorHidePanel.args = {
+  type: 'panel',
+  closeBehavior: 'hide',
+};
+CloseBehaviorHidePanel.play = CloseBehaviorHideDialog.play;

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -62,6 +62,8 @@ const Template: Story<
 
 export const Default = Template.bind({});
 Default.play = async ({ canvasElement }) => {
+  if (viewMode === 'docs') return;
+
   const { getByRole, findByRole } = within(canvasElement);
   await userEvent.click(getByRole('button'));
 
@@ -126,7 +128,9 @@ export const CloseBehaviorHideDialog: typeof Template = Template.bind({});
 CloseBehaviorHideDialog.args = {
   closeBehavior: 'hide',
 };
-CloseBehaviorHideDialog.play = async ({ canvasElement }) => {
+CloseBehaviorHideDialog.play = async ({ canvasElement, viewMode }) => {
+  if (viewMode === 'docs') return;
+
   const { getByRole, findByRole } = within(canvasElement);
 
   await userEvent.click(getByRole('button'));

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -61,7 +61,7 @@ const Template: Story<
 };
 
 export const Default = Template.bind({});
-Default.play = async ({ canvasElement }) => {
+Default.play = async ({ canvasElement, viewMode }) => {
   if (viewMode === 'docs') return;
 
   const { getByRole, findByRole } = within(canvasElement);

--- a/src/components/overlays/Dialog/stories/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/stories/Dialog.stories.tsx
@@ -126,7 +126,7 @@ SizeLarge.play = Default.play;
 
 export const CloseBehaviorHideDialog: typeof Template = Template.bind({});
 CloseBehaviorHideDialog.args = {
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseBehaviorHideDialog.play = async ({ canvasElement, viewMode }) => {
   if (viewMode === 'docs') return;
@@ -143,21 +143,21 @@ CloseBehaviorHideDialog.play = async ({ canvasElement, viewMode }) => {
 export const CloseBehaviorHidePopover: typeof Template = Template.bind({});
 CloseBehaviorHidePopover.args = {
   type: 'popover',
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseBehaviorHidePopover.play = CloseBehaviorHideDialog.play;
 
 export const CloseBehaviorHideTray: typeof Template = Template.bind({});
 CloseBehaviorHideTray.args = {
   type: 'tray',
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseBehaviorHideTray.play = CloseBehaviorHideDialog.play;
 
 export const CloseBehaviorHideFullscreen: typeof Template = Template.bind({});
 CloseBehaviorHideFullscreen.args = {
   type: 'fullscreen',
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseBehaviorHideFullscreen.play = CloseBehaviorHideDialog.play;
 
@@ -165,14 +165,14 @@ export const CloseBehaviorHideFullscreenTakeover: typeof Template =
   Template.bind({});
 CloseBehaviorHideFullscreenTakeover.args = {
   type: 'fullscreenTakeover',
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseBehaviorHideFullscreenTakeover.play = CloseBehaviorHideDialog.play;
 
 export const CloseBehaviorHidePanel: typeof Template = Template.bind({});
 CloseBehaviorHidePanel.args = {
   type: 'panel',
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseBehaviorHidePanel.play = CloseBehaviorHideDialog.play;
 
@@ -198,7 +198,7 @@ CloseOnEsc.play = async (context) => {
 
 export const CloseOnEscCloseBehaviorHide: typeof Template = Template.bind({});
 CloseOnEscCloseBehaviorHide.args = {
-  closeBehavior: 'hide',
+  hideOnClose: true,
 };
 CloseOnEscCloseBehaviorHide.play = CloseOnEsc.play;
 

--- a/src/components/overlays/Dialog/stories/DialogForm.stories.tsx
+++ b/src/components/overlays/Dialog/stories/DialogForm.stories.tsx
@@ -93,7 +93,7 @@ AsyncExampleTrigger.play = async ({ viewMode, canvasElement }) => {
   if (viewMode === 'docs') return;
   const screen = within(canvasElement);
   await userEvent.click(screen.getByRole('button'));
-  const dialog = await screen.getByRole('dialog');
+  const dialog = await screen.findByRole('dialog');
   await expect(dialog).toBeInTheDocument();
 
   const dialogCanvas = within(dialog);
@@ -113,7 +113,7 @@ AsyncExampleContainer.play = async ({ viewMode, canvasElement }) => {
   if (viewMode === 'docs') return;
   const screen = within(canvasElement);
   await userEvent.click(screen.getByRole('button'));
-  const dialog = await screen.getByRole('dialog');
+  const dialog = await screen.findByRole('dialog');
   await expect(dialog).toBeInTheDocument();
 
   const dialogCanvas = within(dialog);

--- a/src/components/overlays/Modal/Modal.tsx
+++ b/src/components/overlays/Modal/Modal.tsx
@@ -133,8 +133,6 @@ let ModalWrapper = forwardRef(function ModalWrapper(
 
   let { modalProps } = useModal({ isDisabled: transitionState !== 'entered' });
 
-  console.log(isOpen, transitionState);
-
   return (
     <ModalWrapperElement data-type={type} data-placement={placement}>
       <ModalElement

--- a/src/components/overlays/Modal/Modal.tsx
+++ b/src/components/overlays/Modal/Modal.tsx
@@ -129,9 +129,9 @@ let ModalWrapper = forwardRef(function ModalWrapper(
     ...otherProps
   } = props;
 
-  usePreventScroll();
+  usePreventScroll({ isDisabled: transitionState !== 'entered' });
 
-  let { modalProps } = useModal();
+  let { modalProps } = useModal({ isDisabled: transitionState !== 'entered' });
 
   console.log(isOpen, transitionState);
 

--- a/src/components/overlays/Modal/Modal.tsx
+++ b/src/components/overlays/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import { mergeProps } from '../../../utils/react';
 
 import { Underlay } from './Underlay';
 import { Overlay } from './Overlay';
+import { WithCloseBehavior } from './types';
 
 import type { ModalProps } from '@react-types/overlays';
 
@@ -26,6 +27,10 @@ export const OVERLAY_WRAPPER_STYLES: Styles = {
   pointerEvents: 'none',
   zIndex: 2,
   transition: 'visibility 0ms linear .13s',
+  visibility: {
+    '': 'hidden',
+    open: 'visible',
+  },
 };
 
 const ModalWrapperElement = tasty({
@@ -61,7 +66,9 @@ const ModalElement = tasty({
   },
 });
 
-export interface CubeModalProps extends Omit<ModalProps, 'container'> {
+export interface CubeModalProps
+  extends Omit<ModalProps, 'container'>,
+    WithCloseBehavior {
   container?: HTMLElement;
   qa?: BaseProps['qa'];
   onClose?: (action?: string) => void;

--- a/src/components/overlays/Modal/Modal.tsx
+++ b/src/components/overlays/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import { mergeProps } from '../../../utils/react';
 
 import { Underlay } from './Underlay';
 import { Overlay } from './Overlay';
-import { WithCloseBehavior } from './types';
+import { TransitionState, WithCloseBehavior } from './types';
 
 import type { ModalProps } from '@react-types/overlays';
 
@@ -26,10 +26,9 @@ export const OVERLAY_WRAPPER_STYLES: Styles = {
   height: '100dvh',
   pointerEvents: 'none',
   zIndex: 2,
-  transition: 'visibility 0ms linear .13s',
-  visibility: {
-    '': 'hidden',
-    open: 'visible',
+  transition: {
+    '': 'visibility .5s steps(2, start)',
+    open: 'visibility 0s linear',
   },
 };
 
@@ -40,7 +39,12 @@ const ModalWrapperElement = tasty({
 
 const ModalElement = tasty({
   styles: {
-    display: 'grid',
+    display: {
+      '': 'none',
+      'entering | entered': 'grid',
+      exiting: 'grid',
+      exited: 'none',
+    },
     zIndex: 2,
     height: {
       '': 'max 90dvh',
@@ -52,8 +56,7 @@ const ModalElement = tasty({
       width: '288px 90vw',
     },
     pointerEvents: 'none',
-    transition:
-      'opacity .25s linear, visibility 0ms linear, transform .25s ease-in-out',
+    transition: 'opacity .25s linear, transform .25s ease-in-out',
     transform: {
       '': 'translate(0, 0) scale(1, 1)',
       '[data-type="modal"] & !open': 'translate(0, -3x) scale(1, 1)',
@@ -99,7 +102,7 @@ function Modal(props: CubeModalProps, ref) {
   );
 }
 
-interface ModalWrapperProps {
+interface ModalWrapperProps extends TransitionState {
   children?: ReactNode;
   qa?: BaseProps['qa'];
   isOpen?: boolean;
@@ -122,6 +125,7 @@ let ModalWrapper = forwardRef(function ModalWrapper(
     placement,
     styles,
     overlayProps,
+    transitionState,
     ...otherProps
   } = props;
 
@@ -129,16 +133,20 @@ let ModalWrapper = forwardRef(function ModalWrapper(
 
   let { modalProps } = useModal();
 
+  console.log(isOpen, transitionState);
+
   return (
-    <ModalWrapperElement
-      mods={{ open: isOpen }}
-      data-type={type}
-      data-placement={placement}
-    >
+    <ModalWrapperElement data-type={type} data-placement={placement}>
       <ModalElement
         qa={qa || 'Modal'}
         styles={styles}
-        mods={{ open: isOpen }}
+        mods={{
+          open: isOpen,
+          entering: transitionState === 'entering',
+          exiting: transitionState === 'exiting',
+          exited: transitionState === 'exited',
+          entered: transitionState === 'entered',
+        }}
         data-type={type}
         data-placement={placement}
         {...mergeProps(otherProps, overlayProps, modalProps)}

--- a/src/components/overlays/Modal/OpenTransition.tsx
+++ b/src/components/overlays/Modal/OpenTransition.tsx
@@ -20,6 +20,7 @@ export function OpenTransition(
             child &&
             cloneElement(child as ReactElement, {
               isOpen: !!OPEN_STATES[state],
+              transitionState: state,
             }),
         )
       }

--- a/src/components/overlays/Modal/OpenTransition.tsx
+++ b/src/components/overlays/Modal/OpenTransition.tsx
@@ -1,5 +1,13 @@
-import { Children, cloneElement, ReactElement } from 'react';
+import {
+  Children,
+  cloneElement,
+  createContext,
+  ReactElement,
+  useContext,
+} from 'react';
 import { Transition } from 'react-transition-group';
+
+import { TransitionStatus } from './types';
 
 import type { TimeoutProps } from 'react-transition-group/Transition';
 
@@ -8,22 +16,32 @@ const OPEN_STATES = {
   entered: true,
 };
 
-export function OpenTransition(
-  props: Omit<TimeoutProps<undefined>, 'timeout'>,
-) {
+export type OpenTransitionProps = Omit<TimeoutProps<undefined>, 'timeout'>;
+
+const OpenTransitionContext = createContext<{
+  transitionState: TransitionStatus;
+} | null>(null);
+
+export function useOpenTransitionContext() {
+  return useContext(OpenTransitionContext);
+}
+
+export function OpenTransition(props: OpenTransitionProps) {
   return (
     <Transition timeout={{ enter: 0, exit: 350 }} {...props}>
-      {(state) =>
-        Children.map(
-          props.children,
-          (child) =>
-            child &&
-            cloneElement(child as ReactElement, {
-              isOpen: !!OPEN_STATES[state],
-              transitionState: state,
-            }),
-        )
-      }
+      {(state) => (
+        <OpenTransitionContext.Provider value={{ transitionState: state }}>
+          {Children.map(
+            props.children,
+            (child) =>
+              child &&
+              cloneElement(child as ReactElement, {
+                isOpen: !!OPEN_STATES[state],
+                transitionState: state,
+              }),
+          )}
+        </OpenTransitionContext.Provider>
+      )}
     </Transition>
   );
 }

--- a/src/components/overlays/Modal/OpenTransition.tsx
+++ b/src/components/overlays/Modal/OpenTransition.tsx
@@ -1,19 +1,26 @@
-import { Children, cloneElement } from 'react';
+import { Children, cloneElement, ReactElement } from 'react';
 import { Transition } from 'react-transition-group';
+
+import type { TimeoutProps } from 'react-transition-group/Transition';
 
 const OPEN_STATES = {
   entering: false,
   entered: true,
 };
 
-export function OpenTransition(props) {
+export function OpenTransition(
+  props: Omit<TimeoutProps<undefined>, 'timeout'>,
+) {
   return (
     <Transition timeout={{ enter: 0, exit: 350 }} {...props}>
       {(state) =>
         Children.map(
           props.children,
           (child) =>
-            child && cloneElement(child, { isOpen: !!OPEN_STATES[state] }),
+            child &&
+            cloneElement(child as ReactElement, {
+              isOpen: !!OPEN_STATES[state],
+            }),
         )
       }
     </Transition>

--- a/src/components/overlays/Modal/Overlay.tsx
+++ b/src/components/overlays/Modal/Overlay.tsx
@@ -26,7 +26,7 @@ function Overlay(props: CubeOverlayProps, ref) {
     onExit,
     onExiting,
     onExited,
-    destroyOnClose = true,
+    hideOnClose = false,
   } = props;
   let [exited, setExited] = useState(!isOpen);
   let { root } = useProviderProps({} as Props);
@@ -46,7 +46,7 @@ function Overlay(props: CubeOverlayProps, ref) {
 
   if (!mountOverlay) {
     // Don't bother showing anything if we don't have to.
-    if (destroyOnClose) {
+    if (!hideOnClose) {
       return null;
     }
   }

--- a/src/components/overlays/Modal/Overlay.tsx
+++ b/src/components/overlays/Modal/Overlay.tsx
@@ -10,6 +10,7 @@ import type { OverlayProps } from '@react-types/overlays';
 
 export interface CubeOverlayProps extends Omit<OverlayProps, 'container'> {
   container?: HTMLElement | null;
+  closeBehavior?: 'hide' | 'remove';
 }
 
 function Overlay(props: CubeOverlayProps, ref) {
@@ -23,6 +24,7 @@ function Overlay(props: CubeOverlayProps, ref) {
     onExit,
     onExiting,
     onExited,
+    closeBehavior,
   } = props;
   let [exited, setExited] = useState(!isOpen);
   let { root } = useProviderProps({} as Props);
@@ -39,9 +41,12 @@ function Overlay(props: CubeOverlayProps, ref) {
 
   // Don't un-render the overlay while it's transitioning out.
   let mountOverlay = isOpen || !exited;
+
   if (!mountOverlay) {
     // Don't bother showing anything if we don't have to.
-    return null;
+    if (closeBehavior === 'remove') {
+      return null;
+    }
   }
 
   let contents = (

--- a/src/components/overlays/Modal/Overlay.tsx
+++ b/src/components/overlays/Modal/Overlay.tsx
@@ -5,12 +5,14 @@ import { Provider, useProviderProps } from '../../../provider';
 import { Props } from '../../../tasty';
 
 import { OpenTransition } from './OpenTransition';
+import { WithCloseBehavior } from './types';
 
 import type { OverlayProps } from '@react-types/overlays';
 
-export interface CubeOverlayProps extends Omit<OverlayProps, 'container'> {
+export interface CubeOverlayProps
+  extends Omit<OverlayProps, 'container'>,
+    WithCloseBehavior {
   container?: HTMLElement | null;
-  closeBehavior?: 'hide' | 'remove';
 }
 
 function Overlay(props: CubeOverlayProps, ref) {
@@ -24,7 +26,7 @@ function Overlay(props: CubeOverlayProps, ref) {
     onExit,
     onExiting,
     onExited,
-    closeBehavior,
+    closeBehavior = 'remove',
   } = props;
   let [exited, setExited] = useState(!isOpen);
   let { root } = useProviderProps({} as Props);

--- a/src/components/overlays/Modal/Overlay.tsx
+++ b/src/components/overlays/Modal/Overlay.tsx
@@ -26,7 +26,7 @@ function Overlay(props: CubeOverlayProps, ref) {
     onExit,
     onExiting,
     onExited,
-    closeBehavior = 'remove',
+    destroyOnClose = true,
   } = props;
   let [exited, setExited] = useState(!isOpen);
   let { root } = useProviderProps({} as Props);
@@ -46,7 +46,7 @@ function Overlay(props: CubeOverlayProps, ref) {
 
   if (!mountOverlay) {
     // Don't bother showing anything if we don't have to.
-    if (closeBehavior === 'remove') {
+    if (destroyOnClose) {
       return null;
     }
   }

--- a/src/components/overlays/Modal/Popover.tsx
+++ b/src/components/overlays/Modal/Popover.tsx
@@ -7,6 +7,7 @@ import { mergeProps } from '../../../utils/react';
 import { PlacementAxis } from '../../../shared';
 
 import { Overlay } from './Overlay';
+import { WithCloseBehavior } from './types';
 
 const PopoverElement = tasty({
   role: 'presentation',
@@ -32,7 +33,8 @@ const PopoverElement = tasty({
 
 export interface CubePopoverProps
   extends BaseProps,
-    Omit<OverlayProps, 'children'> {
+    Omit<OverlayProps, 'children'>,
+    WithCloseBehavior {
   container?: HTMLElement;
   placement?: PlacementAxis;
   arrowProps?: HTMLAttributes<HTMLElement>;

--- a/src/components/overlays/Modal/Tray.tsx
+++ b/src/components/overlays/Modal/Tray.tsx
@@ -8,7 +8,7 @@ import { mergeProps } from '../../../utils/react';
 import { OVERLAY_WRAPPER_STYLES } from './Modal';
 import { Underlay } from './Underlay';
 import { Overlay } from './Overlay';
-import { WithCloseBehavior } from './types';
+import { TransitionState, WithCloseBehavior } from './types';
 
 import type { TrayProps } from '@react-types/overlays';
 
@@ -23,6 +23,12 @@ const TrayWrapperElement = tasty({
 
 const TrayElement = tasty({
   styles: {
+    display: {
+      '': 'none',
+      'entering | entered': 'initial',
+      exiting: 'initial',
+      exited: 'none',
+    },
     zIndex: 2,
     height: 'max 90dvh',
     width: '288px 90vw',
@@ -45,7 +51,7 @@ export interface CubeTrayProps extends TrayProps, WithCloseBehavior {
   styles?: Styles;
 }
 
-interface CubeTrayWrapperProps extends CubeTrayProps {
+interface CubeTrayWrapperProps extends CubeTrayProps, TransitionState {
   isOpen?: boolean;
   overlayProps?: Props;
 }
@@ -97,6 +103,7 @@ let TrayWrapper = forwardRef(function TrayWrapper(
     isFixedHeight,
     isNonModal,
     overlayProps,
+    transitionState,
     ...otherProps
   } = props;
   usePreventScroll();
@@ -117,6 +124,10 @@ let TrayWrapper = forwardRef(function TrayWrapper(
         styles={styles}
         mods={{
           open: isOpen,
+          entering: transitionState === 'entering',
+          exiting: transitionState === 'exiting',
+          exited: transitionState === 'exited',
+          entered: transitionState === 'entered',
           'fixed-height': isFixedHeight,
         }}
         {...domProps}

--- a/src/components/overlays/Modal/Tray.tsx
+++ b/src/components/overlays/Modal/Tray.tsx
@@ -8,6 +8,7 @@ import { mergeProps } from '../../../utils/react';
 import { OVERLAY_WRAPPER_STYLES } from './Modal';
 import { Underlay } from './Underlay';
 import { Overlay } from './Overlay';
+import { WithCloseBehavior } from './types';
 
 import type { TrayProps } from '@react-types/overlays';
 
@@ -35,7 +36,7 @@ const TrayElement = tasty({
   },
 });
 
-export interface CubeTrayProps extends TrayProps {
+export interface CubeTrayProps extends TrayProps, WithCloseBehavior {
   container?: HTMLElement;
   qa?: BaseProps['qa'];
   onClose?: (action?: string) => void;

--- a/src/components/overlays/Modal/Underlay.tsx
+++ b/src/components/overlays/Modal/Underlay.tsx
@@ -20,14 +20,10 @@ const UnderlayElement = tasty({
       '': 'none',
       open: 'auto',
     },
-    visibility: {
-      '': 'hidden',
-      open: 'visible',
-    },
     fill: '#dark.30',
     overflow: 'hidden',
     transition:
-      'transform .25s ease-in-out, opacity .25s linear, visibility 0.13s linear',
+      'transform .25s ease-in-out, opacity .25s linear, visibility 0ms linear',
   },
 });
 

--- a/src/components/overlays/Modal/Underlay.tsx
+++ b/src/components/overlays/Modal/Underlay.tsx
@@ -27,7 +27,7 @@ const UnderlayElement = tasty({
     fill: '#dark.30',
     overflow: 'hidden',
     transition:
-      'transform .25s ease-in-out, opacity .25s linear, visibility 0.13ms linear',
+      'transform .25s ease-in-out, opacity .25s linear, visibility 0.13s linear',
   },
 });
 

--- a/src/components/overlays/Modal/Underlay.tsx
+++ b/src/components/overlays/Modal/Underlay.tsx
@@ -20,6 +20,10 @@ const UnderlayElement = tasty({
       '': 'none',
       open: 'auto',
     },
+    visibility: {
+      '': 'hidden',
+      open: 'visible',
+    },
     fill: '#dark.30',
     overflow: 'hidden',
     transition:

--- a/src/components/overlays/Modal/Underlay.tsx
+++ b/src/components/overlays/Modal/Underlay.tsx
@@ -27,7 +27,7 @@ const UnderlayElement = tasty({
     fill: '#dark.30',
     overflow: 'hidden',
     transition:
-      'transform .25s ease-in-out, opacity .25s linear, visibility 0ms linear',
+      'transform .25s ease-in-out, opacity .25s linear, visibility 0.13ms linear',
   },
 });
 

--- a/src/components/overlays/Modal/index.ts
+++ b/src/components/overlays/Modal/index.ts
@@ -3,3 +3,4 @@ export { Modal } from './Modal';
 export { Overlay } from './Overlay';
 export { Underlay } from './Underlay';
 export { Popover } from './Popover';
+export * from './types';

--- a/src/components/overlays/Modal/types.ts
+++ b/src/components/overlays/Modal/types.ts
@@ -4,7 +4,7 @@ export type CloseBehavior = 'remove' | 'hide';
 export type TransitionStatus = ReactTransitionStatus;
 
 export interface WithCloseBehavior {
-  destroyOnClose?: boolean;
+  hideOnClose?: boolean;
 }
 
 export interface TransitionState {

--- a/src/components/overlays/Modal/types.ts
+++ b/src/components/overlays/Modal/types.ts
@@ -1,0 +1,5 @@
+export type CloseBehavior = 'remove' | 'hide';
+
+export interface WithCloseBehavior {
+  closeBehavior?: CloseBehavior;
+}

--- a/src/components/overlays/Modal/types.ts
+++ b/src/components/overlays/Modal/types.ts
@@ -1,5 +1,12 @@
+import { TransitionStatus as ReactTransitionStatus } from 'react-transition-group';
+
 export type CloseBehavior = 'remove' | 'hide';
+export type TransitionStatus = ReactTransitionStatus;
 
 export interface WithCloseBehavior {
   closeBehavior?: CloseBehavior;
+}
+
+export interface TransitionState {
+  transitionState?: TransitionStatus;
 }

--- a/src/components/overlays/Modal/types.ts
+++ b/src/components/overlays/Modal/types.ts
@@ -4,7 +4,7 @@ export type CloseBehavior = 'remove' | 'hide';
 export type TransitionStatus = ReactTransitionStatus;
 
 export interface WithCloseBehavior {
-  closeBehavior?: CloseBehavior;
+  destroyOnClose?: boolean;
 }
 
 export interface TransitionState {

--- a/src/components/overlays/NewNotifications/Notifications.stories.tsx
+++ b/src/components/overlays/NewNotifications/Notifications.stories.tsx
@@ -288,7 +288,7 @@ NotificationWithDialog.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
   await userEvent.click(canvas.getByRole('button'));
-  await expect(canvas.getByRole('dialog')).toBeInTheDocument();
+  await expect(await canvas.findByRole('dialog')).toBeInTheDocument();
 };
 
 export const ComplexInteraction: Story<CubeNotificationProps> = (args) => {

--- a/src/tasty/__snapshots__/tasty.test.tsx.snap
+++ b/src/tasty/__snapshots__/tasty.test.tsx.snap
@@ -28,9 +28,6 @@ exports[`tasty() API should allow multiple wrapping 1`] = `
 }
 
 .c0.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -116,9 +113,6 @@ exports[`tasty() API should create responsive styles 1`] = `
 
 @media (max-width:979px) {
   .c0.c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
     display: flex;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,6 +1161,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.13":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@~7.5.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -7283,6 +7290,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-package-manager@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-package-manager/-/detect-package-manager-2.0.1.tgz#6b182e3ae5e1826752bfef1de9a7b828cffa50d8"
@@ -8505,6 +8517,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focus-lock@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.5.tgz#bef1bf86000ce5ee634a7fedeecf28a580dfbc9d"
+  integrity sha512-1mTr6pl9HBpJ8CqY7hRc38MCrcuTZIeYAkBD1gBTzbx5/to+bRBaBYtJ68iDq7ryTzAAbKrG3dVKjkrWTaaEaw==
+  dependencies:
+    tslib "^2.0.3"
 
 focus-lock@^0.8.0:
   version "0.8.1"
@@ -12556,6 +12575,13 @@ rc-util@^5.9.4:
     react-is "^16.12.0"
     shallowequal "^1.1.0"
 
+react-clientside-effect@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz#29f9b14e944a376b03fb650eed2a754dd128ea3a"
+  integrity sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+
 react-docgen-typescript@^2.1.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
@@ -12601,6 +12627,18 @@ react-error-boundary@^3.1.0:
   integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+react-focus-lock@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.3.tgz#147bc783f4325b7ab52ac580c8afffdfc1d7ce23"
+  integrity sha512-cGNkz9p5Fpqio6hBHlkKxzRYrBYtcPosFOL6Q3N/LSbHjwP/PTBqHpvbgaOYoE7rWfzw8qXPKTB3Tk/VPgw4NQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.11.5"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.6"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -12821,6 +12859,11 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
@@ -14626,6 +14669,21 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

This PR add ability to specify the way how we'd like to hide a dialog: by unmounting or by hiding in css

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Pipeline is passed
- [x] Tests are added (including unit tests and stories in the storybook)
- [x] Tests are passed successfully
- [x] If you're adding a new component/new props, add stories that describe how this component/prop works
- [x] Changeset(s) is(are) added
- [x] You have passed the threshold of the library size
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information
