### PR TITLE
fix(ItemBase): tooltip logic

### DIFF
--- a/.changeset/khaki-lizards-fry.md
+++ b/.changeset/khaki-lizards-fry.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix tooltip dynamic calculation in ItemBase.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes auto-tooltip overflow detection in `ItemBase` by measuring via an internal `elementRef` and properly forwarding/exposing external label refs.
> 
> - **ItemBase tooltip logic**:
>   - Switch overflow measurement from combined refs to internal `elementRef` used by `ResizeObserver` and `checkLabelOverflow`.
>   - Properly forward external label refs via callback (`function` or `.current`) using `externalLabelRef`.
>   - Replace `observedElementRef` with `elementRef`; update effect deps and cleanup accordingly.
>   - Keep auto-tooltip behavior unchanged functionally, improving reliability of dynamic overflow checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a54634d6a3126b472909d1dfc83b2deaa821062a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->