### PR TITLE
fix(Field): grid column sizing

### DIFF
--- a/.changeset/polite-keys-visit.md
+++ b/.changeset/polite-keys-visit.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Limit the size of the Field items to avoid overflow in the real layouts.

--- a/src/components/forms/Checkbox/CheckboxGroup.tsx
+++ b/src/components/forms/Checkbox/CheckboxGroup.tsx
@@ -24,14 +24,6 @@ import { CheckboxGroupContext } from './context';
 
 import type { AriaCheckboxGroupProps } from '@react-types/checkbox';
 
-const WRAPPER_STYLES = {
-  display: 'grid',
-  gridColumns: {
-    '': '1fr',
-    'has-sider': 'max-content 1fr',
-  },
-};
-
 const CheckGroupElement = tasty({
   qa: 'CheckboxGroup',
   styles: {
@@ -85,7 +77,7 @@ function CheckboxGroup(props: WithNullableValue<CubeCheckboxGroupProps>, ref) {
   } = props;
   let domRef = useDOMRef(ref);
 
-  let styles = extractStyles(otherProps, CONTAINER_STYLES, WRAPPER_STYLES);
+  let styles = extractStyles(otherProps, CONTAINER_STYLES);
 
   let state = useCheckboxGroupState(props);
   let { groupProps, labelProps } = useCheckboxGroup(props, state);

--- a/src/components/forms/FieldWrapper.tsx
+++ b/src/components/forms/FieldWrapper.tsx
@@ -21,8 +21,8 @@ const FieldElement = tasty({
   styles: {
     display: 'grid',
     gridColumns: {
-      '': '1fr',
-      'has-sider': '@(full-label-width, auto) 1fr',
+      '': 'minmax(0, 1fr)',
+      'has-sider': '@(full-label-width, auto) minmax(0, 1fr)',
     },
     gap: 0,
     placeItems: 'baseline stretch',


### PR DESCRIPTION
Limit the size of the Field items to avoid overflow in the real layouts.
