### PR TITLE
fix(TextInput): placeholder color

### DIFF
--- a/.changeset/fix-placeholder-color.md
+++ b/.changeset/fix-placeholder-color.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Fix placeholder color in input recipes to use `#placeholder` token consistently

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -63,7 +63,6 @@ configure({
       '-webkit-text-fill-color': {
         '': 'currentColor',
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': '#primary',
-        ':placeholder-shown': '(#placeholder, currentColor)',
       },
       caretColor: {
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': '#primary',

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -63,6 +63,7 @@ configure({
       '-webkit-text-fill-color': {
         '': 'currentColor',
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': '#primary',
+        ':placeholder-shown': '(#placeholder, currentColor)',
       },
       caretColor: {
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': '#primary',
@@ -80,8 +81,8 @@ configure({
       },
     },
     'input-placeholder': {
-      '-webkit-text-fill-color': 'var(--placeholder-color, initial)',
-      color: 'var(--placeholder-color, initial)',
+      '-webkit-text-fill-color': '#placeholder',
+      color: '#placeholder',
     },
     'input-search-cancel-button': {
       hide: true,

--- a/src/components/fields/TextInput/TextInput.stories.tsx
+++ b/src/components/fields/TextInput/TextInput.stories.tsx
@@ -160,7 +160,11 @@ export default {
 };
 
 const Template: StoryFn<CubeTextInputProps> = (props) => (
-  <TextInput {...props} onChange={(query) => console.log('change', query)} />
+  <TextInput
+    placeholder="Placeholder"
+    {...props}
+    onChange={(query) => console.log('change', query)}
+  />
 );
 
 export const Default = Template.bind({});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: scoped to placeholder styling in the global `input-placeholder` recipe and a Storybook story tweak; no logic, data handling, or API behavior changes.
> 
> **Overview**
> Fixes input placeholder styling to **consistently use the `#placeholder` design token** (replacing the prior `--placeholder-color` CSS variable fallback) for both `color` and `-webkit-text-fill-color`.
> 
> Updates the `TextInput` Storybook template to always render with a placeholder, and adds a changeset for a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebe248065a59b96016c195e18b965c35259687d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->