### PR TITLE
chore: update tasty

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "2.0.2",
+    "@tenphi/tasty": "0.0.0-snapshot.6d7c870",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "0.0.0-snapshot.6d7c870",
+    "@tenphi/tasty": "2.0.3",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 2.0.2
-        version: 2.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.6d7c870
+        version: 0.0.0-snapshot.6d7c870(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@2.0.2':
-    resolution: {integrity: sha512-4yYE6dn9KYq3oV9g8aHrru+0l3rL4FtYNX9qLcIcvk79I6abQT4I1JWAMzORs6jrbQtZwv1QiKNmuDxEI6EkJw==}
+  '@tenphi/tasty@0.0.0-snapshot.6d7c870':
+    resolution: {integrity: sha512-ALoDGhvleLxWnSR0PnfmiuxLQqNBM2VmcSnI05WiAIOme8ZloQGPWyeYt7wNDI1sGALQliTDVbPnvFg3QAUcTw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@2.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.6d7c870(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.6d7c870
-        version: 0.0.0-snapshot.6d7c870(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.0.3
+        version: 2.0.3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@0.0.0-snapshot.6d7c870':
-    resolution: {integrity: sha512-ALoDGhvleLxWnSR0PnfmiuxLQqNBM2VmcSnI05WiAIOme8ZloQGPWyeYt7wNDI1sGALQliTDVbPnvFg3QAUcTw==}
+  '@tenphi/tasty@2.0.3':
+    resolution: {integrity: sha512-KBmglQhsVcrvJvWJF5GjRlp8cdV3B3QLE3cavPgm5vGAIOiMwuGQa8/pbenUobFLZo+zH5N3fZWVAjakEhEhKg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@0.0.0-snapshot.6d7c870(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.0.3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency-only change updating `@tenphi/tasty` from `2.0.2` to `2.0.3` with corresponding lockfile updates; behavior changes, if any, are limited to that library.
> 
> **Overview**
> Updates the `@tenphi/tasty` dependency from `2.0.2` to `2.0.3` and refreshes `pnpm-lock.yaml` to the new resolved version/integrity values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 568d30e1d7e6afbb295716b4e97545cdff7b1089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->