### PR TITLE
fix: decimal icons

### DIFF
--- a/.changeset/hip-doors-crash.md
+++ b/.changeset/hip-doors-crash.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix the return type of the TooltipProvider the second time :)

--- a/.changeset/stale-spies-attend.md
+++ b/.changeset/stale-spies-attend.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix DecimalDecreaseIcon and DecimalIncreaseIcon.

--- a/src/components/overlays/Tooltip/TooltipProvider.tsx
+++ b/src/components/overlays/Tooltip/TooltipProvider.tsx
@@ -1,4 +1,11 @@
-import { ReactElement, ReactNode, RefObject, useEffect, useState } from 'react';
+import {
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  RefObject,
+  useEffect,
+  useState,
+} from 'react';
 
 import { Styles } from '../../../tasty';
 
@@ -11,7 +18,7 @@ import {
 
 export interface CubeTooltipProviderProps
   extends Omit<CubeTooltipTriggerProps, 'children'> {
-  children: ReactElement | TooltipTriggerFunction;
+  children: ReactNode | TooltipTriggerFunction;
   title?: ReactNode;
   tooltipStyles?: Styles;
   width?: CubeTooltipProps['width'];
@@ -29,20 +36,26 @@ export function TooltipProvider(props: CubeTooltipProviderProps): ReactElement {
 
   // SSR: render without tooltip
   if (!rendered) {
-    return isFunction ? (
+    return (
       <>
-        {children({}, { current: null } as unknown as RefObject<HTMLElement>)}
+        {isFunction
+          ? children({}, { current: null } as unknown as RefObject<HTMLElement>)
+          : children}
       </>
-    ) : (
-      <>{children}</>
-    );
+    ) as ReactElement;
   }
 
   // Both patterns pass through to TooltipTrigger
   // The difference is whether we pass function or element as first child
   return (
     <TooltipTrigger {...otherProps}>
-      {children}
+      {isFunction ||
+      isValidElement(children) ||
+      typeof children === 'string' ? (
+        children
+      ) : (
+        <>{children}</>
+      )}
       <Tooltip styles={tooltipStyles} {...(width ? { width } : null)}>
         {title}
       </Tooltip>

--- a/src/icons/DecimalDecreaseIcon.tsx
+++ b/src/icons/DecimalDecreaseIcon.tsx
@@ -10,7 +10,7 @@ export const DecimalDecreaseIcon = wrapIcon(
     viewBox="0 0 24 24"
   >
     <path
-      stroke="#000"
+      stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth="1.5"

--- a/src/icons/DecimalIncreaseIcon.tsx
+++ b/src/icons/DecimalIncreaseIcon.tsx
@@ -10,7 +10,7 @@ export const DecimalIncreaseIcon = wrapIcon(
     viewBox="0 0 24 24"
   >
     <path
-      stroke="#000"
+      stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth="1.5"

--- a/src/icons/Icons.stories.tsx
+++ b/src/icons/Icons.stories.tsx
@@ -61,7 +61,7 @@ const Template: StoryFn<CubeIconProps> = (name) => {
 
           return (
             <Space key={iconName} gap="1x">
-              <Icon size={24} />
+              <Icon size={24} color="#purple-text" />
               <Text preset="t4">{iconName}</Text>
             </Space>
           );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch decimal icons to inherit color via `currentColor` and update Storybook preview color; add patch changesets (including TooltipProvider return type note).
> 
> - **Icons**:
>   - Update `DecimalDecreaseIcon` and `DecimalIncreaseIcon` to use `stroke="currentColor"` instead of `#000`.
> - **Storybook**:
>   - In `src/icons/Icons.stories.tsx`, pass a `color` prop for 24px icon previews.
> - **Changesets**:
>   - Patch releases for `@cube-dev/ui-kit` noting fixes to decimal icons and TooltipProvider return type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acaaf1240682562e01d868f9dcd55597076d2321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->