### PR TITLE
Fix regression when Field's childen might be nullish

### DIFF
--- a/.changeset/lucky-turkeys-know.md
+++ b/.changeset/lucky-turkeys-know.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix regression when Field's childen might be nullish

--- a/src/components/forms/Form/Field.tsx
+++ b/src/components/forms/Form/Field.tsx
@@ -166,9 +166,9 @@ export function Field<T extends FieldTypes>(props: CubeFieldProps<T>) {
     children = children(form);
   }
 
-  let child = Children.only(children);
+  let child = children == null ? null : Children.only(children);
 
-  inputType = inputType ?? (child?.type as any).cubeInputType ?? 'Text';
+  inputType = inputType ?? (child?.type as any)?.cubeInputType ?? 'Text';
 
   const __props = useField<T, CubeFullFieldProps<T>>(allProps, {
     defaultValidationTrigger: getDefaultValidateTrigger(inputType),

--- a/src/components/forms/Form/field.test.tsx
+++ b/src/components/forms/Form/field.test.tsx
@@ -200,4 +200,15 @@ describe('Legacy <Field />', () => {
     expect(formInstance.getFieldValue('test')).toBe('cli');
     expect(onChange).toHaveBeenCalled();
   });
+
+  it('should work if children == null', () => {
+    expect(() =>
+      renderWithForm(
+        <Field name="test">
+          {/* @ts-expect-error */}
+          {null}
+        </Field>,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information
