### PR TITLE
fix(TooltipProvider): return type

### DIFF
--- a/.changeset/popular-weeks-obey.md
+++ b/.changeset/popular-weeks-obey.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix the return type of TooltipProvider.

--- a/src/components/overlays/Tooltip/TooltipProvider.tsx
+++ b/src/components/overlays/Tooltip/TooltipProvider.tsx
@@ -17,7 +17,7 @@ export interface CubeTooltipProviderProps
   width?: CubeTooltipProps['width'];
 }
 
-export function TooltipProvider(props: CubeTooltipProviderProps) {
+export function TooltipProvider(props: CubeTooltipProviderProps): ReactElement {
   const [rendered, setRendered] = useState(false);
   const { title, children, tooltipStyles, width, ...otherProps } = props;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Explicitly types `TooltipProvider` to return `ReactElement` and adds a changeset for a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43a2f413a986da8473513774b948a5993343b527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->