### PR TITLE
chore: update tasty

### DIFF
--- a/.changeset/tasty-2-0-1-update.md
+++ b/.changeset/tasty-2-0-1-update.md
@@ -1,0 +1,13 @@
+---
+"@cube-dev/ui-kit": minor
+---
+
+Update `@tenphi/tasty` to `2.0.1`.
+
+- Unified hash-based class names across all rendering environments for stable cross-environment style deduplication.
+- New `presets` and `globalStyles` options in `configure()`.
+- Default `letterSpacing` in typography presets changed from `'0'` to `'normal'`.
+- Simplified GC to touch-count-driven mechanism — no longer requires `auto: true` configuration.
+- Fixed overlapping and duplicate CSS selectors produced by the condition simplifier.
+
+Migrated: removed deprecated `gc: { auto: true }` from `configure()` call (GC now runs automatically).

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -27,6 +27,6 @@ module.exports = [
     path: './dist/index.js',
     webpack: true,
     import: '{ Button }',
-    limit: '106kB',
+    limit: '107kB',
   },
 ];

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -20,13 +20,13 @@ module.exports = [
         }),
       );
     },
-    limit: '375kB',
+    limit: '380kB',
   },
   {
     name: 'Tree shaking (just a Button)',
     path: './dist/index.js',
     webpack: true,
     import: '{ Button }',
-    limit: '107kB',
+    limit: '110kB',
   },
 ];

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "2.0.1",
+    "@tenphi/tasty": "0.0.0-snapshot.98a23b6",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "1.2.0",
+    "@tenphi/tasty": "0.0.0-snapshot.e8f14d4",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "0.0.0-snapshot.be4449a",
+    "@tenphi/tasty": "1.4.2",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "0.0.0-snapshot.e8f14d4",
+    "@tenphi/tasty": "0.0.0-snapshot.be4449a",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "1.4.2",
+    "@tenphi/tasty": "2.0.1",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "0.0.0-snapshot.98a23b6",
+    "@tenphi/tasty": "2.0.2",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.98a23b6
-        version: 0.0.0-snapshot.98a23b6(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.0.2
+        version: 2.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@0.0.0-snapshot.98a23b6':
-    resolution: {integrity: sha512-aiZyJLNRrphus6O+SgRtkAsBwSUra5qyavn+z+Qe56SWUSUj1I/uNYc486ZmXdVMj6cRYN1q7JnwoxnnAyQA5g==}
+  '@tenphi/tasty@2.0.2':
+    resolution: {integrity: sha512-4yYE6dn9KYq3oV9g8aHrru+0l3rL4FtYNX9qLcIcvk79I6abQT4I1JWAMzORs6jrbQtZwv1QiKNmuDxEI6EkJw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@0.0.0-snapshot.98a23b6(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 1.2.0
-        version: 1.2.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.e8f14d4
+        version: 0.0.0-snapshot.e8f14d4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@1.2.0':
-    resolution: {integrity: sha512-31eXCtX8T3K9t8qEFxE94Kt0Zyu7a619+QhlfbSlxjtB2axytnppucQF/FVy5/wsXinQPoDjpGqyMnZU006caQ==}
+  '@tenphi/tasty@0.0.0-snapshot.e8f14d4':
+    resolution: {integrity: sha512-4XT/OY9qdO0oo2MKUG2zEpQVOZV+apZnjmP6+Ldtz3X+ctG0hfkE9T07I9U4ooXz8lb1pskzLAyv849dSLqQ/Q==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@1.2.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.e8f14d4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.be4449a
-        version: 0.0.0-snapshot.be4449a(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 1.4.2
+        version: 1.4.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@0.0.0-snapshot.be4449a':
-    resolution: {integrity: sha512-NQBLgvCTgBVxSSva6YOooQdPa5+iICEYsZhVA3L8JbbvLM4lOLLtJN6RrNF8usk8SmgbfPB4MtnklmLbFq7bIA==}
+  '@tenphi/tasty@1.4.2':
+    resolution: {integrity: sha512-O5CZEREPfFummX0M4tIsrVmCy+Je0eUYNiKKf3N334HeyoUmsA0LUmO/UH2LepgXZHauyEGWSrryjG+obbrECw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@0.0.0-snapshot.be4449a(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@1.4.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.e8f14d4
-        version: 0.0.0-snapshot.e8f14d4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.be4449a
+        version: 0.0.0-snapshot.be4449a(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@0.0.0-snapshot.e8f14d4':
-    resolution: {integrity: sha512-4XT/OY9qdO0oo2MKUG2zEpQVOZV+apZnjmP6+Ldtz3X+ctG0hfkE9T07I9U4ooXz8lb1pskzLAyv849dSLqQ/Q==}
+  '@tenphi/tasty@0.0.0-snapshot.be4449a':
+    resolution: {integrity: sha512-NQBLgvCTgBVxSSva6YOooQdPa5+iICEYsZhVA3L8JbbvLM4lOLLtJN6RrNF8usk8SmgbfPB4MtnklmLbFq7bIA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@0.0.0-snapshot.e8f14d4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.be4449a(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 2.0.1
-        version: 2.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.98a23b6
+        version: 0.0.0-snapshot.98a23b6(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@2.0.1':
-    resolution: {integrity: sha512-v79rzL6nMN4qm7ujc5nPryZlfFGLNsHLmPExH8XodS3yqWOQXg+Z1HwyEok9QppvRWylQgee6OlqrSq17lTdNQ==}
+  '@tenphi/tasty@0.0.0-snapshot.98a23b6':
+    resolution: {integrity: sha512-aiZyJLNRrphus6O+SgRtkAsBwSUra5qyavn+z+Qe56SWUSUj1I/uNYc486ZmXdVMj6cRYN1q7JnwoxnnAyQA5g==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@2.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.98a23b6(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 1.4.2
-        version: 1.4.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.0.1
+        version: 2.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@1.4.2':
-    resolution: {integrity: sha512-O5CZEREPfFummX0M4tIsrVmCy+Je0eUYNiKKf3N334HeyoUmsA0LUmO/UH2LepgXZHauyEGWSrryjG+obbrECw==}
+  '@tenphi/tasty@2.0.1':
+    resolution: {integrity: sha512-v79rzL6nMN4qm7ujc5nPryZlfFGLNsHLmPExH8XodS3yqWOQXg+Z1HwyEok9QppvRWylQgee6OlqrSq17lTdNQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@1.4.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -22,9 +22,6 @@ import { OverlayProvider } from './overlays/Notifications/OverlayProvider';
 import { PortalProvider } from './portal';
 
 configure({
-  gc: {
-    auto: true,
-  },
   colorSpace: 'rgb',
   units: {
     x: 'var(--gap)',

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -22,6 +22,9 @@ import { OverlayProvider } from './overlays/Notifications/OverlayProvider';
 import { PortalProvider } from './portal';
 
 configure({
+  gc: {
+    auto: true,
+  },
   colorSpace: 'rgb',
   units: {
     x: 'var(--gap)',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades a core styling/runtime dependency and adjusts its `configure()` usage, which can change generated classnames/CSS and affect visual output across environments. Slight bundle size increases are accepted via updated `size-limit` thresholds.
> 
> **Overview**
> Updates `@tenphi/tasty` from `1.4.2` to `2.0.2` and records the release via a new Changeset noting v2 behavior changes (hash-stable classnames, new `configure()` options, typography default tweaks, and GC changes).
> 
> Removes the deprecated `gc: { auto: true }` option from the `tasty` `configure()` call in `Root.tsx` (GC now runs automatically), and relaxes `size-limit` thresholds to account for the dependency upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fef160ac60a8b7f027c97b8daf698899f9f4d39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->