### PR TITLE
chore: update tasty

### DIFF
--- a/.changeset/lovely-parrots-warn.md
+++ b/.changeset/lovely-parrots-warn.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Update tasty to the latest.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -27,6 +27,6 @@ module.exports = [
     path: './dist/index.js',
     webpack: true,
     import: '{ Button }',
-    limit: '110kB',
+    limit: '115kB',
   },
 ];

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "0.0.0-snapshot.d5a87a3",
+    "@tenphi/tasty": "2.1.0",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "2.0.3",
+    "@tenphi/tasty": "0.0.0-snapshot.81de5e7",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "0.0.0-snapshot.81de5e7",
+    "@tenphi/tasty": "0.0.0-snapshot.d5a87a3",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.81de5e7
-        version: 0.0.0-snapshot.81de5e7(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.d5a87a3
+        version: 0.0.0-snapshot.d5a87a3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@0.0.0-snapshot.81de5e7':
-    resolution: {integrity: sha512-0olhCnLGgGl4pTXoBi4gC2qrDKexu9Zpa/Y0T48mfx6XyzSHQnc7/BhdFrSV1evH2RlWm5Ey7GcWB0o1F0AG1g==}
+  '@tenphi/tasty@0.0.0-snapshot.d5a87a3':
+    resolution: {integrity: sha512-t+qKERNKmoKhA4OIiTps0fIWId4srIEgE2XNQ0Hu9W9Z+cEeaKWFTyOg66MQ38k5JB2qsMZ6fIcQbdcfU0RL8g==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@0.0.0-snapshot.81de5e7(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.d5a87a3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 2.0.3
-        version: 2.0.3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.81de5e7
+        version: 0.0.0-snapshot.81de5e7(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@2.0.3':
-    resolution: {integrity: sha512-KBmglQhsVcrvJvWJF5GjRlp8cdV3B3QLE3cavPgm5vGAIOiMwuGQa8/pbenUobFLZo+zH5N3fZWVAjakEhEhKg==}
+  '@tenphi/tasty@0.0.0-snapshot.81de5e7':
+    resolution: {integrity: sha512-0olhCnLGgGl4pTXoBi4gC2qrDKexu9Zpa/Y0T48mfx6XyzSHQnc7/BhdFrSV1evH2RlWm5Ey7GcWB0o1F0AG1g==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@2.0.3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.81de5e7(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.d5a87a3
-        version: 0.0.0-snapshot.d5a87a3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.1.0
+        version: 2.1.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@0.0.0-snapshot.d5a87a3':
-    resolution: {integrity: sha512-t+qKERNKmoKhA4OIiTps0fIWId4srIEgE2XNQ0Hu9W9Z+cEeaKWFTyOg66MQ38k5JB2qsMZ6fIcQbdcfU0RL8g==}
+  '@tenphi/tasty@2.1.0':
+    resolution: {integrity: sha512-tMdbnbYGyfQvXnJian2cFhjb6IZDBn6UqIRqXQrng/QXF2t/tmH3DSpzJmYhsK05on/hz2lz9WJIBEpj1ixg2A==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@0.0.0-snapshot.d5a87a3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.1.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk dependency update, but it may introduce subtle styling/build output changes and slightly increases the tree-shaken bundle size budget.
> 
> **Overview**
> Updates `@tenphi/tasty` from `2.0.3` to `2.1.0` (including lockfile), and adds a Changesets entry to publish a patch release.
> 
> Adjusts the `size-limit` budget for the tree-shaken `Button` import from `110kB` to `115kB` to reflect the new dependency output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9e85751719685041d2c07c42f4d08e9f56a2a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->