### PR TITLE
Fix: missing data-* on `<ComboBox />` component

### DIFF
--- a/.changeset/purple-kiwis-exist.md
+++ b/.changeset/purple-kiwis-exist.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Fixed missing data-\* attribiutes on `<Combobox />` component

--- a/src/components/pickers/ComboBox/ComboBox.tsx
+++ b/src/components/pickers/ComboBox/ComboBox.tsx
@@ -191,6 +191,7 @@ export const ComboBox = forwardRef(function ComboBox<T extends object>(
   let { contains } = useFilter({ sensitivity: 'base' });
 
   const comboboxProps = {
+    ...otherProps,
     inputValue: props.inputValue,
     defaultInputValue: props.defaultInputValue,
     defaultItems: props.defaultItems,

--- a/src/components/pickers/ComboBox/combobox.test.tsx
+++ b/src/components/pickers/ComboBox/combobox.test.tsx
@@ -131,4 +131,28 @@ describe('<Combobox />', () => {
     expect(filterFn).toHaveBeenCalled();
     expect(options).toHaveLength(1);
   });
+
+  it('should have qa', () => {
+    const { getByTestId } = renderWithRoot(
+      <ComboBox label="test" qa="test">
+        {items.map((item) => (
+          <ComboBox.Item key={item.key}>{item.children}</ComboBox.Item>
+        ))}
+      </ComboBox>,
+    );
+
+    expect(getByTestId('test')).toBeInTheDocument();
+  });
+
+  it('should have data-qa', () => {
+    const { getByTestId } = renderWithRoot(
+      <ComboBox label="test" data-qa="test">
+        {items.map((item) => (
+          <ComboBox.Item key={item.key}>{item.children}</ComboBox.Item>
+        ))}
+      </ComboBox>,
+    );
+
+    expect(getByTestId('test')).toBeInTheDocument();
+  });
 });

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -7,6 +7,7 @@
     "declaration": false
   },
   "exclude": [
+    "src/**/__mocks__/**/*",
     "src/**/*.stories.tsx",
     "src/**/*.stories.ts",
     "src/test/**/*",

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -6,6 +6,7 @@
     "noEmit": false
   },
   "exclude": [
+    "src/**/__mocks__/**/*",
     "src/**/*.stories.tsx",
     "src/**/*.stories.ts",
     "src/test/**/*",


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [x] Tests are added (including unit tests and stories in the storybook)
- [x] Tests are passed successfully
- [x] If you're adding a new component/new props, add stories that describe how this component/prop works
- [x] Changeset(s) is(are) added
- [x] You have passed the threshold of the library size
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information
