### PR TITLE
fix(FilterPicker): loading items search

### DIFF
--- a/.changeset/filterpicker-loading-items.md
+++ b/.changeset/filterpicker-loading-items.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': minor
 ---
 
-Add `isLoadingItems` prop to `FilterPicker` and `FilterListBox`. Unlike `isLoading`, this does not disable the trigger — the popover can still be opened while items are being fetched. Inside the popover, a loading disclaimer is shown. When `allowsCustomValue={false}`, the search input is hidden and the disclaimer becomes the focus target; when `allowsCustomValue={true}`, the search input remains visible so a custom value can still be typed and applied. The disclaimer label is customizable via `loadingItemsLabel` (defaults to `"Loading items..."`).
+Simplify `isLoadingItems` in `FilterPicker` and `FilterListBox` — it now shows a loading spinner in the search input suffix inside the popover instead of a full disclaimer. The trigger no longer shows a loading icon for `isLoadingItems`. Remove `loadingItemsLabel` prop. Unify `emptyLabel` to cover all empty states: when provided, it overrides both the "No items" and "No results found" defaults.

--- a/.changeset/filterpicker-loading-items.md
+++ b/.changeset/filterpicker-loading-items.md
@@ -3,3 +3,14 @@
 ---
 
 Simplify `isLoadingItems` in `FilterPicker` and `FilterListBox` — it now shows a loading spinner in the search input suffix inside the popover instead of a full disclaimer. The trigger no longer shows a loading icon for `isLoadingItems`. Remove `loadingItemsLabel` prop. Unify `emptyLabel` to cover all empty states: when provided, it overrides both the "No items" and "No results found" defaults.
+
+During an in-flight server fetch (`filter={false}` + `isLoadingItems={true}`), stale items that do not text-match the current search are now hidden client-side via `contains`. This avoids confusing UI where unrelated stale items remain visible alongside the user's typed value. Once the fetch resolves and `isLoadingItems` flips back to `false`, the parent's items are shown as-is.
+
+Locally-injected selected custom values (the ones that persist via `customKeys` in multi-select with `allowsCustomValue`) now also respect the search input regardless of `filter={false}`. Previously they remained visible while the parent's items were filtered, which created an inconsistent UI. `filter={false}` only governs how parent-provided items are filtered — it does not exempt FilterListBox's own injected items.
+
+Improve virtual-focus behavior with `allowsCustomValue`:
+
+- While the user is typing and the server fetch is in flight, non-matching stale items are hidden and focus moves to the new custom-value suggestion so the user can press Enter to add it immediately.
+- When the fetch resolves with no matches, focus stays on the custom value.
+- When the fetch resolves with matches, focus moves to the first real item.
+- With client-side filtering, when no items match the search, focus moves to the custom-value suggestion (same UX as the server-side path).

--- a/src/components/fields/FilterListBox/FilterListBox.docs.mdx
+++ b/src/components/fields/FilterListBox/FilterListBox.docs.mdx
@@ -692,7 +692,8 @@ const handleSearchChange = useCallback((value) => {
 - **`filter={false}`** disables client-side filtering so items appear exactly as the server returns them
 - **`searchValue` + `onSearchChange`** give you control over the search input; debounce and fetch on your side
 - **`items`** is reactive — replace it with server results and the list updates automatically
-- **`isLoadingItems`** shows a loading spinner in the search input suffix while fetching
+- **`isLoadingItems`** shows a loading spinner in the search input suffix while fetching. While loading, stale items that do not text-match the current search are hidden client-side so the user only sees relevant suggestions
+- **Selected custom values** (with `allowsCustomValue` in multi-select) are filtered against the search input too, so they don't appear when they don't match
 - **`emptyLabel`** can be used to customize the empty state message (e.g. `"Loading items..."` during initial load)
 - Debouncing is the consumer's responsibility (300-500ms is typical)
 

--- a/src/components/fields/FilterListBox/FilterListBox.docs.mdx
+++ b/src/components/fields/FilterListBox/FilterListBox.docs.mdx
@@ -36,7 +36,7 @@ A searchable list selection component that combines a ListBox with an integrated
 - **`size`** `'small' | 'medium' | 'large'` (default: `medium`) — FilterListBox size
 - **`searchPlaceholder`** `string` (default: `Search...`) — Placeholder text in the search input
 - **`filter`** `((textValue: string, inputValue: string) => boolean) | false` — Custom filter function or `false` to disable filtering
-- **`emptyLabel`** `ReactNode` (default: `No items` / `No results found`) — Label displayed when no items match
+- **`emptyLabel`** `ReactNode` (default: context-aware: `No items` or `No results found`) — Label shown when the list is empty. When provided, overrides both defaults for any empty state
 - **`allowsCustomValue`** `boolean` (default: `false`) — Whether to allow custom values not in the options list
 - **`isCheckable`** `boolean` (default: `false`) — Whether to show checkboxes for multiple selection
 - **`shouldFocusWrap`** `boolean` (default: `false`) — Whether keyboard navigation should wrap around
@@ -52,8 +52,7 @@ A searchable list selection component that combines a ListBox with an integrated
 - **`onOptionClick`** `(key: Key) => void` — Callback when an option is clicked
 - **`items`** `Iterable<T>` — Array of items for dynamic content with render function pattern
 - **`isLoading`** `boolean` (default: `false`) — Whether the FilterListBox is in a loading state (shows loading icon in search input)
-- **`isLoadingItems`** `boolean` (default: `false`) — Whether the items are currently loading. Shows a loading disclaimer inside the popover. When `allowsCustomValue` is `false`, the search input is hidden and the disclaimer acts as the focus target; when `true`, the search input remains visible so custom values can still be typed, and the disclaimer is shown below it
-- **`loadingItemsLabel`** `ReactNode` (default: `Loading items...`) — Label displayed inside the loading disclaimer when `isLoadingItems` is `true`
+- **`isLoadingItems`** `boolean` (default: `false`) — Whether items are currently loading. Shows a loading icon in the search input suffix
 - **`autoFocus`** `boolean` — Whether the search input should have autofocus
 - **`customValueProps`** `Partial<CubeItemProps>` — Props to apply to existing custom values (already selected but not in predefined options)
 - **`newCustomValueProps`** `Partial<CubeItemProps>` — Props to apply to new custom values appearing in search results (merged with `customValueProps`)
@@ -659,36 +658,43 @@ Use `customValueProps` to style existing custom values and `newCustomValueProps`
 - `customValueProps` - Applied to custom values that are already selected
 - `newCustomValueProps` - Applied to new custom values appearing when typing in search (merged with `customValueProps`)
 
-### External Filtering
+### Server-Side / Dynamic Search
 
-For server-side filtering or complex custom logic, use `filter={false}` with controlled search:
+For server-side filtering, use `filter={false}` with controlled search and dynamic `items`. Items are replaced when the server responds, and `isLoadingItems` shows a subtle spinner in the search input while the fetch is in flight.
 
 ```jsx
+const [items, setItems] = useState(initialItems);
 const [searchValue, setSearchValue] = useState('');
-const [filteredItems, setFilteredItems] = useState(allItems);
+const [isLoadingItems, setIsLoadingItems] = useState(false);
 
-useEffect(() => {
-  // Your custom filtering logic (e.g., API call, complex algorithm)
-  const filtered = customFilterLogic(allItems, searchValue);
-  setFilteredItems(filtered);
-}, [searchValue, allItems]);
+const handleSearchChange = useCallback((value) => {
+  setSearchValue(value);
+  setIsLoadingItems(true);
+  debouncedFetch(value)
+    .then(setItems)
+    .finally(() => setIsLoadingItems(false));
+}, []);
 
 <FilterListBox
+  items={items}
   searchValue={searchValue}
-  onSearchChange={setSearchValue}
+  onSearchChange={handleSearchChange}
   filter={false}
+  isLoadingItems={isLoadingItems}
 >
-  {filteredItems.map(item => (
+  {(item) => (
     <FilterListBox.Item key={item.id}>{item.name}</FilterListBox.Item>
-  ))}
+  )}
 </FilterListBox>
 ```
 
-**When to use:**
-- Server-side filtering for large datasets
-- Complex custom search algorithms
-- Debounced API calls
-- Multi-field search logic
+**How it works:**
+- **`filter={false}`** disables client-side filtering so items appear exactly as the server returns them
+- **`searchValue` + `onSearchChange`** give you control over the search input; debounce and fetch on your side
+- **`items`** is reactive — replace it with server results and the list updates automatically
+- **`isLoadingItems`** shows a loading spinner in the search input suffix while fetching
+- **`emptyLabel`** can be used to customize the empty state message (e.g. `"Loading items..."` during initial load)
+- Debouncing is the consumer's responsibility (300-500ms is typical)
 
 ### Escape Key Handling
 

--- a/src/components/fields/FilterListBox/FilterListBox.test.tsx
+++ b/src/components/fields/FilterListBox/FilterListBox.test.tsx
@@ -1213,6 +1213,299 @@ describe('<FilterListBox />', () => {
 
       expect(onSelectionChange).toHaveBeenCalledWith('mango');
     });
+
+    it('should hide non-matching stale items and focus the custom value while server fetch is in flight (filter=false + isLoadingItems)', async () => {
+      const staleItems = [
+        <FilterListBox.Item key="apple">Apple</FilterListBox.Item>,
+        <FilterListBox.Item key="banana">Banana</FilterListBox.Item>,
+      ];
+
+      const { rerender } = render(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue=""
+          filter={false}
+          isLoadingItems={false}
+        >
+          {staleItems}
+        </FilterListBox>,
+      );
+
+      // Initially focus lands on the first real item.
+      let focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('Apple');
+
+      // User types — parent triggers fetch and sets isLoadingItems=true while
+      // items are still stale. Stale non-matching items should be hidden and
+      // focus should move to the custom value so the user can press Enter
+      // to add it immediately.
+      rerender(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue="zzz"
+          filter={false}
+          isLoadingItems={true}
+        >
+          {staleItems}
+        </FilterListBox>,
+      );
+
+      const visibleOptions = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      );
+      const visibleTexts = visibleOptions.map((o) => o.textContent);
+
+      // Stale items that don't match the search should be hidden.
+      expect(visibleTexts).not.toContain('Apple');
+      expect(visibleTexts).not.toContain('Banana');
+
+      focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('zzz');
+    });
+
+    it('should keep matching stale items visible while server fetch is in flight (filter=false + isLoadingItems)', async () => {
+      const staleItems = [
+        <FilterListBox.Item key="apple">Apple</FilterListBox.Item>,
+        <FilterListBox.Item key="apricot">Apricot</FilterListBox.Item>,
+      ];
+
+      render(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue="ap"
+          filter={false}
+          isLoadingItems={true}
+        >
+          {staleItems}
+        </FilterListBox>,
+      );
+
+      const visibleOptions = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      );
+      const visibleTexts = visibleOptions.map((o) => o.textContent);
+
+      // Stale items that match the search should remain visible during
+      // loading so the user can still pick them.
+      expect(visibleTexts).toContain('Apple');
+      expect(visibleTexts).toContain('Apricot');
+    });
+
+    it('should keep focus on custom value when fetch returns no matches', async () => {
+      const { rerender } = render(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue="zzz"
+          filter={false}
+          isLoadingItems={true}
+        >
+          {[<FilterListBox.Item key="apple">Apple</FilterListBox.Item>]}
+        </FilterListBox>,
+      );
+
+      let focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('zzz');
+
+      // Fetch resolves with an empty list (no matches). isLoadingItems flips
+      // to false. View should not change — focus stays on the custom value.
+      rerender(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue="zzz"
+          filter={false}
+          isLoadingItems={false}
+        >
+          {[]}
+        </FilterListBox>,
+      );
+
+      focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('zzz');
+    });
+
+    it('should move focus to custom value when client-side filter yields no matches', async () => {
+      // With client-side filtering, a non-matching search collapses the
+      // collection to just the custom value option, which receives focus
+      // naturally.
+      const { getByPlaceholderText } = render(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+        >
+          <FilterListBox.Item key="apple">Apple</FilterListBox.Item>
+          <FilterListBox.Item key="banana">Banana</FilterListBox.Item>
+        </FilterListBox>,
+      );
+
+      const searchInput = getByPlaceholderText('Search...');
+      await act(async () => {
+        await userEvent.type(searchInput, 'zzz');
+      });
+
+      const focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('zzz');
+    });
+
+    it('should move focus off custom value to first real item when items load asynchronously', async () => {
+      const { getByPlaceholderText, rerender } = render(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue=""
+          filter={false}
+        >
+          {[]}
+        </FilterListBox>,
+      );
+
+      const searchInput = getByPlaceholderText('Search...');
+
+      // User types "ban" while items list is empty — only custom value "ban"
+      // appears and receives virtual focus.
+      rerender(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue="ban"
+          filter={false}
+        >
+          {[]}
+        </FilterListBox>,
+      );
+
+      await act(async () => {
+        searchInput.focus();
+      });
+
+      // The custom value option is the only visible option and should be focused.
+      let focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('ban');
+
+      // Server responds with matching items — real items should take focus
+      // instead of the bottom-of-list custom value suggestion.
+      rerender(
+        <FilterListBox
+          label="Select a fruit"
+          searchPlaceholder="Search..."
+          allowsCustomValue={true}
+          searchValue="ban"
+          filter={false}
+        >
+          {[
+            <FilterListBox.Item key="banana">Banana</FilterListBox.Item>,
+            <FilterListBox.Item key="banana-bread">
+              Banana Bread
+            </FilterListBox.Item>,
+          ]}
+        </FilterListBox>,
+      );
+
+      focused = document.querySelector('[role="option"][data-focused]');
+      expect(focused).toHaveTextContent('Banana');
+      // The focused option must not be the raw "ban" custom value (its text
+      // would be exactly "ban", whereas a real item text includes "Banana").
+      expect(focused?.textContent).not.toBe('ban');
+    });
+
+    it('should hide previously selected custom values that do not match the search (filter=false)', async () => {
+      // Selected custom value "zetasdas" is locally injected by FilterListBox
+      // via customKeys. With `filter={false}`, parent items pass through
+      // unfiltered, but locally-injected custom selected values should still
+      // respect the search input for UI consistency.
+      const { rerender } = render(
+        <FilterListBox
+          label="Select items"
+          searchPlaceholder="Search..."
+          selectionMode="multiple"
+          allowsCustomValue={true}
+          selectedKeys={['zetasdas']}
+          searchValue=""
+          filter={false}
+          isLoadingItems={false}
+        >
+          {[<FilterListBox.Item key="apple">Apple</FilterListBox.Item>]}
+        </FilterListBox>,
+      );
+
+      // With empty search, the previously selected custom value is visible.
+      let visibleTexts = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      ).map((o) => o.textContent);
+      expect(visibleTexts).toContain('zetasdas');
+
+      // User searches "prog" — server has not responded yet but for this test
+      // we simulate the post-load state. The custom selected "zetasdas"
+      // should be hidden because it doesn't match the search.
+      rerender(
+        <FilterListBox
+          label="Select items"
+          searchPlaceholder="Search..."
+          selectionMode="multiple"
+          allowsCustomValue={true}
+          selectedKeys={['zetasdas']}
+          searchValue="prog"
+          filter={false}
+          isLoadingItems={false}
+        >
+          {[]}
+        </FilterListBox>,
+      );
+
+      visibleTexts = Array.from(
+        document.querySelectorAll('[role="option"]'),
+      ).map((o) => o.textContent);
+      expect(visibleTexts).not.toContain('zetasdas');
+      // The new custom value option for the typed search should still appear.
+      expect(visibleTexts).toContain('prog');
+    });
+
+    it('should not render a section divider when no real items match and only the custom value remains (filter=false)', async () => {
+      // Selected custom value "zetads" exists but doesn't match "program".
+      // Parent items are empty. Only the new custom-value suggestion for
+      // "program" should render — no empty filtered-items section above it,
+      // and therefore no divider.
+      const { container } = render(
+        <FilterListBox
+          label="Select items"
+          searchPlaceholder="Search..."
+          selectionMode="multiple"
+          allowsCustomValue={true}
+          selectedKeys={['zetads']}
+          searchValue="program"
+          filter={false}
+          isLoadingItems={false}
+        >
+          {[]}
+        </FilterListBox>,
+      );
+
+      const visibleTexts = Array.from(
+        container.querySelectorAll('[role="option"]'),
+      ).map((o) => o.textContent);
+      expect(visibleTexts).toEqual(['program']);
+
+      // Only one section (the custom-value section) should be present. A
+      // divider is drawn between sections, so having a single section means
+      // no divider appears above the custom value.
+      const sections = container.querySelectorAll(
+        '[role="group"], [role="presentation"][data-section], [data-qa="Section"]',
+      );
+      // The combined count of any section-like wrappers should be at most 1.
+      expect(sections.length).toBeLessThanOrEqual(1);
+    });
   });
 
   describe('Virtualization', () => {

--- a/src/components/fields/FilterListBox/FilterListBox.test.tsx
+++ b/src/components/fields/FilterListBox/FilterListBox.test.tsx
@@ -645,6 +645,27 @@ describe('<FilterListBox />', () => {
         container.querySelector('[data-element="InputIcon"]'),
       ).toBeInTheDocument();
     });
+
+    it('should show loading icon in suffix when isLoadingItems is true', () => {
+      const { container } = render(
+        <FilterListBox isLoadingItems label="Select a fruit">
+          {basicItems}
+        </FilterListBox>,
+      );
+
+      const wrapper = container.querySelector(
+        '[data-qa="FilterListBoxSearchWrapper"]',
+      );
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toHaveAttribute('data-suffix');
+
+      const suffix = wrapper?.querySelector('[data-element="Suffix"]');
+      expect(suffix).toBeInTheDocument();
+      expect(suffix?.parentElement).toBe(wrapper);
+
+      const loadingIcon = suffix?.querySelector('[data-qa="LoadingIcon"]');
+      expect(loadingIcon).toBeInTheDocument();
+    });
   });
 
   describe('Disabled state', () => {

--- a/src/components/fields/FilterListBox/FilterListBox.tsx
+++ b/src/components/fields/FilterListBox/FilterListBox.tsx
@@ -336,6 +336,15 @@ export const FilterListBox = forwardRef(function FilterListBox<
   // State to keep track of custom (user-entered) items that were selected.
   const [customKeys, setCustomKeys] = useState<Set<string>>(new Set());
 
+  // Controlled/uncontrolled search value pattern
+  const [internalSearchValue, setInternalSearchValue] = useState('');
+  const isSearchControlled = controlledSearchValue !== undefined;
+  const searchValue = isSearchControlled
+    ? controlledSearchValue
+    : internalSearchValue;
+
+  const { contains } = useFilter({ sensitivity: 'base' });
+
   // Initialize custom keys from current selection
   useEffect(() => {
     if (!allowsCustomValue) return;
@@ -363,12 +372,23 @@ export const FilterListBox = forwardRef(function FilterListBox<
   const mergedChildren: ReactNode = useMemo(() => {
     if (!children && customKeys.size === 0) return children;
 
+    // Selected custom values are injected by FilterListBox itself, not by the
+    // parent. They must respect the search input regardless of the `filter`
+    // prop — `filter={false}` only describes the parent's authority over its
+    // own items. Filter them with the user-provided filter (if any) or the
+    // default `contains`.
+    const term = searchValue.trim();
+    const localFilter: FilterFn =
+      typeof filter === 'function' ? filter : contains;
+
     // Build React elements for custom values (kept stable via their key).
-    const customArray = Array.from(customKeys).map((key) => (
-      <Item key={key} textValue={key} {...customValueProps}>
-        {key}
-      </Item>
-    ));
+    const customArray = Array.from(customKeys)
+      .filter((key) => !term || localFilter(key, term))
+      .map((key) => (
+        <Item key={key} textValue={key} {...customValueProps}>
+          {key}
+        </Item>
+      ));
 
     // Identify which custom keys are currently selected so we can promote them.
     const selectedKeysSet = new Set<string>();
@@ -407,19 +427,22 @@ export const FilterListBox = forwardRef(function FilterListBox<
     // Final order: selected custom items -> original array (already possibly
     // sorted by parent) -> unselected custom items.
     return [...selectedCustom, ...originalArray, ...unselectedCustom];
-  }, [children, customKeys, selectionMode, selectedKey, selectedKeys]);
+  }, [
+    children,
+    customKeys,
+    selectionMode,
+    selectedKey,
+    selectedKeys,
+    searchValue,
+    filter,
+    contains,
+    customValueProps,
+  ]);
 
   // Determine an aria-label for the internal ListBox to avoid React Aria warnings.
   const innerAriaLabel =
     (props as any)['aria-label'] ||
     (typeof label === 'string' ? label : undefined);
-
-  // Controlled/uncontrolled search value pattern
-  const [internalSearchValue, setInternalSearchValue] = useState('');
-  const isSearchControlled = controlledSearchValue !== undefined;
-  const searchValue = isSearchControlled
-    ? controlledSearchValue
-    : internalSearchValue;
 
   const handleSearchChange = useCallback(
     (value: string) => {
@@ -431,20 +454,26 @@ export const FilterListBox = forwardRef(function FilterListBox<
     [isSearchControlled, onSearchChange],
   );
 
-  const { contains } = useFilter({ sensitivity: 'base' });
-
   // Choose the text filter function: user-provided `filter` prop (if any),
   // or the default `contains` helper from `useFilter`.
-  // When filter={false}, disable filtering completely.
-  const textFilterFn = useMemo<FilterFn>(
-    () => (filter === false ? () => true : filter || contains),
-    [filter, contains],
-  );
+  // When `filter={false}`, the parent owns filtering — we normally pass items
+  // through unchanged. The exception is when `isLoadingItems` is `true`: a
+  // server fetch is in flight and currently visible items are stale, so we
+  // fall back to client-side `contains` to hide non-matching stale items
+  // until the new items arrive.
+  const textFilterFn = useMemo<FilterFn>(() => {
+    if (filter === false) {
+      return isLoadingItems ? contains : () => true;
+    }
+    return filter || contains;
+  }, [filter, contains, isLoadingItems]);
 
   // Create a filter function for collection nodes (similar to ComboBox pattern)
   const filterFn = useCallback(
     (nodes: Iterable<any>) => {
-      if (filter === false) return nodes;
+      // Server-side filtering with no fetch in flight — items are
+      // authoritative and shown as-is.
+      if (filter === false && !isLoadingItems) return nodes;
 
       const term = searchValue.trim();
 
@@ -475,7 +504,7 @@ export const FilterListBox = forwardRef(function FilterListBox<
         })
         .filter(Boolean);
     },
-    [filter, searchValue, textFilterFn],
+    [filter, searchValue, textFilterFn, isLoadingItems],
   );
 
   // Handle custom values if allowed
@@ -511,10 +540,20 @@ export const FilterListBox = forwardRef(function FilterListBox<
       return childrenToProcess;
     }
 
-    // Check if there are any items that will match the filter
+    // Check if there are any items that will match the filter.
     // This determines whether we need to visually separate the custom value
+    // from real items (i.e. render a divider between sections). When there
+    // are no visible items, we skip the section wrapper so no divider is
+    // drawn above a lone custom-value option.
+    //
+    // Selected custom values (from `customKeys`) are filtered by `localFilter`
+    // in `mergedChildren` regardless of `filter={false}`, so this check must
+    // use the same logic — otherwise we'd report "items visible" and draw a
+    // divider while the actual collection only contains the custom value.
+    const localFilter: FilterFn =
+      typeof filter === 'function' ? filter : contains;
+
     const hasVisibleFilteredItems = (() => {
-      // Check original collection items
       for (const item of localCollectionState.collection) {
         if (item.type === 'item') {
           const textValue = item.textValue || String(item.rendered || '');
@@ -531,9 +570,8 @@ export const FilterListBox = forwardRef(function FilterListBox<
         }
       }
 
-      // Also check custom keys - they appear as items in mergedChildren
       for (const customKey of customKeys) {
-        if (textFilterFn(customKey, term)) {
+        if (localFilter(customKey, term)) {
           return true;
         }
       }
@@ -603,6 +641,8 @@ export const FilterListBox = forwardRef(function FilterListBox<
     customValueProps,
     newCustomValueProps,
     textFilterFn,
+    filter,
+    contains,
   ]);
 
   styles = extractStyles(otherProps, PROP_STYLES, styles);
@@ -633,14 +673,42 @@ export const FilterListBox = forwardRef(function FilterListBox<
 
     const { selectionManager, collection } = listState;
 
-    // Helper to collect visible item keys (supports sections)
-    // Collection is already filtered by React Stately via filterFn
-    const collectVisibleKeys = (nodes: Iterable<any>, out: Key[]) => {
+    // Walk the collection and:
+    //   1. Collect visible item keys (supports sections).
+    //   2. Detect the synthetic "new custom value" option — the one generated
+    //      from the current search term when `allowsCustomValue` is true.
+    //
+    // The custom value is rendered in one of two layouts depending on whether
+    // any real item text-matches the search term (`hasVisibleFilteredItems`
+    // in `enhancedChildren`):
+    //   • Some items match → wrapped in a `__custom_value__` section
+    //     (`customValueHasMatches = true`)
+    //   • No items match    → appended at the top level with key === term
+    //     (`customValueHasMatches = false`)
+    //
+    // The layout itself is the signal we use to decide whether the custom
+    // value should be the focus target (no matches) or whether focus should
+    // move to a real item (matches present).
+    const term = searchValue.trim();
+    let newCustomValueKey: Key | null = null;
+    let customValueHasMatches = false;
+
+    const collectVisibleKeys = (
+      nodes: Iterable<any>,
+      out: Key[],
+      inCustomSection = false,
+    ) => {
       for (const node of nodes) {
         if (node.type === 'item') {
           out.push(node.key);
+          if (inCustomSection) {
+            newCustomValueKey = node.key;
+            customValueHasMatches = true;
+          }
         } else if (node.childNodes) {
-          collectVisibleKeys(node.childNodes, out);
+          const isCustomSection =
+            inCustomSection || node.key === '__custom_value__';
+          collectVisibleKeys(node.childNodes, out, isCustomSection);
         }
       }
     };
@@ -648,16 +716,49 @@ export const FilterListBox = forwardRef(function FilterListBox<
     const visibleKeys: Key[] = [];
     collectVisibleKeys(collection, visibleKeys);
 
+    // Detect the appended-at-top-level case (no items text-match). The custom
+    // option is added with key === trimmed search term and lives directly in
+    // the top-level collection (not nested in any section).
+    if (newCustomValueKey == null && allowsCustomValue && term) {
+      for (const node of collection) {
+        if (node.type === 'item' && String(node.key) === term) {
+          newCustomValueKey = node.key;
+          customValueHasMatches = false;
+          break;
+        }
+      }
+    }
+
     // If there are no visible items, reset the focused key so Enter won't select anything
     if (visibleKeys.length === 0) {
       selectionManager.setFocusedKey(null);
       return;
     }
 
-    // Early exit if the current focused key is still present in the visible items.
+    // The custom value should be the focus target when it exists and there
+    // are no real text-matches — the user's typed value is then the only
+    // actionable option. During an in-flight server fetch (`filter === false`
+    // + `isLoadingItems`) `textFilterFn` falls back to client-side `contains`
+    // so non-matching stale items are hidden, which keeps this signal honest.
+    const customValueShouldBeFocused =
+      newCustomValueKey != null && !customValueHasMatches;
+
+    // Decide whether the current focus is already on the right thing. If yes,
+    // don't disturb it. Otherwise fall through and re-pick a focus target.
     const currentFocused = selectionManager.focusedKey;
     if (currentFocused != null && visibleKeys.includes(currentFocused)) {
-      return;
+      const currentIsNewCustomValue =
+        newCustomValueKey != null && currentFocused === newCustomValueKey;
+      if (customValueShouldBeFocused) {
+        if (currentIsNewCustomValue) return;
+      } else if (newCustomValueKey != null) {
+        // Custom value exists but isn't the priority (matches available) —
+        // any non-custom focus is fine.
+        if (!currentIsNewCustomValue) return;
+      } else {
+        // No custom value involved at all.
+        return;
+      }
     }
 
     // Helper to find the first selected item that's visible
@@ -687,17 +788,20 @@ export const FilterListBox = forwardRef(function FilterListBox<
     // Determine which key to focus
     let keyToFocus: Key | null = null;
 
-    // If there's no focus yet (initial state), prioritize selected items
-    if (currentFocused == null) {
-      keyToFocus = findFirstVisibleSelectedKey();
+    if (customValueShouldBeFocused) {
+      // No real matches — promote the custom value over any selected/stale
+      // item so the user can press Enter to add the value they just typed.
+      keyToFocus = newCustomValueKey;
     } else {
-      // If current focused item was filtered out, try to focus another selected item
       keyToFocus = findFirstVisibleSelectedKey();
-    }
 
-    // Fallback to first visible item if no selected item found
-    if (keyToFocus == null) {
-      keyToFocus = visibleKeys[0];
+      // Fallback to first visible item if no selected item found. Prefer the
+      // first real (non-custom-value) item so focus doesn't land on the
+      // bottom-of-list custom-value suggestion when real items are available.
+      if (keyToFocus == null) {
+        const firstRealKey = visibleKeys.find((k) => k !== newCustomValueKey);
+        keyToFocus = firstRealKey ?? visibleKeys[0];
+      }
     }
 
     // Mark this focus change as keyboard navigation so ListBox will scroll to it
@@ -707,7 +811,14 @@ export const FilterListBox = forwardRef(function FilterListBox<
 
     // Set focus to the determined key
     selectionManager.setFocusedKey(keyToFocus);
-  }, [searchValue, enhancedChildren, selectionMode, selectedKey, selectedKeys]);
+  }, [
+    searchValue,
+    enhancedChildren,
+    selectionMode,
+    selectedKey,
+    selectedKeys,
+    allowsCustomValue,
+  ]);
 
   // Keyboard navigation handler for search input
   const { keyboardProps } = useKeyboard({

--- a/src/components/fields/FilterListBox/FilterListBox.tsx
+++ b/src/components/fields/FilterListBox/FilterListBox.tsx
@@ -48,7 +48,7 @@ const FilterListBoxWrapperElement = tasty({
     display: 'grid',
     flow: 'column',
     gridColumns: '1sf',
-    gridRows: 'max-content max-content max-content 1sf',
+    gridRows: 'max-content max-content 1sf',
     gap: 0,
     position: 'relative',
     radius: true,
@@ -95,6 +95,8 @@ const SearchInputElement = tasty({
     padding: {
       '': '.5x 1.5x',
       prefix: '0 1.5x 0 .5x',
+      suffix: '.5x .5x .5x 1.5x',
+      'prefix & suffix': '0 .5x 0 .5x',
     },
   },
 });
@@ -102,35 +104,6 @@ const SearchInputElement = tasty({
 const StyledHeaderWithoutBorder = tasty(StyledHeader, {
   styles: {
     border: false,
-  },
-});
-
-const LoadingDisclaimerElement = tasty({
-  qa: 'FilterListBoxLoadingDisclaimer',
-  styles: {
-    display: 'flex',
-    flow: 'row',
-    gap: '1x',
-    padding: '.75x 1.5x',
-    color: '#dark-03',
-    preset: 'p4',
-    placeItems: 'center start',
-    fill: '#clear',
-    border: 'bottom',
-    height: {
-      '': 'auto',
-      focusable: '($size + 1x)',
-    },
-    $size: {
-      '': '$size-md',
-      'size=small': '$size-sm',
-      'size=medium': '$size-md',
-      'size=large': '$size-lg',
-    },
-    outline: {
-      '': '#purple-03.0',
-      focused: '#purple-03',
-    },
   },
 });
 
@@ -146,25 +119,14 @@ export interface CubeFilterListBoxProps<T>
    * Pass `false` to disable internal filtering completely (useful for external filtering).
    */
   filter?: FilterFn | false;
-  /** Custom label to display when no results are found after filtering */
+  /** Label shown when the list is empty. When provided, overrides both the "No results found" and "No items" defaults. */
   emptyLabel?: ReactNode;
   /** Custom styles for the search input */
   searchInputStyles?: Styles;
   /** Whether the FilterListBox is in loading state (shows loading icon in search input) */
   isLoading?: boolean;
-  /**
-   * Whether the items are currently loading. Shows a "loading items" disclaimer
-   * inside the popover. When `allowsCustomValue` is `false`, the search input is
-   * hidden and the disclaimer acts as the focus target for keyboard navigation.
-   * When `allowsCustomValue` is `true`, the search input remains visible and the
-   * disclaimer is shown below it (so a custom value can still be typed and applied).
-   */
+  /** Whether items are currently loading. Shows a loading icon in the search input suffix. */
   isLoadingItems?: boolean;
-  /**
-   * Label displayed inside the loading disclaimer when `isLoadingItems` is `true`.
-   * @default "Loading items..."
-   */
-  loadingItemsLabel?: ReactNode;
   /** Ref for accessing the search input element */
   searchInputRef?: RefObject<HTMLInputElement | null>;
   /** Whether to allow entering custom values that are not present in the predefined options */
@@ -269,7 +231,6 @@ export const FilterListBox = forwardRef(function FilterListBox<
     isDisabled,
     isLoading,
     isLoadingItems,
-    loadingItemsLabel = 'Loading items...',
     searchPlaceholder = 'Search...',
     autoFocus,
     filter,
@@ -483,9 +444,10 @@ export const FilterListBox = forwardRef(function FilterListBox<
   // Create a filter function for collection nodes (similar to ComboBox pattern)
   const filterFn = useCallback(
     (nodes: Iterable<any>) => {
+      if (filter === false) return nodes;
+
       const term = searchValue.trim();
 
-      // Don't filter if no search term
       if (!term) {
         return nodes;
       }
@@ -513,7 +475,7 @@ export const FilterListBox = forwardRef(function FilterListBox<
         })
         .filter(Boolean);
     },
-    [searchValue, textFilterFn],
+    [filter, searchValue, textFilterFn],
   );
 
   // Handle custom values if allowed
@@ -890,9 +852,6 @@ export const FilterListBox = forwardRef(function FilterListBox<
     },
   });
 
-  const showSearchInput = !isLoadingItems || allowsCustomValue;
-  const showLoadingDisclaimer = !!isLoadingItems;
-
   const mods = useMemo(
     () => ({
       invalid: isInvalid,
@@ -901,13 +860,9 @@ export const FilterListBox = forwardRef(function FilterListBox<
       focused: isFocused,
       loading: !!isLoading,
       'loading-items': !!isLoadingItems,
-      // `searchable` marks this as a FilterListBox context (vs a bare ListBox)
-      // and tells inner components — notably ListBox — to drop their own
-      // borders. It must stay true even when the search input is hidden
-      // (e.g. isLoadingItems && !allowsCustomValue), otherwise ListBox would
-      // render a redundant inner border.
       searchable: true,
       prefix: !!isLoading,
+      suffix: !!isLoadingItems,
       ...externalMods,
     }),
     [
@@ -953,16 +908,13 @@ export const FilterListBox = forwardRef(function FilterListBox<
     }
   };
 
-  // Custom option click handler that ensures the active focus target (search
-  // input, or the disclaimer when it replaces the search input) receives focus
-  // so subsequent keyboard navigation keeps working after a mouse click.
+  // Custom option click handler that ensures search input receives focus
   const handleOptionClick = (key: Key) => {
+    // Focus the search input to enable keyboard navigation
     // Use setTimeout to ensure this happens after React state updates
     setTimeout(() => {
       if (searchInputRef.current) {
         searchInputRef.current.focus();
-      } else if (disclaimerRef.current) {
-        disclaimerRef.current.focus();
       }
     }, 0);
 
@@ -986,6 +938,7 @@ export const FilterListBox = forwardRef(function FilterListBox<
         qa={qa || 'FilterListBox'}
         id={id}
         data-prefix={isLoading ? '' : undefined}
+        data-suffix={isLoadingItems ? '' : undefined}
         type="search"
         placeholder={searchPlaceholder}
         value={searchValue}
@@ -1009,48 +962,12 @@ export const FilterListBox = forwardRef(function FilterListBox<
         {...keyboardProps}
         {...modAttrs(mods)}
       />
+      {isLoadingItems && (
+        <div data-element="Suffix">
+          <LoadingIcon data-element="InputIcon" />
+        </div>
+      )}
     </SearchWrapperElement>
-  );
-
-  // When the search input is hidden (e.g. items are loading and custom values
-  // are not allowed), the disclaimer takes over the search input's role as the
-  // focus target so arrow-key navigation over the (possibly partial) list still
-  // works.
-  const disclaimerIsFocusable = showLoadingDisclaimer && !showSearchInput;
-  const disclaimerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (disclaimerIsFocusable && autoFocus) {
-      disclaimerRef.current?.focus();
-    }
-    // Run only when we switch into a focusable-disclaimer state so we don't
-    // steal focus on unrelated re-renders.
-  }, [disclaimerIsFocusable]);
-
-  const loadingDisclaimer = showLoadingDisclaimer ? (
-    <LoadingDisclaimerElement
-      ref={disclaimerRef}
-      data-size={size}
-      mods={{ focusable: disclaimerIsFocusable, ...mods }}
-      {...(disclaimerIsFocusable
-        ? {
-            tabIndex: 0,
-            role: 'combobox',
-            'aria-expanded': 'true',
-            'aria-haspopup': 'listbox',
-            'aria-activedescendant':
-              listStateRef.current?.selectionManager.focusedKey != null
-                ? `ListBoxItem-${listStateRef.current?.selectionManager.focusedKey}`
-                : undefined,
-            ...keyboardProps,
-          }
-        : {})}
-    >
-      <LoadingIcon />
-      <span>{loadingItemsLabel}</span>
-    </LoadingDisclaimerElement>
-  ) : (
-    <div role="presentation" />
   );
 
   const filterListBoxField = (
@@ -1068,8 +985,7 @@ export const FilterListBox = forwardRef(function FilterListBox<
       ) : (
         <div role="presentation" />
       )}
-      {showSearchInput ? searchInput : <div role="presentation" />}
-      {loadingDisclaimer}
+      {searchInput}
       <ListBox
         ref={listBoxRef}
         aria-label={innerAriaLabel}
@@ -1103,11 +1019,11 @@ export const FilterListBox = forwardRef(function FilterListBox<
         allValueProps={allValueProps}
         filter={filterFn}
         emptyLabel={
-          searchValue.trim()
-            ? emptyLabel !== undefined
-              ? emptyLabel
-              : 'No results found'
-            : 'No items'
+          emptyLabel !== undefined
+            ? emptyLabel
+            : searchValue.trim()
+              ? 'No results found'
+              : 'No items'
         }
         onSelectionChange={handleSelectionChange}
         onEscape={onEscape}

--- a/src/components/fields/FilterPicker/FilterPicker.docs.mdx
+++ b/src/components/fields/FilterPicker/FilterPicker.docs.mdx
@@ -32,7 +32,7 @@ A versatile selection component that combines a trigger button with a searchable
 - **`selectionMode`** `'single' | 'multiple'` (default: `single`) — Selection mode for the picker
 - **`allowsCustomValue`** `boolean` (default: `false`) — Whether to allow entering custom values that are not present in the predefined options
 - **`isClearable`** `boolean` (default: `false`) — Whether the filter picker is clearable using a clear button in the rightIcon slot
-- **`isLoadingItems`** `boolean` (default: `false`) — Whether the items are currently loading. Unlike `isLoading`, this does NOT disable the trigger, so the popover can still be opened while items are being fetched. Shows a `LoadingIcon` in the trigger and a loading disclaimer inside the popover. When `allowsCustomValue` is `false`, the search input is hidden and only the disclaimer is shown; when `true`, the search input remains visible so users can still type and apply a custom value.
+- **`isLoadingItems`** `boolean` (default: `false`) — Whether items are currently loading. Shows a loading spinner in the search input suffix inside the popover. Unlike `isLoading`, does not disable the trigger.
 - **`disallowEmptySelection`** `boolean` (default: `false`) — Whether to disallow empty selection
 - **`disabledKeys`** `Key[]` — Array of keys for disabled items
 - **`items`** `Iterable<T>` — Array of items to render when using the render function pattern for large datasets with dynamic content
@@ -42,7 +42,7 @@ A versatile selection component that combines a trigger button with a searchable
 - **`theme`** `'default' | 'special'` (default: `default`) — Button theme
 - **`size`** `'small' | 'medium' | 'large'` (default: `medium`) — Size of the picker component
 - **`searchPlaceholder`** `string` — Placeholder text in the search input
-- **`emptyLabel`** `string` — Custom label to display when no results are found after filtering
+- **`emptyLabel`** `ReactNode` (default: context-aware: `No items` or `No results found`) — Label shown when the list is empty. When provided, overrides both defaults for any empty state
 - **`filter`** `((textValue: string, inputValue: string) => boolean) | false` — Custom filter function for determining if an option should be included in search results
 - **`header`** `ReactNode` — Custom header content
 - **`footer`** `ReactNode` — Custom footer content
@@ -484,7 +484,7 @@ const categories = [
 
 ### Loading Items
 
-Use `isLoadingItems` to indicate that items are currently being fetched. Unlike `isLoading`, the trigger stays enabled so users can still open the popover and interact with items that have already loaded.
+Use `isLoadingItems` to indicate that items are currently being fetched. Unlike `isLoading`, the trigger stays enabled so users can still open the popover and interact with items that have already loaded. A loading spinner appears in the search input suffix.
 
 <Story of={FilterPickerStories.LoadingItemsState} />
 
@@ -494,24 +494,6 @@ Use `isLoadingItems` to indicate that items are currently being fetched. Unlike 
   placeholder="Select a fruit..."
   isLoadingItems={true}
   selectionMode="multiple"
->
-  <FilterPicker.Item key="apple">Apple</FilterPicker.Item>
-  <FilterPicker.Item key="banana">Banana</FilterPicker.Item>
-</FilterPicker>
-```
-
-When `allowsCustomValue` is `true`, the search input remains visible so users can still type and apply a custom value while items are loading. The loading disclaimer is shown below the search input.
-
-<Story of={FilterPickerStories.LoadingItemsWithCustomValue} />
-
-```jsx
-<FilterPicker
-  label="Loading Items (Custom Value)"
-  placeholder="Type or pick a fruit..."
-  isLoadingItems={true}
-  allowsCustomValue={true}
-  selectionMode="multiple"
-  searchPlaceholder="Search or type custom value..."
 >
   <FilterPicker.Item key="apple">Apple</FilterPicker.Item>
   <FilterPicker.Item key="banana">Banana</FilterPicker.Item>
@@ -779,80 +761,61 @@ The clear button:
 - Calls the optional `onClear` callback
 - Is hidden when the picker is disabled or read-only
 
-### External Filtering
+### Server-Side / Dynamic Search
 
-<Story of={FilterPickerStories.ExternalFiltering} />
+<Story of={FilterPickerStories.AsyncSearch} />
 
-FilterPicker provides two approaches for implementing external filtering when you need to control the filtering logic outside the component:
-
-#### Approach 1: Disabled Internal Filtering
-
-Use `filter={false}` to disable internal filtering while providing pre-filtered items:
+When items come from a backend API, use `filter={false}` with controlled search to let the server handle filtering. Items are replaced when the response arrives, and `isLoadingItems` shows a subtle spinner in the search input while the fetch is in flight.
 
 ```jsx
-const [externalSearch, setExternalSearch] = useState('');
-
-const filteredFruits = useMemo(() => {
-  if (!externalSearch.trim()) return allFruits;
-  return allFruits.filter((fruit) =>
-    fruit.label.toLowerCase().includes(externalSearch.toLowerCase())
-  );
-}, [externalSearch]);
-
-<FilterPicker
-  label="Select Fruits"
-  placeholder="Choose fruits..."
-  selectionMode="multiple"
-  filter={false}
-  items={filteredFruits}
-  searchPlaceholder="Type to search..."
->
-  {(fruit) => (
-    <FilterPicker.Item key={fruit.key}>{fruit.label}</FilterPicker.Item>
-  )}
-</FilterPicker>
-```
-
-#### Approach 2: Controlled Search Input
-
-Use `searchValue` and `onSearchChange` for complete control over the search behavior:
-
-```jsx
+const [items, setItems] = useState(initialItems);
 const [searchValue, setSearchValue] = useState('');
+const [isLoadingItems, setIsLoadingItems] = useState(false);
 
-// Simulate debounced search
-const [processedSearch, setProcessedSearch] = useState('');
-useEffect(() => {
-  const timer = setTimeout(() => setProcessedSearch(searchValue), 300);
-  return () => clearTimeout(timer);
-}, [searchValue]);
-
-const filteredFruits = useMemo(() => {
-  if (!processedSearch.trim()) return allFruits;
-  return allFruits.filter((fruit) =>
-    fruit.label.toLowerCase().includes(processedSearch.toLowerCase())
-  );
-}, [processedSearch]);
+const handleSearchChange = useCallback((value) => {
+  setSearchValue(value);
+  setIsLoadingItems(true);
+  debouncedFetch(value)
+    .then(setItems)
+    .finally(() => setIsLoadingItems(false));
+}, []);
 
 <FilterPicker
-  label="Select Fruits"
-  placeholder="Choose fruits..."
-  selectionMode="multiple"
+  items={items}
   searchValue={searchValue}
+  onSearchChange={handleSearchChange}
   filter={false}
-  items={filteredFruits}
-  onSearchChange={setSearchValue}
+  sortSelectedToTop={false}
+  isLoadingItems={isLoadingItems}
+  placeholder="Search items..."
+  selectionMode="multiple"
+  onOpenChange={(isOpen) => {
+    if (!isOpen) {
+      setSearchValue('');
+      setItems(initialItems);
+    }
+  }}
 >
-  {(fruit) => (
-    <FilterPicker.Item key={fruit.key}>{fruit.label}</FilterPicker.Item>
+  {(item) => (
+    <FilterPicker.Item key={item.id} textValue={item.name}>
+      {item.name}
+    </FilterPicker.Item>
   )}
 </FilterPicker>
 ```
 
-**When to use each approach:**
-- **`filter={false}`**: Simpler approach when you just need to pre-filter items without controlling the search input itself. Good for server-side filtering or custom filter logic.
-- **Controlled Search**: Use when you need full control over the search input (debouncing, external UI sync, clearing from outside, or tracking search analytics).
-- **Combine Both**: You can use both together for maximum control - controlled search input with external filtering.
+**How it works:**
+- **`filter={false}`** disables client-side filtering so items are shown exactly as the server returns them
+- **`searchValue` + `onSearchChange`** give you control over the search input; debounce and fetch on your side
+- **`items`** is a reactive prop — replace it with server results and the list updates automatically
+- **`isLoadingItems`** shows a loading spinner in the search input suffix while fetching
+- **`sortSelectedToTop={false}`** is recommended when the server controls item order
+- **`emptyLabel`** can be used to customize the empty state message (e.g. `"Loading items..."` during initial load)
+- **Reset on close** — use `onOpenChange` to restore the initial item set and clear the search when the popover closes, ensuring the trigger label resolves correctly
+
+**Tips:**
+- Debouncing is the consumer's responsibility (300-500ms is typical)
+- During the debounce delay, old items remain visible — if you want instant client-side feedback while waiting, use a filter function instead of `false`
 
 ## Performance
 

--- a/src/components/fields/FilterPicker/FilterPicker.docs.mdx
+++ b/src/components/fields/FilterPicker/FilterPicker.docs.mdx
@@ -808,7 +808,8 @@ const handleSearchChange = useCallback((value) => {
 - **`filter={false}`** disables client-side filtering so items are shown exactly as the server returns them
 - **`searchValue` + `onSearchChange`** give you control over the search input; debounce and fetch on your side
 - **`items`** is a reactive prop — replace it with server results and the list updates automatically
-- **`isLoadingItems`** shows a loading spinner in the search input suffix while fetching
+- **`isLoadingItems`** shows a loading spinner in the search input suffix while fetching. While loading, stale items that do not text-match the current search are hidden client-side so the user only sees relevant suggestions
+- **Selected custom values** (with `allowsCustomValue` in multi-select) are filtered against the search input too, so they don't appear when they don't match
 - **`sortSelectedToTop={false}`** is recommended when the server controls item order
 - **`emptyLabel`** can be used to customize the empty state message (e.g. `"Loading items..."` during initial load)
 - **Reset on close** — use `onOpenChange` to restore the initial item set and clear the search when the popover closes, ensuring the trigger label resolves correctly

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { userEvent, within } from 'storybook/test';
 
 import {
@@ -2351,256 +2351,119 @@ export const MultipleControlled: Story = {
   },
 };
 
-export const ExternalFiltering: Story = {
+const ALL_ITEMS = Array.from({ length: 500 }, (_, i) => ({
+  id: `item-${i + 1}`,
+  name: `Item ${i + 1} — ${['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta', 'Iota', 'Kappa'][i % 10]} ${['Service', 'Module', 'Component', 'Widget', 'Plugin'][Math.floor(i / 10) % 5]}`,
+}));
+
+const INITIAL_ITEMS = ALL_ITEMS.slice(0, 100);
+
+function simulateServerSearch(
+  query: string,
+  signal?: AbortSignal,
+): Promise<typeof ALL_ITEMS> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
+      if (!query.trim()) {
+        resolve(INITIAL_ITEMS);
+        return;
+      }
+
+      const lowerQuery = query.toLowerCase();
+      resolve(
+        ALL_ITEMS.filter((item) =>
+          item.name.toLowerCase().includes(lowerQuery),
+        ),
+      );
+    }, 1000);
+
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    });
+  });
+}
+
+export const AsyncSearch: Story = {
   render: () => {
-    const allFruits = [
-      {
-        key: 'apple',
-        label: 'Apple',
-        description: 'Crisp and sweet red fruit',
+    const [items, setItems] = useState(INITIAL_ITEMS);
+    const [searchValue, setSearchValue] = useState('');
+    const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+    const [isLoadingItems, setIsLoadingItems] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
+    const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+    const fetchItems = useCallback((query: string) => {
+      abortRef.current?.abort();
+      clearTimeout(debounceRef.current);
+
+      setIsLoadingItems(true);
+
+      debounceRef.current = setTimeout(() => {
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        simulateServerSearch(query, controller.signal)
+          .then((result) => {
+            setItems(result);
+            setIsLoadingItems(false);
+          })
+          .catch(() => {});
+      }, 300);
+    }, []);
+
+    const handleSearchChange = useCallback(
+      (value: string) => {
+        setSearchValue(value);
+        fetchItems(value);
       },
-      {
-        key: 'banana',
-        label: 'Banana',
-        description: 'Yellow tropical fruit rich in potassium',
-      },
-      {
-        key: 'cherry',
-        label: 'Cherry',
-        description: 'Small red stone fruit with sweet flavor',
-      },
-      {
-        key: 'date',
-        label: 'Date',
-        description: 'Sweet dried fruit from date palm',
-      },
-      {
-        key: 'elderberry',
-        label: 'Elderberry',
-        description: 'Dark purple berry with tart flavor',
-      },
-      { key: 'fig', label: 'Fig', description: 'Sweet fruit with soft flesh' },
-      {
-        key: 'grape',
-        label: 'Grape',
-        description: 'Small sweet fruit that grows in clusters',
-      },
-      {
-        key: 'honeydew',
-        label: 'Honeydew',
-        description: 'Sweet melon with pale green flesh',
-      },
-      {
-        key: 'kiwi',
-        label: 'Kiwi',
-        description: 'Small oval fruit with fuzzy brown skin',
-      },
-      {
-        key: 'lemon',
-        label: 'Lemon',
-        description: 'Yellow citrus fruit with sour taste',
-      },
-      {
-        key: 'mango',
-        label: 'Mango',
-        description: 'Tropical stone fruit with sweet orange flesh',
-      },
-      {
-        key: 'orange',
-        label: 'Orange',
-        description: 'Round citrus fruit with orange peel',
-      },
-    ];
+      [fetchItems],
+    );
 
-    // Example 1: Using filter={false} with externally filtered items
-    const Example1 = () => {
-      const [externalSearch, setExternalSearch] = useState('');
-      const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
-
-      const filteredFruits = useMemo(() => {
-        if (!externalSearch.trim()) return allFruits;
-        return allFruits.filter((fruit) =>
-          fruit.label.toLowerCase().includes(externalSearch.toLowerCase()),
-        );
-      }, [externalSearch]);
-
-      return (
-        <Space gap="2x" flow="column" width="100%">
-          <Title preset="h5">
-            Approach 1: Disabled Internal Filtering (filter={'{false}'})
-          </Title>
-          <Paragraph>
-            Use this approach when you want to filter items outside the
-            component (e.g., server-side filtering, custom search logic) while
-            keeping the FilterPicker's search input for visual consistency.
-          </Paragraph>
-
-          <Flow gap="1x">
-            <Text preset="t4" weight="600" color="#dark.80">
-              External Search Input:
-            </Text>
-            <input
-              type="text"
-              value={externalSearch}
-              placeholder="Filter fruits externally..."
-              style={{
-                padding: '8px 12px',
-                border: '1px solid #d0d0d0',
-                borderRadius: '6px',
-                fontSize: '14px',
-                width: '100%',
-              }}
-              onChange={(e) => setExternalSearch(e.target.value)}
-            />
-          </Flow>
-
-          <FilterPicker
-            label="Select Fruits"
-            placeholder="Choose fruits..."
-            selectionMode="multiple"
-            selectedKeys={selectedKeys}
-            filter={false}
-            items={filteredFruits}
-            searchPlaceholder="Type to search (disabled internally)..."
-            width="100%"
-            onSelectionChange={(keys) => setSelectedKeys(keys as string[])}
-          >
-            {(fruit: (typeof filteredFruits)[number]) => (
-              <FilterPicker.Item
-                key={fruit.key}
-                textValue={fruit.label}
-                description={fruit.description}
-              >
-                {fruit.label}
-              </FilterPicker.Item>
-            )}
-          </FilterPicker>
-
-          <Text preset="t4" color="#dark.60">
-            Showing {filteredFruits.length} of {allFruits.length} fruits •
-            Selected: {selectedKeys.length}
-          </Text>
-        </Space>
-      );
-    };
-
-    // Example 2: Using controlled searchValue and onSearchChange
-    const Example2 = () => {
-      const [searchValue, setSearchValue] = useState('');
-      const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
-
-      // Simulate external processing (e.g., debouncing, API calls)
-      const [processedSearch, setProcessedSearch] = useState('');
-
-      // Simulate debounced search with a simple effect
-      useEffect(() => {
-        const timer = setTimeout(() => {
-          setProcessedSearch(searchValue);
-        }, 300);
-        return () => clearTimeout(timer);
-      }, [searchValue]);
-
-      const filteredFruits = useMemo(() => {
-        if (!processedSearch.trim()) return allFruits;
-        return allFruits.filter((fruit) =>
-          fruit.label.toLowerCase().includes(processedSearch.toLowerCase()),
-        );
-      }, [processedSearch]);
-
-      return (
-        <Space gap="2x" flow="column" width="100%">
-          <Title preset="h5">
-            Approach 2: Controlled Search Input (searchValue + onSearchChange)
-          </Title>
-          <Paragraph>
-            Use this approach when you need full control over the search input
-            value, such as for debouncing, synchronizing with external state, or
-            implementing server-side search.
-          </Paragraph>
-
-          <Flow gap="1x">
-            <Text preset="t4" weight="600" color="#dark.80">
-              Current search value:{' '}
-              <Badge theme="primary">{searchValue || '(empty)'}</Badge>
-            </Text>
-            {searchValue !== processedSearch && (
-              <Text preset="t4" color="#dark.60">
-                Processing search... (debounced)
-              </Text>
-            )}
-          </Flow>
-
-          <FilterPicker
-            label="Select Fruits (Controlled Search)"
-            placeholder="Choose fruits..."
-            selectionMode="multiple"
-            selectedKeys={selectedKeys}
-            searchValue={searchValue}
-            filter={false}
-            items={filteredFruits}
-            searchPlaceholder="Type to search (controlled)..."
-            width="100%"
-            onSelectionChange={(keys) => setSelectedKeys(keys as string[])}
-            onSearchChange={setSearchValue}
-          >
-            {(fruit: (typeof filteredFruits)[number]) => (
-              <FilterPicker.Item
-                key={fruit.key}
-                textValue={fruit.label}
-                description={fruit.description}
-              >
-                {fruit.label}
-              </FilterPicker.Item>
-            )}
-          </FilterPicker>
-
-          <Text preset="t4" color="#dark.60">
-            Showing {filteredFruits.length} of {allFruits.length} fruits •
-            Selected: {selectedKeys.length}
-          </Text>
-        </Space>
-      );
-    };
+    const handleOpenChange = useCallback((isOpen: boolean) => {
+      if (!isOpen) {
+        setSearchValue('');
+        setItems(INITIAL_ITEMS);
+        setIsLoadingItems(false);
+        abortRef.current?.abort();
+        clearTimeout(debounceRef.current);
+      }
+    }, []);
 
     return (
-      <Space gap="4x" flow="column" width="max 80x">
-        <Flow gap="2x">
-          <Title preset="h4">External Filtering Patterns</Title>
-          <Paragraph>
-            FilterPicker provides two approaches for implementing external
-            filtering when you need to control the filtering logic outside the
-            component.
-          </Paragraph>
-        </Flow>
-
-        <Example1 />
-        <Example2 />
-
-        <Space
-          gap="2x"
-          padding="2x"
-          fill="#purple.04"
-          radius="1r"
-          border="#purple.30"
+      <Space gap="2x" flow="column" placeItems="start" width="40x">
+        <FilterPicker
+          label="Server-Side Search"
+          placeholder="Select items..."
+          selectionMode="multiple"
+          searchPlaceholder="Search 500 items (1s server delay)..."
+          width="100%"
+          items={items}
+          selectedKeys={selectedKeys}
+          searchValue={searchValue}
+          filter={false}
+          sortSelectedToTop={false}
+          isLoadingItems={isLoadingItems}
+          onSearchChange={handleSearchChange}
+          onSelectionChange={(keys) => setSelectedKeys(keys as string[])}
+          onOpenChange={handleOpenChange}
         >
-          <Title preset="h6">When to Use Each Approach</Title>
-          <Flow as="ul" gap="1x" padding="0 0 0 2x">
-            <Text as="li">
-              <strong>filter={'{false}'}:</strong> Simpler approach when you
-              just need to pre-filter items without controlling the search input
-              itself. Good for server-side filtering or custom filter logic.
-            </Text>
-            <Text as="li">
-              <strong>Controlled Search:</strong> Use when you need full control
-              over the search input (debouncing, external UI sync, clearing from
-              outside, or tracking search analytics).
-            </Text>
-            <Text as="li">
-              <strong>Combine Both:</strong> You can use both together for
-              maximum control - controlled search input with external filtering.
-            </Text>
-          </Flow>
-        </Space>
+          {(item: (typeof items)[number]) => (
+            <FilterPicker.Item key={item.id} textValue={item.name}>
+              {item.name}
+            </FilterPicker.Item>
+          )}
+        </FilterPicker>
+
+        <Text preset="t4" color="#dark.60">
+          Showing {items.length} of {ALL_ITEMS.length} items
+          {selectedKeys.length > 0 && ` • Selected: ${selectedKeys.length}`}
+        </Text>
       </Space>
     );
   },
@@ -2608,7 +2471,7 @@ export const ExternalFiltering: Story = {
     docs: {
       description: {
         story:
-          'Demonstrates two approaches for external filtering: (1) using `filter={false}` to disable internal filtering while providing pre-filtered items, and (2) using controlled search input with `searchValue` and `onSearchChange` props for complete control over the search behavior.',
+          'Demonstrates server-side search with a simulated 1-second backend delay. Uses `filter={false}` to disable client-side filtering, controlled `searchValue`/`onSearchChange` for the search input, and dynamically replaces `items` when the server responds. A loading spinner appears in the search input suffix via `isLoadingItems` while the fetch is in flight. Search input is debounced at 300ms with in-flight request cancellation.',
       },
     },
   },

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -2439,7 +2439,7 @@ export const AsyncSearch: Story = {
       <Space gap="2x" flow="column" placeItems="start" width="40x">
         <FilterPicker
           allowsCustomValue
-          label="Server-Side Search!"
+          label="Server-Side Search"
           placeholder="Select items..."
           selectionMode="multiple"
           searchPlaceholder="Search 500 items (1s server delay)..."

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -2438,7 +2438,8 @@ export const AsyncSearch: Story = {
     return (
       <Space gap="2x" flow="column" placeItems="start" width="40x">
         <FilterPicker
-          label="Server-Side Search"
+          allowsCustomValue
+          label="Server-Side Search!"
           placeholder="Select items..."
           selectionMode="multiple"
           searchPlaceholder="Search 500 items (1s server delay)..."

--- a/src/components/fields/FilterPicker/FilterPicker.test.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.test.tsx
@@ -765,4 +765,38 @@ describe('<FilterPicker />', () => {
       expect(trigger).toHaveTextContent('Selected: Red Apple, Sweet Cherry');
     });
   });
+
+  describe('isLoadingItems', () => {
+    it('should show suffix spinner in popover search input when isLoadingItems is true', async () => {
+      const { getByRole, baseElement } = renderWithRoot(
+        <FilterPicker
+          isLoadingItems
+          label="Test"
+          placeholder="Pick..."
+          selectionMode="multiple"
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      // Open the popover
+      const trigger = getByRole('button');
+      await user.click(trigger);
+
+      // The popover renders in a portal, so search in baseElement
+      await waitFor(() => {
+        const searchWrapper = baseElement.querySelector(
+          '[data-qa="FilterListBoxSearchWrapper"]',
+        );
+        expect(searchWrapper).toBeInTheDocument();
+        expect(searchWrapper).toHaveAttribute('data-suffix');
+
+        const suffix = searchWrapper?.querySelector('[data-element="Suffix"]');
+        expect(suffix).toBeInTheDocument();
+
+        const icon = suffix?.querySelector('[data-qa="LoadingIcon"]');
+        expect(icon).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -127,11 +127,9 @@ export interface CubeFilterPickerProps<T>
   /** Callback called when the clear button is pressed */
   onClear?: () => void;
   /**
-   * Whether the items are currently loading. Unlike `isLoading`, this does NOT
-   * disable the trigger, so the popover can still be opened while items are being
-   * fetched. Shows a `LoadingIcon` in the trigger and a loading disclaimer inside
-   * the popover. When `allowsCustomValue` is `false`, the search input is hidden
-   * and only the disclaimer is shown.
+   * Whether items are currently loading. Shows a loading spinner in the search
+   * input suffix inside the popover. Unlike `isLoading`, this does NOT disable
+   * the trigger.
    */
   isLoadingItems?: boolean;
   /**
@@ -265,7 +263,6 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
     onOptionClick,
     isClearable,
     isLoadingItems,
-    loadingItemsLabel,
     searchValue,
     onSearchChange,
     sortSelectedToTop: sortSelectedToTopProp,
@@ -660,7 +657,7 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
       }}
       icon={icon}
       rightIcon={
-        isLoading || isLoadingItems ? (
+        isLoading ? (
           <LoadingIcon />
         ) : rightIcon !== undefined ? (
           rightIcon
@@ -842,7 +839,6 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
                 isDisabled={isDisabled}
                 isLoading={isLoading}
                 isLoadingItems={isLoadingItems}
-                loadingItemsLabel={loadingItemsLabel}
                 stateRef={listStateRef}
                 isCheckable={isCheckable}
                 mods={{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `FilterListBox` filtering and virtual-focus behavior (especially with `allowsCustomValue` + `filter={false}`), which can affect keyboard navigation and item visibility across multiple consumer flows.
> 
> **Overview**
> **Simplifies `isLoadingItems` UX for `FilterPicker`/`FilterListBox`:** removes the in-popover loading disclaimer and `loadingItemsLabel`, and instead shows a subtle spinner in the search input suffix; `FilterPicker` no longer shows a trigger loading icon for `isLoadingItems`.
> 
> **Refines server-side search behavior (`filter={false}`):** while `isLoadingItems` is true, non-matching stale items are temporarily hidden using `contains`, and locally-injected selected custom values now always respect the search term even when parent filtering is disabled.
> 
> **Improves custom-value virtual focus:** updates focus targeting so when no matches exist (including during in-flight fetches) focus moves/stays on the new custom-value option, and when matches arrive it prefers the first real item. Also unifies `emptyLabel` so a provided value overrides both the “No items” and “No results found” defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843930369211c3525fd7f7a875edc140e85170d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->