### PR TITLE
feat(Tree): add component

### DIFF
--- a/.changeset/tasty-2-1-1.md
+++ b/.changeset/tasty-2-1-1.md
@@ -1,0 +1,9 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Update `@tenphi/tasty` to `2.1.1`.
+
+- Fix `$: '> SubElementName'` selector affix when the trailing element name matches the sub-element key (avoids duplicate key injection; placeholder behavior is correct).
+
+Migrated: `TreeNode` uses `@ts-expect-error` for `Checkbox` `onChange` (react-types / `AriaCheckboxProps`).

--- a/.changeset/tree-component.md
+++ b/.changeset/tree-component.md
@@ -1,0 +1,12 @@
+---
+"@cube-dev/ui-kit": minor
+---
+
+Add `Tree` component — a hierarchical tree view built on React Aria/Stately with an Ant Design–compatible API for easy migration.
+
+- `treeData` accepts nested `{ key, title, children, isLeaf, isCheckable, isCheckboxDisabled }` nodes
+- Optional checkbox column via `isCheckable` with cascading parent/child state and `halfChecked` keys in `onCheck` payload
+- Controlled / uncontrolled `checkedKeys`, `expandedKeys`, and `selectedKeys` (single or multiple `selectionMode`)
+- Async `loadData` with per-row loading indicator; auto-expands lazy nodes after load
+- Per-node and per-tree `isDisabled`, `blockNode`, `autoExpandParent`, custom `title` ReactNode
+- `rowStyles` prop forwarded to each row's underlying `Item` for visual customization

--- a/.changeset/tree-component.md
+++ b/.changeset/tree-component.md
@@ -8,5 +8,5 @@ Add `Tree` component — a hierarchical tree view built on React Aria/Stately wi
 - Optional checkbox column via `isCheckable` with cascading parent/child state and `halfChecked` keys in `onCheck` payload
 - Controlled / uncontrolled `checkedKeys`, `expandedKeys`, and `selectedKeys` (single or multiple `selectionMode`)
 - Async `loadData` with per-row loading indicator; auto-expands lazy nodes after load
-- Per-node and per-tree `isDisabled`, `blockNode`, `autoExpandParent`, custom `title` ReactNode
+- Per-node and per-tree `isDisabled`, `autoExpandParent`, custom `title` ReactNode
 - `rowStyles` prop forwarded to each row's underlying `Item` for visual customization

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -20,7 +20,7 @@ module.exports = [
         }),
       );
     },
-    limit: '380kB',
+    limit: '390kB',
   },
   {
     name: 'Tree shaking (just a Button)',

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/tasty": "2.1.0",
+    "@tenphi/tasty": "2.1.1",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/tasty':
-        specifier: 2.1.0
-        version: 2.1.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.1.1
+        version: 2.1.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2873,8 +2873,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/tasty@2.1.0':
-    resolution: {integrity: sha512-tMdbnbYGyfQvXnJian2cFhjb6IZDBn6UqIRqXQrng/QXF2t/tmH3DSpzJmYhsK05on/hz2lz9WJIBEpj1ixg2A==}
+  '@tenphi/tasty@2.1.1':
+    resolution: {integrity: sha512-V50f66I7JwR4ygv3Xy65lxTyUykIO8ZlKtktW0CWnTwUZvzTBBp/RntgsUGQ8VvjT5yo2gwYITo6p3gTlKsW+w==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10431,7 +10431,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/tasty@2.1.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.1.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/src/components/content/Tree/Tree.docs.mdx
+++ b/src/components/content/Tree/Tree.docs.mdx
@@ -1,0 +1,330 @@
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
+import { Tree } from './Tree';
+import * as TreeStories from './Tree.stories';
+
+<Meta of={TreeStories} />
+
+# Tree
+
+Tree displays hierarchical data as a list of nodes you can expand, collapse,
+select, and (optionally) check. Built on `useTree` and `useTreeState`
+(React Aria + React Stately) and styled with Tasty.
+
+The component's data shape (`treeData`) and the public callback shape are
+designed to be a near drop-in for AntD's `Tree` (modulo the `is*` boolean
+prop convention used across `@cube-dev/ui-kit`), so existing AntD `Tree`
+consumers can be migrated with minimal churn.
+
+## When to Use
+
+- Rendering hierarchical structures such as file systems, organizational
+  charts, navigation, or schema browsers.
+- Letting users select one or many nodes from a tree, with cascading
+  parent/child checkbox semantics.
+- Lazily loading children when a node is expanded the first time
+  (`loadData`).
+- Filtering with auto-expanded ancestors (`autoExpandParent`).
+
+## Component
+
+<Story of={TreeStories.Default} />
+
+---
+
+### Properties
+
+- **`treeData`** `CubeTreeNodeData[]` — Hierarchical data describing the
+  tree.
+- **`isCheckable`** `boolean` (default: `false`) — Render a checkbox in
+  front of every eligible row.
+- **`isSelectable`** `boolean` — Sugar for `selectionMode="none"` when
+  `false`. `selectionMode` wins when both are passed.
+- **`selectionMode`** `'none' | 'single' | 'multiple'` (default: `'single'`)
+  — Selection cardinality.
+- **`blockNode`** `boolean` (default: `false`) — Stretch each row to fill
+  the container width.
+- **`isDisabled`** `boolean` (default: `false`) — Disable the entire tree.
+- **`defaultExpandedKeys`** `string[]` — Default expanded keys
+  (uncontrolled).
+- **`expandedKeys`** `string[]` — Controlled expanded keys.
+- **`autoExpandParent`** `boolean` (default: `false`) — Auto-expand parents
+  of currently expanded keys. Useful for filtering.
+- **`defaultCheckedKeys`** `string[]` — Default checked keys (uncontrolled).
+- **`checkedKeys`** `string[] | { checked: string[]; halfChecked?: string[] }`
+  — Controlled checked keys. Pass the object form to receive the same
+  shape back from `onCheck`.
+- **`defaultSelectedKeys`** `string[]` — Default selected keys
+  (uncontrolled).
+- **`selectedKeys`** `string[]` — Controlled selected keys.
+- **`height`** `number` — Fixed height in pixels. When omitted, the tree
+  fills the available vertical space and scrolls internally.
+- **`loadData`** `(node: TreeLoadDataNode) => Promise<void>` — Async
+  loader called the first time a non-leaf node with no `children` is
+  expanded. The consumer is expected to merge new children into
+  `treeData` (typical AntD pattern).
+- **`onExpand`** `(expandedKeys: Key[], info: TreeOnExpandInfo) => void` —
+  Called when a node is expanded or collapsed.
+- **`onCheck`** `(checked: Key[] | { checked, halfChecked }, info: TreeOnCheckInfo) => void`
+  — Called when a node is checked or unchecked.
+- **`onSelect`** `(selectedKeys: Key[], info: TreeOnSelectInfo) => void` —
+  Called when row selection changes.
+- **`rowStyles`** `Styles` — Override styles for `[data-element="Row"]`.
+
+#### `CubeTreeNodeData`
+
+- **`key`** `string` — Unique identifier of the node.
+- **`title`** `ReactNode` — Visible label.
+- **`children`** `CubeTreeNodeData[]` — Children. Pass `undefined`
+  together with `isLeaf={false}` for lazy nodes.
+- **`isLeaf`** `boolean` — Force leaf rendering (no expand toggle, no
+  `loadData` call).
+- **`isDisabled`** `boolean` — Disable interactions on this row (focus /
+  select / expand / check).
+- **`isCheckboxDisabled`** `boolean` — Disable only the checkbox of this
+  row.
+- **`isCheckable`** `boolean` — Per-node override; `false` hides the
+  checkbox for this row even when the tree is `isCheckable`.
+
+### Base Properties
+
+Supports [Base properties](/docs/getting-started-base-properties--docs)
+
+### Styling Properties
+
+#### styles
+
+Customizes the root `treegrid` element of the Tree.
+
+**Sub-elements:**
+
+- `Row` — A single tree row (also targetable via the dedicated
+  `rowStyles` prop).
+
+#### rowStyles
+
+Customizes `[data-element="Row"]`. Useful when you need to override row
+spacing, hover/selected colors, or cell layout without re-targeting via
+`styles`.
+
+**Sub-elements:**
+
+- `Toggle` — The expand/collapse button.
+- `Checkbox` — The checkbox slot (visible only when `isCheckable`).
+- `Title` — The title label.
+
+### Modifiers
+
+The following row-level modifiers are emitted automatically. They are
+useful when overriding `rowStyles`:
+
+| Modifier        | Type      | Description                                            |
+| --------------- | --------- | ------------------------------------------------------ |
+| `selected`      | `boolean` | Row is selected.                                       |
+| `checked`       | `boolean` | Row is fully checked.                                  |
+| `indeterminate` | `boolean` | Row is in the half-checked state.                      |
+| `expanded`      | `boolean` | Row is expanded.                                       |
+| `disabled`      | `boolean` | Row is disabled.                                       |
+| `loading`       | `boolean` | The row's children are being fetched via `loadData`.   |
+| `leaf`          | `boolean` | Row has no children.                                   |
+| `block-node`    | `boolean` | Tree is in `blockNode` mode.                           |
+| `has-checkbox`  | `boolean` | Row renders a checkbox.                                |
+
+## Variants
+
+### Selection Modes
+
+- `none` — Row click does not select. Useful in pure-display or pure-
+  checkable trees.
+- `single` (default) — One row selected at a time.
+- `multiple` — Multi-select with keyboard modifiers and shift-range.
+
+## Examples
+
+### Basic Usage
+
+```jsx
+const data = [
+  { key: 'fruits', title: 'Fruits', children: [
+    { key: 'apple', title: 'Apple' },
+    { key: 'banana', title: 'Banana' },
+  ]},
+  { key: 'vegetables', title: 'Vegetables', children: [
+    { key: 'carrot', title: 'Carrot' },
+  ]},
+];
+
+<Tree treeData={data} defaultExpandedKeys={['fruits']} />;
+```
+
+### Checkable
+
+`isCheckable` enables AntD-style cascading parent ↔ child checkbox
+behavior: checking a parent checks all eligible descendants, and a
+parent flips into the indeterminate (half-checked) state when only some
+of its descendants are checked.
+
+```jsx
+<Tree
+  treeData={data}
+  isCheckable
+  selectionMode="none"
+  defaultCheckedKeys={['apple']}
+  onCheck={(keys, info) => {
+    console.log('checked', keys);
+    console.log('half-checked', info.halfCheckedKeys);
+  }}
+/>
+```
+
+<Story of={TreeStories.Checkable} />
+
+### Controlled Checked
+
+To match AntD's object-shape API, pass `checkedKeys` as
+`{ checked, halfChecked }`. `onCheck` returns the same shape.
+
+```jsx
+const [checkedKeys, setCheckedKeys] = useState({ checked: [], halfChecked: [] });
+
+<Tree
+  treeData={data}
+  isCheckable
+  checkedKeys={checkedKeys}
+  onCheck={(next) => setCheckedKeys(next)}
+/>
+```
+
+<Story of={TreeStories.ControlledChecked} />
+
+### Lazy Loading
+
+Set `isLeaf: false` and omit `children` on a node, then provide a
+`loadData` callback. The callback should merge new children into
+`treeData`. The row shows a spinner while in flight; subsequent expands
+of the same key won't refire `loadData`.
+
+```jsx
+const handleLoadData = (node) =>
+  fetch(`/api/children?key=${node.key}`)
+    .then((r) => r.json())
+    .then((children) => mergeIntoTreeData(node.key, children));
+
+<Tree treeData={data} loadData={handleLoadData} />
+```
+
+<Story of={TreeStories.LazyLoading} />
+
+### Auto-expand Parent (Filtering)
+
+Pass the matching keys via `expandedKeys` and set `autoExpandParent` to
+keep their ancestors expanded.
+
+```jsx
+<Tree
+  treeData={data}
+  expandedKeys={matchedKeys}
+  autoExpandParent
+/>
+```
+
+<Story of={TreeStories.AutoExpandParent} />
+
+### Block Node
+
+```jsx
+<Tree treeData={data} blockNode isCheckable />
+```
+
+<Story of={TreeStories.BlockNode} />
+
+### Per-node Disabling
+
+Disable the entire row, just the checkbox, or hide the checkbox via
+node-level flags.
+
+```jsx
+const data = [
+  { key: 'a', title: 'A', children: [
+    { key: 'a-1', title: 'A-1', isDisabled: true },
+    { key: 'a-2', title: 'A-2', isCheckboxDisabled: true },
+    { key: 'a-3', title: 'A-3', isCheckable: false },
+  ]},
+];
+
+<Tree treeData={data} isCheckable defaultExpandedKeys={['a']} />
+```
+
+<Story of={TreeStories.PerNodeDisable} />
+
+### Fixed Height
+
+```jsx
+<Tree treeData={data} height={300} />
+```
+
+<Story of={TreeStories.FixedHeight} />
+
+## Accessibility
+
+Tree implements the
+[`treegrid` ARIA pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treegrid/)
+via `useTree` from React Aria.
+
+### Keyboard Navigation
+
+- `Tab` — Moves focus into / out of the tree (focus stays on the
+  currently active row inside).
+- `ArrowUp` / `ArrowDown` — Move focus to the previous / next visible row.
+- `ArrowRight` — Expand the focused row (or move to its first child if
+  already expanded).
+- `ArrowLeft` — Collapse the focused row (or move to its parent if
+  already collapsed).
+- `Home` / `End` — Move focus to the first / last visible row.
+- `Space` / `Enter` — Toggle selection on the focused row (in `single`
+  or `multiple` mode).
+
+### Screen Reader Support
+
+- Each row reports `aria-level`, `aria-posinset`, `aria-setsize`, and
+  `aria-expanded` so screen readers can announce the position and
+  expansion state.
+- When `isCheckable` is enabled, the row carries `aria-checked` (`true`,
+  `false`, or `mixed` for the indeterminate state).
+- Disabled rows expose `aria-disabled="true"`.
+
+### ARIA Properties
+
+- `aria-label` — Provide a label that describes the tree's contents
+  (defaults to `"Tree"`).
+
+## Best Practices
+
+1. **Do**: Provide stable, unique `key`s — they are used for selection,
+   expansion, checking, and lazy-load tracking.
+   ```jsx
+   <Tree treeData={data.map((node) => ({ ...node, key: node.id }))} />
+   ```
+2. **Don't**: Mutate `treeData` in place. Always return a new array
+   from `loadData`'s commit step so React Stately can rebuild the
+   collection.
+3. **Accessibility**: When using checkboxes for selection, set
+   `selectionMode="none"` so the row click doesn't compete with the
+   checkbox.
+4. **Performance**: For very large trees, prefer virtualization (planned;
+   see Suggested Improvements) or use `loadData` to defer subtree
+   construction.
+
+## Suggested Improvements
+
+- Built-in virtualization for very large trees (10k+ rows).
+- Drag-and-drop reordering, mirroring AntD's `draggable` API.
+- An `onRightClick`/context menu hook.
+- Reveal-on-mount: scroll the focused row into view when expanded
+  programmatically.
+- Optional inline title editing.
+
+## Related Components
+
+- [ListBox](/components/ListBox) — Flat list with single/multi selection.
+- [Menu](/components/Menu) — Hierarchical action lists in popovers.
+- [Tabs](/components/Tabs) — Switch between sibling content panels.

--- a/src/components/content/Tree/Tree.docs.mdx
+++ b/src/components/content/Tree/Tree.docs.mdx
@@ -41,8 +41,6 @@ consumers can be migrated with minimal churn.
   `false`. `selectionMode` wins when both are passed.
 - **`selectionMode`** `'none' | 'single' | 'multiple'` (default: `'single'`)
   — Selection cardinality.
-- **`blockNode`** `boolean` (default: `false`) — Stretch each row to fill
-  the container width.
 - **`isDisabled`** `boolean` (default: `false`) — Disable the entire tree.
 - **`defaultExpandedKeys`** `string[]` — Default expanded keys
   (uncontrolled).
@@ -126,7 +124,6 @@ useful when overriding `rowStyles`:
 | `disabled`      | `boolean` | Row is disabled.                                       |
 | `loading`       | `boolean` | The row's children are being fetched via `loadData`.   |
 | `leaf`          | `boolean` | Row has no children.                                   |
-| `block-node`    | `boolean` | Tree is in `blockNode` mode.                           |
 | `has-checkbox`  | `boolean` | Row renders a checkbox.                                |
 
 ## Variants
@@ -228,14 +225,6 @@ keep their ancestors expanded.
 ```
 
 <Story of={TreeStories.AutoExpandParent} />
-
-### Block Node
-
-```jsx
-<Tree treeData={data} blockNode isCheckable />
-```
-
-<Story of={TreeStories.BlockNode} />
 
 ### Per-node Disabling
 

--- a/src/components/content/Tree/Tree.stories.tsx
+++ b/src/components/content/Tree/Tree.stories.tsx
@@ -1,0 +1,415 @@
+import { useMemo, useState } from 'react';
+
+import { Flow } from '../../layout/Flow';
+import { Space } from '../../layout/Space';
+import { Text } from '../Text';
+
+import { Tree } from './Tree';
+
+import type { Key } from '@react-types/shared';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type {
+  CubeTreeNodeData,
+  CubeTreeProps,
+  TreeLoadDataNode,
+} from './types';
+
+const FILE_SYSTEM: CubeTreeNodeData[] = [
+  {
+    key: 'src',
+    title: 'src',
+    children: [
+      {
+        key: 'src/components',
+        title: 'components',
+        children: [
+          { key: 'src/components/Button.tsx', title: 'Button.tsx' },
+          { key: 'src/components/Card.tsx', title: 'Card.tsx' },
+          { key: 'src/components/Tree.tsx', title: 'Tree.tsx' },
+        ],
+      },
+      {
+        key: 'src/hooks',
+        title: 'hooks',
+        children: [
+          { key: 'src/hooks/useTree.ts', title: 'useTree.ts' },
+          { key: 'src/hooks/useEvent.ts', title: 'useEvent.ts' },
+        ],
+      },
+      { key: 'src/index.ts', title: 'index.ts' },
+    ],
+  },
+  {
+    key: 'public',
+    title: 'public',
+    children: [
+      { key: 'public/index.html', title: 'index.html' },
+      { key: 'public/favicon.ico', title: 'favicon.ico' },
+    ],
+  },
+  { key: 'package.json', title: 'package.json' },
+  { key: 'README.md', title: 'README.md' },
+];
+
+const meta = {
+  title: 'Content/Tree',
+  component: Tree,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    treeData: FILE_SYSTEM,
+    defaultExpandedKeys: ['src'],
+  },
+  argTypes: {
+    /* Content */
+    treeData: {
+      control: { type: null },
+      description: 'Hierarchical tree data array',
+      table: {
+        type: { summary: 'CubeTreeNodeData[]' },
+      },
+    },
+
+    /* Selection */
+    selectionMode: {
+      control: 'radio',
+      options: ['none', 'single', 'multiple'],
+      description: 'Selection cardinality',
+      table: {
+        defaultValue: { summary: 'single' },
+        type: { summary: "'none' | 'single' | 'multiple'" },
+      },
+    },
+    selectedKeys: {
+      control: { type: null },
+      description: 'Controlled selected keys',
+      table: { type: { summary: 'string[]' } },
+    },
+    defaultSelectedKeys: {
+      control: { type: null },
+      description: 'Default selected keys (uncontrolled)',
+      table: { type: { summary: 'string[]' } },
+    },
+
+    /* Expansion */
+    expandedKeys: {
+      control: { type: null },
+      description: 'Controlled expanded keys',
+      table: { type: { summary: 'string[]' } },
+    },
+    defaultExpandedKeys: {
+      control: { type: null },
+      description: 'Default expanded keys (uncontrolled)',
+      table: { type: { summary: 'string[]' } },
+    },
+    autoExpandParent: {
+      control: 'boolean',
+      description: 'Auto-expand parents of currently expanded keys',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+
+    /* Checking */
+    isCheckable: {
+      control: 'boolean',
+      description: 'Render a checkbox in front of every eligible row',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    checkedKeys: {
+      control: { type: null },
+      description:
+        'Controlled checked keys. Accepts `string[]` or `{ checked, halfChecked }`.',
+      table: {
+        type: {
+          summary: 'string[] | { checked: string[]; halfChecked?: string[] }',
+        },
+      },
+    },
+    defaultCheckedKeys: {
+      control: { type: null },
+      description: 'Default checked keys (uncontrolled)',
+      table: { type: { summary: 'string[]' } },
+    },
+
+    /* Presentation */
+    blockNode: {
+      control: 'boolean',
+      description: 'Stretch each row to fill the container width',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    height: {
+      control: 'number',
+      description:
+        'Fixed height (px). When omitted, the tree fills its container.',
+      table: { type: { summary: 'number' } },
+    },
+
+    /* State */
+    isSelectable: {
+      control: 'boolean',
+      description: 'Sugar for `selectionMode="none"` when `false`',
+      table: { type: { summary: 'boolean' } },
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Disable the entire tree',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+
+    /* Behavior */
+    loadData: {
+      control: { type: null },
+      description: 'Async loader called on first expansion of a non-leaf node',
+      table: {
+        type: { summary: '(node: TreeLoadDataNode) => Promise<void>' },
+      },
+    },
+
+    /* Events */
+    onExpand: {
+      action: 'expand',
+      description: 'Called when a node is expanded or collapsed',
+      table: {
+        type: { summary: '(keys: Key[], info: TreeOnExpandInfo) => void' },
+      },
+    },
+    onCheck: {
+      action: 'check',
+      description: 'Called when a node is checked or unchecked',
+      table: {
+        type: {
+          summary:
+            '(checked: Key[] | { checked, halfChecked }, info: TreeOnCheckInfo) => void',
+        },
+      },
+    },
+    onSelect: {
+      action: 'select',
+      description: 'Called when row selection changes',
+      table: {
+        type: { summary: '(keys: Key[], info: TreeOnSelectInfo) => void' },
+      },
+    },
+
+    /* Styling */
+    styles: {
+      control: { type: null },
+      description: 'Custom styles for the root',
+      table: { type: { summary: 'Styles' } },
+    },
+    rowStyles: {
+      control: { type: null },
+      description: 'Override styles for `[data-element="Row"]`',
+      table: { type: { summary: 'Styles' } },
+    },
+  },
+} satisfies Meta<typeof Tree>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Checkable: Story = {
+  args: {
+    isCheckable: true,
+    selectionMode: 'none',
+    defaultExpandedKeys: ['src', 'src/components'],
+  },
+};
+
+export const Multiple: Story = {
+  args: {
+    selectionMode: 'multiple',
+    defaultExpandedKeys: ['src'],
+  },
+};
+
+export const SelectionDisabled: Story = {
+  args: {
+    selectionMode: 'none',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+  },
+};
+
+export const BlockNode: Story = {
+  args: {
+    blockNode: true,
+    isCheckable: true,
+    selectionMode: 'none',
+  },
+};
+
+export const FixedHeight: Story = {
+  args: {
+    height: 200,
+    defaultExpandedKeys: ['src', 'src/components', 'src/hooks', 'public'],
+  },
+};
+
+export const PerNodeDisable: Story = {
+  args: {
+    treeData: [
+      {
+        key: 'a',
+        title: 'A',
+        children: [
+          { key: 'a-1', title: 'A-1', isDisabled: true },
+          {
+            key: 'a-2',
+            title: 'A-2 (checkbox disabled)',
+            isCheckboxDisabled: true,
+          },
+          { key: 'a-3', title: 'A-3 (no checkbox)', isCheckable: false },
+        ],
+      },
+      { key: 'b', title: 'B' },
+    ],
+    isCheckable: true,
+    selectionMode: 'none',
+    defaultExpandedKeys: ['a'],
+  },
+};
+
+const ControlledCheckedRender = (args: CubeTreeProps) => {
+  const [checkedKeys, setCheckedKeys] = useState<string[]>([]);
+  const [halfCheckedKeys, setHalfCheckedKeys] = useState<Key[]>([]);
+
+  return (
+    <Flow gap="2x">
+      <Tree
+        {...args}
+        checkedKeys={checkedKeys}
+        onCheck={(keys, info) => {
+          setCheckedKeys(keys as string[]);
+          setHalfCheckedKeys(info.halfCheckedKeys);
+        }}
+      />
+      <Space gap=".5x" flow="column">
+        <Text preset="t3">checked: {JSON.stringify(checkedKeys)}</Text>
+        <Text preset="t3">halfChecked: {JSON.stringify(halfCheckedKeys)}</Text>
+      </Space>
+    </Flow>
+  );
+};
+
+export const ControlledChecked: Story = {
+  args: {
+    isCheckable: true,
+    selectionMode: 'none',
+    defaultExpandedKeys: ['src', 'src/components'],
+  },
+  render: ControlledCheckedRender,
+};
+
+const LazyLoadingRender = (args: CubeTreeProps) => {
+  const [data, setData] = useState<CubeTreeNodeData[]>([
+    { key: 'root-1', title: 'Folder 1', isLeaf: false },
+    { key: 'root-2', title: 'Folder 2', isLeaf: false },
+    { key: 'root-3', title: 'Plain leaf', isLeaf: true },
+  ]);
+
+  const handleLoadData = (node: TreeLoadDataNode) =>
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        setData((prev) =>
+          prev.map((root) =>
+            root.key === node.key
+              ? {
+                  ...root,
+                  children: [
+                    {
+                      key: `${node.key}/child-1`,
+                      title: `${root.title} / child 1`,
+                    },
+                    {
+                      key: `${node.key}/child-2`,
+                      title: `${root.title} / child 2`,
+                    },
+                  ],
+                }
+              : root,
+          ),
+        );
+        resolve();
+      }, 800);
+    });
+
+  return <Tree {...args} treeData={data} loadData={handleLoadData} />;
+};
+
+export const LazyLoading: Story = {
+  args: {
+    selectionMode: 'single',
+  },
+  render: LazyLoadingRender,
+};
+
+const AutoExpandParentRender = (args: CubeTreeProps) => {
+  const [filter, setFilter] = useState('Tree');
+
+  const matchedKeys = useMemo(() => {
+    const out: string[] = [];
+    const walk = (nodes: CubeTreeNodeData[]) => {
+      for (const node of nodes) {
+        if (
+          typeof node.title === 'string' &&
+          node.title.toLowerCase().includes(filter.toLowerCase())
+        ) {
+          out.push(node.key);
+        }
+        if (node.children) walk(node.children);
+      }
+    };
+    walk(FILE_SYSTEM);
+    return out;
+  }, [filter]);
+
+  return (
+    <Flow gap="2x">
+      <input
+        value={filter}
+        placeholder="Filter…"
+        style={{ padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+        onChange={(e) => setFilter(e.target.value)}
+      />
+      <Tree
+        {...args}
+        autoExpandParent
+        treeData={FILE_SYSTEM}
+        expandedKeys={matchedKeys}
+      />
+    </Flow>
+  );
+};
+
+export const AutoExpandParent: Story = {
+  args: {
+    selectionMode: 'single',
+  },
+  render: AutoExpandParentRender,
+};
+
+export const Empty: Story = {
+  args: {
+    treeData: [],
+  },
+};

--- a/src/components/content/Tree/Tree.stories.tsx
+++ b/src/components/content/Tree/Tree.stories.tsx
@@ -366,21 +366,34 @@ export const LazyLoading: Story = {
 const AutoExpandParentRender = (args: CubeTreeProps) => {
   const [filter, setFilter] = useState('Tree');
 
-  const matchedKeys = useMemo(() => {
-    const out: string[] = [];
-    const walk = (nodes: CubeTreeNodeData[]) => {
+  const { treeData, matchedKeys } = useMemo(() => {
+    const query = filter.trim().toLowerCase();
+    if (!query) return { treeData: FILE_SYSTEM, matchedKeys: [] as string[] };
+
+    const matched: string[] = [];
+
+    const filterNodes = (nodes: CubeTreeNodeData[]): CubeTreeNodeData[] => {
+      const result: CubeTreeNodeData[] = [];
       for (const node of nodes) {
-        if (
+        const titleMatches =
           typeof node.title === 'string' &&
-          node.title.toLowerCase().includes(filter.toLowerCase())
-        ) {
-          out.push(node.key);
+          node.title.toLowerCase().includes(query);
+        const filteredChildren = node.children
+          ? filterNodes(node.children)
+          : undefined;
+
+        if (titleMatches || (filteredChildren && filteredChildren.length > 0)) {
+          if (titleMatches) matched.push(node.key);
+          result.push({
+            ...node,
+            children: filteredChildren,
+          });
         }
-        if (node.children) walk(node.children);
       }
+      return result;
     };
-    walk(FILE_SYSTEM);
-    return out;
+
+    return { treeData: filterNodes(FILE_SYSTEM), matchedKeys: matched };
   }, [filter]);
 
   return (
@@ -394,7 +407,7 @@ const AutoExpandParentRender = (args: CubeTreeProps) => {
       <Tree
         {...args}
         autoExpandParent
-        treeData={FILE_SYSTEM}
+        treeData={treeData}
         expandedKeys={matchedKeys}
       />
     </Flow>

--- a/src/components/content/Tree/Tree.stories.tsx
+++ b/src/components/content/Tree/Tree.stories.tsx
@@ -138,14 +138,6 @@ const meta = {
     },
 
     /* Presentation */
-    blockNode: {
-      control: 'boolean',
-      description: 'Stretch each row to fill the container width',
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-    },
     height: {
       control: 'number',
       description:
@@ -247,14 +239,6 @@ export const SelectionDisabled: Story = {
 export const Disabled: Story = {
   args: {
     isDisabled: true,
-  },
-};
-
-export const BlockNode: Story = {
-  args: {
-    blockNode: true,
-    isCheckable: true,
-    selectionMode: 'none',
   },
 };
 

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -306,6 +306,36 @@ describe('<Tree />', () => {
       expect(info.node).toBeDefined();
     });
 
+    it('emits only visible keys when selecting all in multiple mode', async () => {
+      const onSelect = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          selectionMode="multiple"
+          onSelect={onSelect}
+        />,
+      );
+
+      // Focus the tree, then trigger Ctrl+A to select all visible rows.
+      const rows = getAllByRole('row');
+      await act(async () => await userEvent.click(rows[0]));
+      onSelect.mockClear();
+      await act(async () => await userEvent.keyboard('{Control>}a{/Control}'));
+
+      expect(onSelect).toHaveBeenCalled();
+      const [keys, info] = onSelect.mock.calls[onSelect.mock.calls.length - 1];
+      // `vegetables` is collapsed, so its children must NOT be in the
+      // emitted selection — only the visible rows are.
+      expect(new Set(keys)).toEqual(
+        new Set(['fruits', 'apple', 'banana', 'vegetables']),
+      );
+      expect(keys).not.toContain('carrot');
+      expect(keys).not.toContain('potato');
+      expect(info.selectedNodes.map((n) => n.key)).not.toContain('carrot');
+      expect(info.selectedNodes.map((n) => n.key)).not.toContain('potato');
+    });
+
     it('does not call onSelect when selectionMode is "none"', async () => {
       const onSelect = vi.fn();
       const { getAllByRole } = renderWithRoot(

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { useState } from 'react';
+import { createRef, useState } from 'react';
 
 import { act, renderWithRoot, waitFor } from '../../../test';
 
@@ -370,6 +370,41 @@ describe('<Tree />', () => {
 
       await waitFor(() => {
         expect(getByText('Apple')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('populates the forwarded ref with the tree DOM element', () => {
+      // The internal `treeRef` (used by `useTree` for keyboard nav/focus)
+      // and the consumer's forwarded ref must both point at the same node.
+      const ref = createRef<HTMLDivElement>();
+      renderWithRoot(<Tree ref={ref} treeData={SAMPLE} />);
+      expect(ref.current).toBeInstanceOf(HTMLElement);
+      expect(ref.current?.getAttribute('role')).toBe('treegrid');
+    });
+
+    it('keeps keyboard navigation working when a ref is forwarded', async () => {
+      // Regression: previously `useTree` was wired to the internal ref
+      // while the DOM node received only the external ref, so keyboard
+      // handlers silently broke whenever a consumer forwarded a ref.
+      const user = userEvent.setup();
+      const ref = createRef<HTMLDivElement>();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          ref={ref}
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits', 'vegetables']}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      // Focus the tree — react-aria's `useTree` should now be able to
+      // route keyboard events because `treeRef.current` is set.
+      act(() => rows[0].focus());
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rows[1]);
       });
     });
   });

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -356,5 +356,21 @@ describe('<Tree />', () => {
         expect(getByText('Apple')).toBeInTheDocument();
       });
     });
+
+    it('expands ancestors when autoExpandParent is true in uncontrolled mode', async () => {
+      // Same as above, but with `defaultExpandedKeys` (uncontrolled). The
+      // parent expansion must apply equally to the default keys.
+      const { getByText } = renderWithRoot(
+        <Tree
+          autoExpandParent
+          treeData={SAMPLE}
+          defaultExpandedKeys={['apple']}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getByText('Apple')).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -61,6 +61,40 @@ describe('<Tree />', () => {
     expect(info.node.key).toBe('fruits');
   });
 
+  it('reports the correct toggled node across multiple uncontrolled toggles', async () => {
+    const onExpand = vi.fn();
+    const { getAllByRole } = renderWithRoot(
+      <Tree
+        treeData={SAMPLE}
+        defaultExpandedKeys={['fruits']}
+        onExpand={onExpand}
+      />,
+    );
+
+    const rows = getAllByRole('row');
+    const fruitsToggle = rows[0].querySelector(
+      'button[data-element="Toggle"]',
+    ) as HTMLButtonElement;
+    const vegetablesToggle = rows[3].querySelector(
+      'button[data-element="Toggle"]',
+    ) as HTMLButtonElement;
+
+    await act(async () => await userEvent.click(vegetablesToggle));
+    let [, info] = onExpand.mock.calls[onExpand.mock.calls.length - 1];
+    expect(info.expanded).toBe(true);
+    expect(info.node.key).toBe('vegetables');
+
+    await act(async () => await userEvent.click(fruitsToggle));
+    [, info] = onExpand.mock.calls[onExpand.mock.calls.length - 1];
+    expect(info.expanded).toBe(false);
+    expect(info.node.key).toBe('fruits');
+
+    await act(async () => await userEvent.click(vegetablesToggle));
+    [, info] = onExpand.mock.calls[onExpand.mock.calls.length - 1];
+    expect(info.expanded).toBe(false);
+    expect(info.node.key).toBe('vegetables');
+  });
+
   describe('checkable mode', () => {
     it('renders checkboxes when isCheckable is true', () => {
       const { getAllByRole } = renderWithRoot(

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -191,6 +191,76 @@ describe('<Tree />', () => {
       expect(arg).toHaveProperty('halfChecked');
     });
 
+    it('marks the grandparent fully checked when completing a sibling subtree (uncontrolled)', async () => {
+      // Three-level tree:
+      //   root → [groupA → [a1, a2], groupB → [b1, b2]]
+      // Default-checked: a1, a2, b1 (only leaves, like a typical consumer
+      // would persist). Toggling b1 → b2 → b1 → b2 (or just toggling b2)
+      // should leave `root` fully checked because every leaf is checked.
+      const data: CubeTreeNodeData[] = [
+        {
+          key: 'root',
+          title: 'Root',
+          children: [
+            {
+              key: 'groupA',
+              title: 'Group A',
+              children: [
+                { key: 'a1', title: 'A1' },
+                { key: 'a2', title: 'A2' },
+              ],
+            },
+            {
+              key: 'groupB',
+              title: 'Group B',
+              children: [
+                { key: 'b1', title: 'B1' },
+                { key: 'b2', title: 'B2' },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const onCheck = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          isCheckable
+          treeData={data}
+          defaultExpandedKeys={['root', 'groupA', 'groupB']}
+          defaultCheckedKeys={['a1', 'a2', 'b1']}
+          onCheck={onCheck}
+        />,
+      );
+
+      const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+      // Order: root, groupA, a1, a2, groupB, b1, b2
+      const rootCheckbox = checkboxes[0];
+      const b2Checkbox = checkboxes[6];
+
+      expect(rootCheckbox).not.toBeChecked();
+      expect(b2Checkbox).not.toBeChecked();
+
+      await act(async () => await userEvent.click(b2Checkbox));
+
+      // Every leaf is now checked → the root checkbox must reflect that.
+      expect(b2Checkbox).toBeChecked();
+      expect(rootCheckbox).toBeChecked();
+
+      const [keys] = onCheck.mock.calls[onCheck.mock.calls.length - 1];
+      expect(keys).toEqual(
+        expect.arrayContaining([
+          'root',
+          'groupA',
+          'groupB',
+          'a1',
+          'a2',
+          'b1',
+          'b2',
+        ]),
+      );
+    });
+
     it('skips checkboxes for nodes with isCheckable={false}', () => {
       const data: CubeTreeNodeData[] = [
         {

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -1,0 +1,326 @@
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { act, renderWithRoot, waitFor } from '../../../test';
+
+import { Tree } from './Tree';
+
+import type { CubeTreeNodeData, TreeLoadDataNode } from './types';
+
+const SAMPLE: CubeTreeNodeData[] = [
+  {
+    key: 'fruits',
+    title: 'Fruits',
+    children: [
+      { key: 'apple', title: 'Apple' },
+      { key: 'banana', title: 'Banana' },
+    ],
+  },
+  {
+    key: 'vegetables',
+    title: 'Vegetables',
+    children: [
+      { key: 'carrot', title: 'Carrot' },
+      { key: 'potato', title: 'Potato' },
+    ],
+  },
+];
+
+describe('<Tree />', () => {
+  it('renders the root nodes and respects defaultExpandedKeys', () => {
+    const { getByText, queryByText } = renderWithRoot(
+      <Tree treeData={SAMPLE} defaultExpandedKeys={['fruits']} />,
+    );
+
+    expect(getByText('Fruits')).toBeInTheDocument();
+    expect(getByText('Vegetables')).toBeInTheDocument();
+    expect(getByText('Apple')).toBeInTheDocument();
+    expect(getByText('Banana')).toBeInTheDocument();
+    expect(queryByText('Carrot')).not.toBeInTheDocument();
+  });
+
+  it('toggles expansion when clicking the expand button', async () => {
+    const onExpand = vi.fn();
+    const { getByText, queryByText, getAllByRole } = renderWithRoot(
+      <Tree treeData={SAMPLE} onExpand={onExpand} />,
+    );
+
+    expect(queryByText('Apple')).not.toBeInTheDocument();
+
+    const rows = getAllByRole('row');
+    const fruitsToggle = rows[0].querySelector(
+      'button[data-element="Toggle"]',
+    ) as HTMLButtonElement;
+    await act(async () => await userEvent.click(fruitsToggle));
+
+    expect(getByText('Apple')).toBeInTheDocument();
+    expect(onExpand).toHaveBeenCalled();
+    const [keys, info] = onExpand.mock.calls[0];
+    expect(keys).toContain('fruits');
+    expect(info.expanded).toBe(true);
+    expect(info.node.key).toBe('fruits');
+  });
+
+  describe('checkable mode', () => {
+    it('renders checkboxes when isCheckable is true', () => {
+      const { getAllByRole } = renderWithRoot(
+        <Tree isCheckable treeData={SAMPLE} defaultExpandedKeys={['fruits']} />,
+      );
+
+      // Root + 2 leaves of "fruits" + Vegetables = 4 visible rows
+      const checkboxes = getAllByRole('checkbox');
+      expect(checkboxes.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('cascades a parent check to all children (uncontrolled)', async () => {
+      const onCheck = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          isCheckable
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          onCheck={onCheck}
+        />,
+      );
+
+      const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+      // first checkbox should be the "Fruits" parent
+      await act(async () => await userEvent.click(checkboxes[0]));
+
+      expect(onCheck).toHaveBeenCalled();
+      const [keys] = onCheck.mock.calls[onCheck.mock.calls.length - 1];
+      expect(keys).toEqual(
+        expect.arrayContaining(['fruits', 'apple', 'banana']),
+      );
+    });
+
+    it('emits halfChecked when only some children are checked', async () => {
+      const onCheck = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          isCheckable
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          onCheck={onCheck}
+        />,
+      );
+
+      const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+      // checkboxes order: Fruits, Apple, Banana, Vegetables
+      await act(async () => await userEvent.click(checkboxes[1]));
+
+      const lastCall = onCheck.mock.calls[onCheck.mock.calls.length - 1];
+      const [, info] = lastCall;
+      expect(info.halfCheckedKeys).toContain('fruits');
+    });
+
+    it('respects controlled checkedKeys (array form)', async () => {
+      function Wrapper() {
+        const [keys, setKeys] = useState<string[]>([]);
+        return (
+          <Tree
+            isCheckable
+            treeData={SAMPLE}
+            defaultExpandedKeys={['fruits']}
+            checkedKeys={keys}
+            onCheck={(next) => setKeys(next as string[])}
+          />
+        );
+      }
+
+      const { getAllByRole } = renderWithRoot(<Wrapper />);
+
+      const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+      await act(async () => await userEvent.click(checkboxes[1])); // Apple
+
+      // Apple was the second checkbox
+      expect(checkboxes[1]).toBeChecked();
+    });
+
+    it('returns object shape from onCheck when checkedKeys is an object', async () => {
+      const onCheck = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          isCheckable
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          checkedKeys={{ checked: [], halfChecked: [] }}
+          onCheck={onCheck}
+        />,
+      );
+
+      const checkboxes = getAllByRole('checkbox') as HTMLInputElement[];
+      await act(async () => await userEvent.click(checkboxes[1]));
+
+      const [arg] = onCheck.mock.calls[0];
+      expect(arg).toHaveProperty('checked');
+      expect(arg).toHaveProperty('halfChecked');
+    });
+
+    it('skips checkboxes for nodes with isCheckable={false}', () => {
+      const data: CubeTreeNodeData[] = [
+        {
+          key: 'a',
+          title: 'A',
+          isCheckable: false,
+        },
+        { key: 'b', title: 'B' },
+      ];
+      const { getAllByRole } = renderWithRoot(
+        <Tree isCheckable treeData={data} />,
+      );
+      // Only "B" should have a checkbox
+      expect(getAllByRole('checkbox').length).toBe(1);
+    });
+  });
+
+  describe('selection', () => {
+    it('does not render checkboxes when isCheckable is omitted', () => {
+      const { queryAllByRole } = renderWithRoot(
+        <Tree treeData={SAMPLE} defaultExpandedKeys={['fruits']} />,
+      );
+      expect(queryAllByRole('checkbox').length).toBe(0);
+    });
+
+    it('fires onSelect with the toggled key when clicking a row', async () => {
+      const onSelect = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          onSelect={onSelect}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      // Click on the title cell of "Apple"
+      await act(async () => await userEvent.click(rows[1]));
+
+      expect(onSelect).toHaveBeenCalled();
+      const [keys, info] = onSelect.mock.calls[0];
+      expect(keys.length).toBe(1);
+      expect(info.node).toBeDefined();
+    });
+
+    it('does not call onSelect when selectionMode is "none"', async () => {
+      const onSelect = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          selectionMode="none"
+          onSelect={onSelect}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      await act(async () => await userEvent.click(rows[1]));
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disabled', () => {
+    it('marks all rows as disabled when isDisabled is true', () => {
+      const { getAllByRole } = renderWithRoot(
+        <Tree isDisabled treeData={SAMPLE} defaultExpandedKeys={['fruits']} />,
+      );
+
+      const rows = getAllByRole('row');
+      for (const row of rows) {
+        expect(row).toHaveAttribute('aria-disabled', 'true');
+      }
+    });
+
+    it('marks individual rows as disabled when node.isDisabled is true', () => {
+      const data: CubeTreeNodeData[] = [
+        { key: 'a', title: 'A', isDisabled: true },
+        { key: 'b', title: 'B' },
+      ];
+      const { getAllByRole } = renderWithRoot(<Tree treeData={data} />);
+
+      const rows = getAllByRole('row');
+      expect(rows[0]).toHaveAttribute('aria-disabled', 'true');
+      expect(rows[1]).not.toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('loadData', () => {
+    it('fires loadData on first expansion of a non-leaf with no children', async () => {
+      const data: CubeTreeNodeData[] = [
+        { key: 'lazy', title: 'Lazy', isLeaf: false },
+      ];
+
+      let resolveLoad: (() => void) | null = null;
+      const loadData = vi.fn(
+        (_node: TreeLoadDataNode) =>
+          new Promise<void>((resolve) => {
+            resolveLoad = () => resolve();
+          }),
+      );
+
+      const { getAllByRole } = renderWithRoot(
+        <Tree treeData={data} loadData={loadData} />,
+      );
+
+      const toggle = getAllByRole('row')[0].querySelector(
+        'button[data-element="Toggle"]',
+      ) as HTMLButtonElement;
+      await act(async () => await userEvent.click(toggle));
+
+      expect(loadData).toHaveBeenCalledTimes(1);
+      expect(loadData.mock.calls[0][0].key).toBe('lazy');
+
+      await act(async () => {
+        resolveLoad?.();
+      });
+    });
+
+    it('does not fire loadData when isLeaf is true', async () => {
+      const data: CubeTreeNodeData[] = [
+        { key: 'leaf', title: 'Leaf', isLeaf: true },
+      ];
+      const loadData = vi.fn(() => Promise.resolve());
+      const { getAllByRole } = renderWithRoot(
+        <Tree treeData={data} loadData={loadData} />,
+      );
+      const row = getAllByRole('row')[0];
+      const toggle = row.querySelector(
+        'button[data-element="Toggle"]',
+      ) as HTMLButtonElement | null;
+      // Either no toggle, or clicking it does nothing
+      if (toggle) {
+        await act(async () => await userEvent.click(toggle));
+      }
+      expect(loadData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('controlled expansion', () => {
+    it('honors a controlled expandedKeys array', async () => {
+      const { rerender, getByText, queryByText } = renderWithRoot(
+        <Tree treeData={SAMPLE} expandedKeys={[]} />,
+      );
+
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+
+      rerender(<Tree treeData={SAMPLE} expandedKeys={['fruits']} />);
+
+      await waitFor(() => {
+        expect(getByText('Apple')).toBeInTheDocument();
+      });
+    });
+
+    it('expands ancestors when autoExpandParent is true', async () => {
+      // "apple" lives under "fruits"; passing only the deep key with
+      // autoExpandParent should auto-expand the parent.
+      const { getByText } = renderWithRoot(
+        <Tree autoExpandParent treeData={SAMPLE} expandedKeys={['apple']} />,
+      );
+
+      await waitFor(() => {
+        expect(getByText('Apple')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -8,6 +8,7 @@ import { mergeProps } from '../../../utils/react';
 import { extractStyles } from '../../../utils/styles';
 
 import { TreeElement } from './styled';
+import { buildTreeIndex } from './tree-index';
 import { TreeNode } from './TreeNode';
 import { useCheckboxTree } from './use-checkbox-tree';
 import { useLoadData } from './use-load-data';
@@ -50,21 +51,6 @@ function renderItem(node: CubeTreeNodeData): ReactElement {
   );
 }
 
-/** Walk the treeData and build a flat `key -> node` index. */
-function buildNodesByKey(
-  treeData: CubeTreeNodeData[],
-): Map<string, CubeTreeNodeData> {
-  const map = new Map<string, CubeTreeNodeData>();
-  const visit = (nodes: CubeTreeNodeData[]) => {
-    for (const node of nodes) {
-      map.set(node.key, node);
-      if (node.children) visit(node.children);
-    }
-  };
-  visit(treeData);
-  return map;
-}
-
 /** Walk the treeData and collect all keys whose `isDisabled === true`. */
 function collectDisabledKeys(
   treeData: CubeTreeNodeData[],
@@ -79,23 +65,6 @@ function collectDisabledKeys(
   };
   visit(treeData);
   return keys;
-}
-
-/**
- * Map `key -> parentKey` (used for `autoExpandParent`).
- */
-function buildParentOf(
-  treeData: CubeTreeNodeData[],
-): Map<string, string | null> {
-  const parentOf = new Map<string, string | null>();
-  const visit = (nodes: CubeTreeNodeData[], parent: string | null) => {
-    for (const node of nodes) {
-      parentOf.set(node.key, parent);
-      if (node.children) visit(node.children, node.key);
-    }
-  };
-  visit(treeData, null);
-  return parentOf;
 }
 
 /**
@@ -165,8 +134,14 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
 
   const treeRef = useRef<HTMLDivElement>(null);
 
-  const nodesByKey = useMemo(() => buildNodesByKey(treeData), [treeData]);
-  const parentOf = useMemo(() => buildParentOf(treeData), [treeData]);
+  /**
+   * Single tree walk that produces `byKey`, `parentOf`, and `childrenOf`.
+   * Shared with `useCheckboxTree` so a `treeData` change triggers exactly
+   * one walk (instead of three) for these three maps.
+   */
+  const treeIndex = useMemo(() => buildTreeIndex(treeData), [treeData]);
+  const nodesByKey = treeIndex.byKey;
+  const parentOf = treeIndex.parentOf;
 
   const disabledKeys = useMemo(
     () => collectDisabledKeys(treeData, isDisabled),
@@ -188,8 +163,23 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     [autoExpandParent, expandedKeys, parentOf],
   );
 
+  /**
+   * Mirror the same logic for the uncontrolled `defaultExpandedKeys`.
+   * `useTreeState` only reads it on mount, but we still need to expand
+   * ancestors so consumers passing a deep key (e.g. a search match) get
+   * the same behaviour as in the controlled mode.
+   */
+  const effectiveDefaultExpandedKeys = useMemo(
+    () =>
+      autoExpandParent
+        ? expandWithParents(defaultExpandedKeys, parentOf)
+        : defaultExpandedKeys,
+    [autoExpandParent, defaultExpandedKeys, parentOf],
+  );
+
   const checkbox = useCheckboxTree({
     treeData,
+    index: treeIndex,
     isCheckable,
     defaultCheckedKeys,
     checkedKeys,
@@ -317,7 +307,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
           ? handleSelectionChange
           : undefined,
       expandedKeys: effectiveExpandedKeys,
-      defaultExpandedKeys,
+      defaultExpandedKeys: effectiveDefaultExpandedKeys,
       onExpandedChange: handleExpandedChange,
       disabledKeys,
       disabledBehavior: 'all' as const,
@@ -332,7 +322,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
       onSelect,
       handleSelectionChange,
       effectiveExpandedKeys,
-      defaultExpandedKeys,
+      effectiveDefaultExpandedKeys,
       handleExpandedChange,
       disabledKeys,
       treeData,

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -1,0 +1,448 @@
+import { OUTER_STYLES } from '@tenphi/tasty';
+import { forwardRef, useMemo, useRef } from 'react';
+import { useTree } from 'react-aria';
+import { Item, useTreeState } from 'react-stately';
+
+import { useEvent } from '../../../_internal/hooks';
+import { mergeProps } from '../../../utils/react';
+import { extractStyles } from '../../../utils/styles';
+
+import { TreeElement } from './styled';
+import { TreeNode } from './TreeNode';
+import { useCheckboxTree } from './use-checkbox-tree';
+import { useLoadData } from './use-load-data';
+
+import type { Key, Node, Selection } from '@react-types/shared';
+import type { CSSProperties, ForwardedRef, ReactElement } from 'react';
+import type {
+  CubeTreeNodeData,
+  CubeTreeProps,
+  TreeOnExpandInfo,
+  TreeOnSelectInfo,
+  TreeSelectionMode,
+} from './types';
+
+/**
+ * Render an `<Item>` for React Stately's collection builder.
+ *
+ * The visible row content is rendered by `TreeNode` via a
+ * `nodesByKey` lookup, so the `<Item>`'s body is only used by
+ * Stately to build the collection (`textValue` for keyboard nav,
+ * `childItems` for nested traversal).
+ *
+ * For nested traversal to work, the `children` of the `<Tree>` must
+ * be passed as a *function* together with the top-level `items`
+ * array — see the `<Tree>` `useCollection` call below. Stately
+ * propagates that renderer into `childItems` so nested arrays of
+ * raw `CubeTreeNodeData` are turned back into `<Item>` elements.
+ */
+function renderItem(node: CubeTreeNodeData): ReactElement {
+  const textValue =
+    typeof node.title === 'string' ? node.title : String(node.key);
+  return (
+    <Item
+      key={node.key}
+      textValue={textValue}
+      childItems={node.children as CubeTreeNodeData[] | undefined}
+    >
+      {node.title as any}
+    </Item>
+  );
+}
+
+/** Walk the treeData and build a flat `key -> node` index. */
+function buildNodesByKey(
+  treeData: CubeTreeNodeData[],
+): Map<string, CubeTreeNodeData> {
+  const map = new Map<string, CubeTreeNodeData>();
+  const visit = (nodes: CubeTreeNodeData[]) => {
+    for (const node of nodes) {
+      map.set(node.key, node);
+      if (node.children) visit(node.children);
+    }
+  };
+  visit(treeData);
+  return map;
+}
+
+/** Walk the treeData and collect all keys whose `isDisabled === true`. */
+function collectDisabledKeys(
+  treeData: CubeTreeNodeData[],
+  treeIsDisabled: boolean,
+): string[] {
+  const keys: string[] = [];
+  const visit = (nodes: CubeTreeNodeData[]) => {
+    for (const node of nodes) {
+      if (treeIsDisabled || node.isDisabled) keys.push(node.key);
+      if (node.children) visit(node.children);
+    }
+  };
+  visit(treeData);
+  return keys;
+}
+
+/**
+ * Map `key -> parentKey` (used for `autoExpandParent`).
+ */
+function buildParentOf(
+  treeData: CubeTreeNodeData[],
+): Map<string, string | null> {
+  const parentOf = new Map<string, string | null>();
+  const visit = (nodes: CubeTreeNodeData[], parent: string | null) => {
+    for (const node of nodes) {
+      parentOf.set(node.key, parent);
+      if (node.children) visit(node.children, node.key);
+    }
+  };
+  visit(treeData, null);
+  return parentOf;
+}
+
+/**
+ * Expand the supplied keys with all of their ancestors. Used when
+ * `autoExpandParent` is `true` so that the consumer can pass deep keys
+ * (e.g. search matches) without having to manually walk parents.
+ */
+function expandWithParents(
+  keys: string[] | undefined,
+  parentOf: Map<string, string | null>,
+): string[] | undefined {
+  if (!keys || keys.length === 0) return keys;
+  const set = new Set<string>(keys);
+  for (const key of keys) {
+    let parent = parentOf.get(key);
+    while (parent) {
+      set.add(parent);
+      parent = parentOf.get(parent);
+    }
+  }
+  return Array.from(set);
+}
+
+/**
+ * Coerce the public `selectionMode` / `isSelectable` pair into a single
+ * `selectionMode` value for `useTreeState`.
+ *
+ * - `selectionMode` wins when both are passed.
+ * - `isSelectable === false` is sugar for `selectionMode='none'`.
+ * - `selectionMode` defaults to `'single'` (matches AntD's default).
+ */
+function resolveSelectionMode(
+  selectionMode: TreeSelectionMode | undefined,
+  isSelectable: boolean | undefined,
+): TreeSelectionMode {
+  if (selectionMode != null) return selectionMode;
+  if (isSelectable === false) return 'none';
+  return 'single';
+}
+
+function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
+  const {
+    treeData,
+    isCheckable = false,
+    isSelectable,
+    selectionMode: selectionModeProp,
+    blockNode = false,
+    isDisabled = false,
+    defaultExpandedKeys,
+    expandedKeys,
+    autoExpandParent = false,
+    defaultCheckedKeys,
+    checkedKeys,
+    defaultSelectedKeys,
+    selectedKeys,
+    height,
+    loadData,
+    onExpand,
+    onCheck,
+    onSelect,
+    rowStyles,
+    qa,
+    ...otherProps
+  } = props;
+
+  const baseStyles = extractStyles(otherProps, OUTER_STYLES);
+
+  const treeRef = useRef<HTMLDivElement>(null);
+
+  const nodesByKey = useMemo(() => buildNodesByKey(treeData), [treeData]);
+  const parentOf = useMemo(() => buildParentOf(treeData), [treeData]);
+
+  const disabledKeys = useMemo(
+    () => collectDisabledKeys(treeData, isDisabled),
+    [treeData, isDisabled],
+  );
+
+  const selectionMode = resolveSelectionMode(selectionModeProp, isSelectable);
+
+  /**
+   * Apply `autoExpandParent` to the controlled `expandedKeys`. This is
+   * a one-shot thing — once the consumer responds to `onExpand` and
+   * sets `autoExpandParent` to `false`, we stop force-expanding parents.
+   */
+  const effectiveExpandedKeys = useMemo(
+    () =>
+      autoExpandParent
+        ? expandWithParents(expandedKeys, parentOf)
+        : expandedKeys,
+    [autoExpandParent, expandedKeys, parentOf],
+  );
+
+  const checkbox = useCheckboxTree({
+    treeData,
+    isCheckable,
+    defaultCheckedKeys,
+    checkedKeys,
+    onCheck,
+  });
+
+  const loadDataController = useLoadData({ nodesByKey, loadData });
+
+  /**
+   * Translate Stately's `Set<Key>` callbacks into the public AntD-flavoured
+   * `Key[]` shape and dispatch the per-key load.
+   */
+  const handleExpandedChange = useEvent((nextSet: Set<Key>) => {
+    loadDataController.onExpandedChanged(nextSet);
+
+    if (!onExpand) return;
+    const nextArr: Key[] = Array.from(nextSet);
+    const previous = new Set<Key>(effectiveExpandedKeys ?? []);
+
+    /**
+     * Find the single key that toggled relative to the previous set.
+     * Useful for `info.node` and `info.expanded` — matches AntD.
+     */
+    let toggledKey: Key | null = null;
+    let toggledExpanded = false;
+    for (const k of nextArr) {
+      if (!previous.has(k)) {
+        toggledKey = k;
+        toggledExpanded = true;
+        break;
+      }
+    }
+    if (toggledKey == null) {
+      for (const k of previous) {
+        if (!nextSet.has(k)) {
+          toggledKey = k;
+          toggledExpanded = false;
+          break;
+        }
+      }
+    }
+
+    const node =
+      toggledKey != null ? nodesByKey.get(String(toggledKey)) : undefined;
+    const info: TreeOnExpandInfo = {
+      expanded: toggledExpanded,
+      node: node ?? ({} as CubeTreeNodeData),
+    };
+    onExpand(nextArr, info);
+  });
+
+  const handleSelectionChange = useEvent((selection: Selection) => {
+    if (!onSelect) return;
+    const arr: Key[] =
+      selection === 'all'
+        ? Array.from(nodesByKey.keys())
+        : Array.from(selection);
+    /**
+     * Stately's `onSelectionChange` hands us the *next* selection only —
+     * we don't get a "toggled key" diff for free. For `single` mode we
+     * can infer it cheaply (it's the only entry); for `multiple` we
+     * report the most recent addition. Falls back to the first key.
+     */
+    let toggledKey: Key | null = null;
+    let toggledSelected = false;
+    if (selectionMode === 'single') {
+      toggledKey = arr[0] ?? null;
+      toggledSelected = arr.length > 0;
+    } else if (selection !== 'all') {
+      toggledKey = arr.length > 0 ? arr[arr.length - 1] : null;
+      toggledSelected = arr.length > 0;
+    } else {
+      toggledKey = arr[0] ?? null;
+      toggledSelected = true;
+    }
+
+    const node =
+      toggledKey != null ? nodesByKey.get(String(toggledKey)) : undefined;
+    const selectedNodes = arr
+      .map((k) => nodesByKey.get(String(k)))
+      .filter((n): n is CubeTreeNodeData => !!n);
+
+    const info: TreeOnSelectInfo = {
+      selected: toggledSelected,
+      node: node ?? ({} as CubeTreeNodeData),
+      selectedNodes,
+    };
+
+    onSelect(arr, info);
+  });
+
+  /**
+   * Stately propagates the `children` function through `childItems`,
+   * so a single render function recursively turns the entire
+   * `treeData` array into `<Item>` elements.
+   */
+  const renderCollectionItem = useEvent((item: CubeTreeNodeData) =>
+    renderItem(item),
+  );
+
+  const ariaProps = useMemo(
+    () => ({
+      selectionMode,
+      selectedKeys,
+      defaultSelectedKeys,
+      onSelectionChange:
+        onSelect && selectionMode !== 'none'
+          ? handleSelectionChange
+          : undefined,
+      expandedKeys: effectiveExpandedKeys,
+      defaultExpandedKeys,
+      onExpandedChange: handleExpandedChange,
+      disabledKeys,
+      disabledBehavior: 'all' as const,
+      items: treeData,
+      children: renderCollectionItem as any,
+      'aria-label': 'Tree',
+    }),
+    [
+      selectionMode,
+      selectedKeys,
+      defaultSelectedKeys,
+      onSelect,
+      handleSelectionChange,
+      effectiveExpandedKeys,
+      defaultExpandedKeys,
+      handleExpandedChange,
+      disabledKeys,
+      treeData,
+      renderCollectionItem,
+    ],
+  );
+
+  const baseState = useTreeState<CubeTreeNodeData>(ariaProps);
+
+  /**
+   * The legacy `TreeCollection` returned by `useTreeState` doesn't
+   * implement `getChildren`, but `@react-aria/tree`'s `useTree`
+   * (via `useGridListItem`) calls it unguarded for any nested row
+   * (`node.level > 0`). Patch it once so `useTree` works on top of
+   * the legacy state without forking.
+   */
+  const state = useMemo(() => {
+    const collection = baseState.collection;
+    if (typeof (collection as any).getChildren === 'function') {
+      return baseState;
+    }
+    const getChildren = (key: Key): Iterable<Node<CubeTreeNodeData>> => {
+      const result: Node<CubeTreeNodeData>[] = [];
+      const node = collection.getItem(key);
+      if (!node) return result;
+      for (const child of node.childNodes) {
+        result.push(child);
+      }
+      return result;
+    };
+    const patched = Object.assign(
+      Object.create(Object.getPrototypeOf(collection)),
+      collection,
+      { getChildren },
+    );
+    return { ...baseState, collection: patched };
+  }, [baseState]);
+
+  const { gridProps } = useTree(ariaProps, state, treeRef);
+
+  /**
+   * Iterate the collection in DOM order. The TreeCollection only walks
+   * into expanded subtrees, so `getKeys()` already gives us *only*
+   * visible rows — no manual filtering required.
+   */
+  const visibleNodes: Node<CubeTreeNodeData>[] = useMemo(() => {
+    const out: Node<CubeTreeNodeData>[] = [];
+    for (const key of state.collection.getKeys()) {
+      const node = state.collection.getItem(key);
+      if (node && node.type === 'item') out.push(node);
+    }
+    return out;
+  }, [state.collection, state.expandedKeys]);
+
+  const heightStyle = useMemo<CSSProperties | undefined>(
+    () =>
+      height != null
+        ? ({
+            ['--tree-height' as keyof CSSProperties]: `${height}px`,
+          } as CSSProperties)
+        : undefined,
+    [height],
+  );
+
+  const mods = useMemo(
+    () => ({
+      'has-height': height != null,
+    }),
+    [height],
+  );
+
+  const elementProps = mergeProps(gridProps, {
+    ref: ref ?? treeRef,
+  });
+
+  return (
+    <TreeElement
+      {...elementProps}
+      ref={ref ?? treeRef}
+      qa={qa ?? 'Tree'}
+      mods={mods}
+      styles={baseStyles}
+      style={heightStyle}
+    >
+      {visibleNodes.map((node) => {
+        const data = nodesByKey.get(String(node.key));
+        if (!data) return null;
+        const isExpanded = state.expandedKeys.has(node.key);
+        return (
+          <TreeNode
+            key={node.key}
+            node={node}
+            data={data}
+            state={state}
+            isCheckable={isCheckable}
+            isExpanded={isExpanded}
+            isChecked={checkbox.checkedSet.has(String(node.key))}
+            isIndeterminate={checkbox.halfCheckedSet.has(String(node.key))}
+            isLoading={loadDataController.loadingKeys.has(String(node.key))}
+            isBlockNode={blockNode}
+            rowStyles={rowStyles}
+            onToggleChecked={checkbox.toggle}
+          />
+        );
+      })}
+    </TreeElement>
+  );
+}
+
+const _Tree = forwardRef(TreeBase);
+
+/**
+ * Hierarchical data display with optional checkboxes, single/multi
+ * selection, async lazy loading, and keyboard navigation.
+ *
+ * Built on `useTree` / `useTreeState` (React Aria + React Stately) and
+ * styled with Tasty.
+ *
+ * @example
+ * ```tsx
+ * <Tree
+ *   treeData={data}
+ *   isCheckable
+ *   selectionMode="none"
+ *   defaultExpandedKeys={['root']}
+ *   onCheck={(keys) => console.log(keys)}
+ * />
+ * ```
+ */
+export const Tree = _Tree;

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -199,15 +199,32 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
   const loadDataController = useLoadData({ nodesByKey, loadData });
 
   /**
+   * Tracks the previously-expanded set so we can diff against the next set
+   * inside `handleExpandedChange`. In controlled mode the parent owns the
+   * truth (read from `effectiveExpandedKeys`); in uncontrolled mode this
+   * ref is the only source for the previous state — `effectiveExpandedKeys`
+   * is `undefined` and would otherwise produce an empty `previous` set,
+   * mis-identifying every toggle.
+   */
+  const previousExpandedRef = useRef<Set<Key>>(
+    new Set<Key>(expandedKeys ?? defaultExpandedKeys ?? []),
+  );
+
+  /**
    * Translate Stately's `Set<Key>` callbacks into the public AntD-flavoured
    * `Key[]` shape and dispatch the per-key load.
    */
   const handleExpandedChange = useEvent((nextSet: Set<Key>) => {
     loadDataController.onExpandedChanged(nextSet);
 
+    const previous =
+      expandedKeys !== undefined
+        ? new Set<Key>(effectiveExpandedKeys ?? [])
+        : previousExpandedRef.current;
+    previousExpandedRef.current = new Set<Key>(nextSet);
+
     if (!onExpand) return;
     const nextArr: Key[] = Array.from(nextSet);
-    const previous = new Set<Key>(effectiveExpandedKeys ?? []);
 
     /**
      * Find the single key that toggled relative to the previous set.

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -14,7 +14,12 @@ import { useCheckboxTree } from './use-checkbox-tree';
 import { useLoadData } from './use-load-data';
 
 import type { Key, Node, Selection } from '@react-types/shared';
-import type { CSSProperties, ForwardedRef, ReactElement } from 'react';
+import type {
+  CSSProperties,
+  ForwardedRef,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import type {
   CubeTreeNodeData,
   CubeTreeProps,
@@ -26,16 +31,9 @@ import type {
 /**
  * Render an `<Item>` for React Stately's collection builder.
  *
- * The visible row content is rendered by `TreeNode` via a
- * `nodesByKey` lookup, so the `<Item>`'s body is only used by
- * Stately to build the collection (`textValue` for keyboard nav,
- * `childItems` for nested traversal).
- *
- * For nested traversal to work, the `children` of the `<Tree>` must
- * be passed as a *function* together with the top-level `items`
- * array — see the `<Tree>` `useCollection` call below. Stately
- * propagates that renderer into `childItems` so nested arrays of
- * raw `CubeTreeNodeData` are turned back into `<Item>` elements.
+ * The visible content is rendered by `TreeNode` via `nodesByKey`,
+ * so `<Item>`'s body is only used by Stately for the collection
+ * (`textValue` for keyboard nav, `childItems` for nested traversal).
  */
 function renderItem(node: CubeTreeNodeData): ReactElement {
   const textValue =
@@ -46,12 +44,11 @@ function renderItem(node: CubeTreeNodeData): ReactElement {
       textValue={textValue}
       childItems={node.children as CubeTreeNodeData[] | undefined}
     >
-      {node.title as any}
+      {node.title as ReactNode}
     </Item>
   );
 }
 
-/** Walk the treeData and collect all keys whose `isDisabled === true`. */
 function collectDisabledKeys(
   treeData: CubeTreeNodeData[],
   treeIsDisabled: boolean,
@@ -67,11 +64,7 @@ function collectDisabledKeys(
   return keys;
 }
 
-/**
- * Expand the supplied keys with all of their ancestors. Used when
- * `autoExpandParent` is `true` so that the consumer can pass deep keys
- * (e.g. search matches) without having to manually walk parents.
- */
+/** Expand the supplied keys with all of their ancestor keys. */
 function expandWithParents(
   keys: string[] | undefined,
   parentOf: Map<string, string | null>,
@@ -89,13 +82,22 @@ function expandWithParents(
 }
 
 /**
- * Coerce the public `selectionMode` / `isSelectable` pair into a single
- * `selectionMode` value for `useTreeState`.
- *
- * - `selectionMode` wins when both are passed.
- * - `isSelectable === false` is sugar for `selectionMode='none'`.
- * - `selectionMode` defaults to `'single'` (matches AntD's default).
+ * Diff two key sets to find the single key that was added or removed.
+ * Returns `null` when both sets are equal.
  */
+function findToggledKey(
+  previous: Set<Key>,
+  next: Set<Key>,
+): { key: Key; added: boolean } | null {
+  for (const k of next) {
+    if (!previous.has(k)) return { key: k, added: true };
+  }
+  for (const k of previous) {
+    if (!next.has(k)) return { key: k, added: false };
+  }
+  return null;
+}
+
 function resolveSelectionMode(
   selectionMode: TreeSelectionMode | undefined,
   isSelectable: boolean | undefined,
@@ -111,7 +113,6 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     isCheckable = false,
     isSelectable,
     selectionMode: selectionModeProp,
-    blockNode = false,
     isDisabled = false,
     defaultExpandedKeys,
     expandedKeys,
@@ -126,6 +127,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     onCheck,
     onSelect,
     rowStyles,
+    ariaLabel,
     qa,
     ...otherProps
   } = props;
@@ -134,11 +136,6 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
 
   const treeRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * Single tree walk that produces `byKey`, `parentOf`, and `childrenOf`.
-   * Shared with `useCheckboxTree` so a `treeData` change triggers exactly
-   * one walk (instead of three) for these three maps.
-   */
   const treeIndex = useMemo(() => buildTreeIndex(treeData), [treeData]);
   const nodesByKey = treeIndex.byKey;
   const parentOf = treeIndex.parentOf;
@@ -150,11 +147,6 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
 
   const selectionMode = resolveSelectionMode(selectionModeProp, isSelectable);
 
-  /**
-   * Apply `autoExpandParent` to the controlled `expandedKeys`. This is
-   * a one-shot thing — once the consumer responds to `onExpand` and
-   * sets `autoExpandParent` to `false`, we stop force-expanding parents.
-   */
   const effectiveExpandedKeys = useMemo(
     () =>
       autoExpandParent
@@ -163,12 +155,6 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     [autoExpandParent, expandedKeys, parentOf],
   );
 
-  /**
-   * Mirror the same logic for the uncontrolled `defaultExpandedKeys`.
-   * `useTreeState` only reads it on mount, but we still need to expand
-   * ancestors so consumers passing a deep key (e.g. a search match) get
-   * the same behaviour as in the controlled mode.
-   */
   const effectiveDefaultExpandedKeys = useMemo(
     () =>
       autoExpandParent
@@ -193,27 +179,15 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
   });
 
   /**
-   * Tracks the previously-expanded set so we can diff against the next set
-   * inside `handleExpandedChange`. In controlled mode the parent owns the
-   * truth (read from `effectiveExpandedKeys`); in uncontrolled mode this
-   * ref is the only source for the previous state — `effectiveExpandedKeys`
-   * is `undefined` and would otherwise produce an empty `previous` set,
-   * mis-identifying every toggle.
-   *
-   * Must mirror what `useTreeState` was initialized with (the *effective*
-   * sets, which include `autoExpandParent` ancestors). Using the raw
-   * `defaultExpandedKeys` here would make the first toggle in uncontrolled
-   * mode diff against an undersized previous set, reporting auto-expanded
-   * ancestors as newly expanded.
+   * In controlled mode, `previous` is read from `effectiveExpandedKeys`;
+   * in uncontrolled mode this ref is the only source. Initialized from
+   * the *effective* (ancestor-expanded) keys so the first toggle diffs
+   * correctly.
    */
   const previousExpandedRef = useRef<Set<Key>>(
     new Set<Key>(effectiveExpandedKeys ?? effectiveDefaultExpandedKeys ?? []),
   );
 
-  /**
-   * Translate Stately's `Set<Key>` callbacks into the public AntD-flavoured
-   * `Key[]` shape and dispatch the per-key load.
-   */
   const handleExpandedChange = useEvent((nextSet: Set<Key>) => {
     loadDataController.onExpandedChanged(nextSet);
 
@@ -224,52 +198,38 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     previousExpandedRef.current = new Set<Key>(nextSet);
 
     if (!onExpand) return;
-    const nextArr: Key[] = Array.from(nextSet);
 
-    /**
-     * Find the single key that toggled relative to the previous set.
-     * Useful for `info.node` and `info.expanded` — matches AntD.
-     */
-    let toggledKey: Key | null = null;
-    let toggledExpanded = false;
-    for (const k of nextArr) {
-      if (!previous.has(k)) {
-        toggledKey = k;
-        toggledExpanded = true;
-        break;
-      }
-    }
-    if (toggledKey == null) {
-      for (const k of previous) {
-        if (!nextSet.has(k)) {
-          toggledKey = k;
-          toggledExpanded = false;
-          break;
-        }
-      }
-    }
+    const toggled = findToggledKey(previous, nextSet);
+    if (!toggled) return;
 
-    const node =
-      toggledKey != null ? nodesByKey.get(String(toggledKey)) : undefined;
+    const node = nodesByKey.get(String(toggled.key));
+    if (!node) return;
+
     const info: TreeOnExpandInfo = {
-      expanded: toggledExpanded,
-      node: node ?? ({} as CubeTreeNodeData),
+      expanded: toggled.added,
+      node,
     };
-    onExpand(nextArr, info);
+    onExpand(Array.from(nextSet), info);
   });
 
+  /**
+   * Same pattern as `previousExpandedRef`: in controlled mode we read
+   * from `selectedKeys`; in uncontrolled mode this ref tracks state.
+   */
+  const previousSelectionRef = useRef<Set<Key>>(
+    new Set<Key>(selectedKeys ?? defaultSelectedKeys ?? []),
+  );
+
+  /**
+   * `useEvent` captures the closure lazily, so `state` (declared below
+   * `ariaProps` / `useTreeState`) is safely accessible at call time.
+   */
   const handleSelectionChange = useEvent((selection: Selection) => {
     if (!onSelect) return;
     let arr: Key[];
     if (selection === 'all') {
-      /**
-       * `'all'` (e.g. Ctrl+A in `multiple` mode) means "every visible
-       * row". `nodesByKey` is the full `treeData` index and would leak
-       * keys hidden under collapsed parents — use the collection's
-       * `getKeys()` instead, which only walks expanded subtrees.
-       * Filter to `item` nodes so we don't emit synthetic collection
-       * entries (e.g. sections) as selected keys.
-       */
+      // `nodesByKey` contains the full tree; use the collection's visible
+      // keys so we don't leak keys under collapsed parents.
       arr = [];
       for (const key of state.collection.getKeys()) {
         const node = state.collection.getItem(key);
@@ -278,48 +238,34 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     } else {
       arr = Array.from(selection);
     }
-    /**
-     * Stately's `onSelectionChange` hands us the *next* selection only —
-     * we don't get a "toggled key" diff for free. For `single` mode we
-     * can infer it cheaply (it's the only entry); for `multiple` we
-     * report the most recent addition. Falls back to the first key.
-     */
-    let toggledKey: Key | null = null;
-    let toggledSelected = false;
-    if (selectionMode === 'single') {
-      toggledKey = arr[0] ?? null;
-      toggledSelected = arr.length > 0;
-    } else if (selection !== 'all') {
-      toggledKey = arr.length > 0 ? arr[arr.length - 1] : null;
-      toggledSelected = arr.length > 0;
-    } else {
-      toggledKey = arr[0] ?? null;
-      toggledSelected = true;
-    }
 
-    const node =
-      toggledKey != null ? nodesByKey.get(String(toggledKey)) : undefined;
+    const nextSet = new Set<Key>(arr);
+    const previous =
+      selectedKeys !== undefined
+        ? new Set<Key>(selectedKeys ?? [])
+        : previousSelectionRef.current;
+    previousSelectionRef.current = nextSet;
+
+    const toggled = findToggledKey(previous, nextSet);
+    if (!toggled) return;
+
+    const node = nodesByKey.get(String(toggled.key));
+    if (!node) return;
+
     const selectedNodes = arr
       .map((k) => nodesByKey.get(String(k)))
       .filter((n): n is CubeTreeNodeData => !!n);
 
     const info: TreeOnSelectInfo = {
-      selected: toggledSelected,
-      node: node ?? ({} as CubeTreeNodeData),
+      selected: toggled.added,
+      node,
       selectedNodes,
     };
 
     onSelect(arr, info);
   });
 
-  /**
-   * Stately propagates the `children` function through `childItems`,
-   * so a single render function recursively turns the entire
-   * `treeData` array into `<Item>` elements.
-   */
-  const renderCollectionItem = useEvent((item: CubeTreeNodeData) =>
-    renderItem(item),
-  );
+  const hasOnSelect = onSelect != null;
 
   const ariaProps = useMemo(
     () => ({
@@ -327,7 +273,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
       selectedKeys,
       defaultSelectedKeys,
       onSelectionChange:
-        onSelect && selectionMode !== 'none'
+        hasOnSelect && selectionMode !== 'none'
           ? handleSelectionChange
           : undefined,
       expandedKeys: effectiveExpandedKeys,
@@ -336,62 +282,45 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
       disabledKeys,
       disabledBehavior: 'all' as const,
       items: treeData,
-      children: renderCollectionItem as any,
-      'aria-label': 'Tree',
+      children: renderItem as any,
+      'aria-label': ariaLabel ?? 'Tree',
     }),
     [
       selectionMode,
       selectedKeys,
       defaultSelectedKeys,
-      onSelect,
+      hasOnSelect,
       handleSelectionChange,
       effectiveExpandedKeys,
       effectiveDefaultExpandedKeys,
       handleExpandedChange,
       disabledKeys,
       treeData,
-      renderCollectionItem,
+      ariaLabel,
     ],
   );
 
   const baseState = useTreeState<CubeTreeNodeData>(ariaProps);
 
-  /**
-   * The legacy `TreeCollection` returned by `useTreeState` doesn't
-   * implement `getChildren`, but `@react-aria/tree`'s `useTree`
-   * (via `useGridListItem`) calls it unguarded for any nested row
-   * (`node.level > 0`). Patch it once so `useTree` works on top of
-   * the legacy state without forking.
-   */
+  // The legacy `TreeCollection` from `useTreeState` lacks `getChildren`,
+  // but `useTree` calls it for nested rows. Derive a patched state.
+  // TODO: Remove this patch when upgrading to a react-stately version
+  // that ships `getChildren` on TreeCollection natively.
   const state = useMemo(() => {
     const collection = baseState.collection;
     if (typeof (collection as any).getChildren === 'function') {
       return baseState;
     }
-    const getChildren = (key: Key): Iterable<Node<CubeTreeNodeData>> => {
-      const result: Node<CubeTreeNodeData>[] = [];
+    const patched = Object.create(collection);
+    patched.getChildren = (key: Key): Iterable<Node<CubeTreeNodeData>> => {
       const node = collection.getItem(key);
-      if (!node) return result;
-      for (const child of node.childNodes) {
-        result.push(child);
-      }
-      return result;
+      return node ? Array.from(node.childNodes) : [];
     };
-    const patched = Object.assign(
-      Object.create(Object.getPrototypeOf(collection)),
-      collection,
-      { getChildren },
-    );
     return { ...baseState, collection: patched };
   }, [baseState]);
 
   const { gridProps } = useTree(ariaProps, state, treeRef);
 
-  /**
-   * Iterate the collection in DOM order. The TreeCollection only walks
-   * into expanded subtrees, so `getKeys()` already gives us *only*
-   * visible rows — no manual filtering required.
-   */
   const visibleNodes: Node<CubeTreeNodeData>[] = useMemo(() => {
     const out: Node<CubeTreeNodeData>[] = [];
     for (const key of state.collection.getKeys()) {
@@ -399,7 +328,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
       if (node && node.type === 'item') out.push(node);
     }
     return out;
-  }, [state.collection, state.expandedKeys]);
+  }, [state.collection]);
 
   const heightStyle = useMemo<CSSProperties | undefined>(
     () =>
@@ -418,13 +347,8 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     [height],
   );
 
-  /**
-   * Merge the consumer's forwarded ref with our internal `treeRef`. Both
-   * must point at the same DOM node: `useTree` reads `treeRef.current` for
-   * keyboard navigation/focus management, and consumers expect the
-   * forwarded `ref` to receive the element too.
-   */
-  const mergedRef = useMemo(() => mergeRefs(ref, treeRef), [ref]);
+  // Both `useTree` and the consumer need the same DOM node.
+  const mergedRef = useMemo(() => mergeRefs(ref, treeRef), [ref, treeRef]);
 
   const elementProps = mergeProps(gridProps, {
     ref: mergedRef,
@@ -433,16 +357,15 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
   return (
     <TreeElement
       {...elementProps}
-      ref={mergedRef}
       qa={qa ?? 'Tree'}
       mods={mods}
       styles={baseStyles}
       style={heightStyle}
     >
       {visibleNodes.map((node) => {
-        const data = nodesByKey.get(String(node.key));
+        const keyStr = String(node.key);
+        const data = nodesByKey.get(keyStr);
         if (!data) return null;
-        const isExpanded = state.expandedKeys.has(node.key);
         return (
           <TreeNode
             key={node.key}
@@ -450,11 +373,10 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
             data={data}
             state={state}
             isCheckable={isCheckable}
-            isExpanded={isExpanded}
-            isChecked={checkbox.checkedSet.has(String(node.key))}
-            isIndeterminate={checkbox.halfCheckedSet.has(String(node.key))}
-            isLoading={loadDataController.loadingKeys.has(String(node.key))}
-            isBlockNode={blockNode}
+            isExpanded={state.expandedKeys.has(node.key)}
+            isChecked={checkbox.checkedSet.has(keyStr)}
+            isIndeterminate={checkbox.halfCheckedSet.has(keyStr)}
+            isLoading={loadDataController.loadingKeys.has(keyStr)}
             rowStyles={rowStyles}
             onToggleChecked={checkbox.toggle}
           />
@@ -465,6 +387,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
 }
 
 const _Tree = forwardRef(TreeBase);
+_Tree.displayName = 'Tree';
 
 /**
  * Hierarchical data display with optional checkboxes, single/multi

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -260,10 +260,24 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
 
   const handleSelectionChange = useEvent((selection: Selection) => {
     if (!onSelect) return;
-    const arr: Key[] =
-      selection === 'all'
-        ? Array.from(nodesByKey.keys())
-        : Array.from(selection);
+    let arr: Key[];
+    if (selection === 'all') {
+      /**
+       * `'all'` (e.g. Ctrl+A in `multiple` mode) means "every visible
+       * row". `nodesByKey` is the full `treeData` index and would leak
+       * keys hidden under collapsed parents — use the collection's
+       * `getKeys()` instead, which only walks expanded subtrees.
+       * Filter to `item` nodes so we don't emit synthetic collection
+       * entries (e.g. sections) as selected keys.
+       */
+      arr = [];
+      for (const key of state.collection.getKeys()) {
+        const node = state.collection.getItem(key);
+        if (node && node.type === 'item') arr.push(key);
+      }
+    } else {
+      arr = Array.from(selection);
+    }
     /**
      * Stately's `onSelectionChange` hands us the *next* selection only —
      * we don't get a "toggled key" diff for free. For `single` mode we

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -4,7 +4,7 @@ import { useTree } from 'react-aria';
 import { Item, useTreeState } from 'react-stately';
 
 import { useEvent } from '../../../_internal/hooks';
-import { mergeProps } from '../../../utils/react';
+import { mergeProps, mergeRefs } from '../../../utils/react';
 import { extractStyles } from '../../../utils/styles';
 
 import { TreeElement } from './styled';
@@ -186,7 +186,11 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     onCheck,
   });
 
-  const loadDataController = useLoadData({ nodesByKey, loadData });
+  const loadDataController = useLoadData({
+    nodesByKey,
+    loadData,
+    initialExpandedKeys: effectiveExpandedKeys ?? effectiveDefaultExpandedKeys,
+  });
 
   /**
    * Tracks the previously-expanded set so we can diff against the next set
@@ -195,9 +199,15 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
    * ref is the only source for the previous state — `effectiveExpandedKeys`
    * is `undefined` and would otherwise produce an empty `previous` set,
    * mis-identifying every toggle.
+   *
+   * Must mirror what `useTreeState` was initialized with (the *effective*
+   * sets, which include `autoExpandParent` ancestors). Using the raw
+   * `defaultExpandedKeys` here would make the first toggle in uncontrolled
+   * mode diff against an undersized previous set, reporting auto-expanded
+   * ancestors as newly expanded.
    */
   const previousExpandedRef = useRef<Set<Key>>(
-    new Set<Key>(expandedKeys ?? defaultExpandedKeys ?? []),
+    new Set<Key>(effectiveExpandedKeys ?? effectiveDefaultExpandedKeys ?? []),
   );
 
   /**
@@ -394,14 +404,22 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     [height],
   );
 
+  /**
+   * Merge the consumer's forwarded ref with our internal `treeRef`. Both
+   * must point at the same DOM node: `useTree` reads `treeRef.current` for
+   * keyboard navigation/focus management, and consumers expect the
+   * forwarded `ref` to receive the element too.
+   */
+  const mergedRef = useMemo(() => mergeRefs(ref, treeRef), [ref]);
+
   const elementProps = mergeProps(gridProps, {
-    ref: ref ?? treeRef,
+    ref: mergedRef,
   });
 
   return (
     <TreeElement
       {...elementProps}
-      ref={ref ?? treeRef}
+      ref={mergedRef}
       qa={qa ?? 'Tree'}
       mods={mods}
       styles={baseStyles}

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -246,6 +246,7 @@ function TreeNodeInner(props: TreeNodeProps) {
       <TreeRowItem
         {...gridCellProps}
         isSelected={isSelected}
+        isDisabled={isDisabled}
         mods={itemMods}
         icon={toggleNode}
         prefix={checkboxNode}

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -1,14 +1,21 @@
 import { memo, useMemo, useRef } from 'react';
-import { useButton, useTreeItem } from 'react-aria';
+import { useTreeItem } from 'react-aria';
 
 import { useEvent } from '../../../_internal/hooks';
 import { DirectionIcon, LoadingIcon } from '../../../icons';
 import { mergeProps } from '../../../utils/react';
 import { Checkbox } from '../../fields/Checkbox/Checkbox';
 
-import { TreeNodeRow } from './styled';
+import {
+  TreeNodeCheckboxWrapper,
+  TreeNodeRow,
+  TreeNodeToggle,
+  TreeNodeTogglePlaceholder,
+  TreeRowItem,
+} from './styled';
 
 import type { Node } from '@react-types/shared';
+import type { Styles } from '@tenphi/tasty';
 import type {
   CSSProperties,
   KeyboardEvent as ReactKeyboardEvent,
@@ -39,6 +46,9 @@ export interface TreeNodeProps {
 
   /** Toggle this row's checkbox (cascades). */
   onToggleChecked: (key: string) => void;
+
+  /** Styles applied to the visible row (`TreeRowItem`). */
+  rowStyles?: Styles;
 }
 
 const ROW_LEVEL_OFFSET = 0; // root nodes start at level 0
@@ -55,20 +65,15 @@ function TreeNodeInner(props: TreeNodeProps) {
     isLoading,
     isBlockNode,
     onToggleChecked,
+    rowStyles,
   } = props;
 
   const rowRef = useRef<HTMLDivElement>(null);
-  const toggleRef = useRef<HTMLButtonElement>(null);
 
   const { rowProps, gridCellProps, expandButtonProps } = useTreeItem(
     { node },
     state,
     rowRef,
-  );
-
-  const { buttonProps: nativeToggleButtonProps } = useButton(
-    expandButtonProps,
-    toggleRef,
   );
 
   const isDisabled = state.disabledKeys.has(node.key);
@@ -93,9 +98,8 @@ function TreeNodeInner(props: TreeNodeProps) {
     onToggleChecked(String(node.key));
   });
 
-  const mods = useMemo(
+  const rowMods = useMemo(
     () => ({
-      selected: isSelected,
       checked: isChecked,
       indeterminate: isIndeterminate,
       expanded: isExpanded,
@@ -106,7 +110,6 @@ function TreeNodeInner(props: TreeNodeProps) {
       'has-checkbox': isRowCheckable,
     }),
     [
-      isSelected,
       isChecked,
       isIndeterminate,
       isExpanded,
@@ -116,6 +119,18 @@ function TreeNodeInner(props: TreeNodeProps) {
       isBlockNode,
       isRowCheckable,
     ],
+  );
+
+  const itemMods = useMemo(
+    () => ({
+      checked: isChecked,
+      indeterminate: isIndeterminate,
+      expanded: isExpanded,
+      loading: isLoading,
+      leaf: isLeaf,
+      'has-checkbox': isRowCheckable,
+    }),
+    [isChecked, isIndeterminate, isExpanded, isLoading, isLeaf, isRowCheckable],
   );
 
   /**
@@ -149,50 +164,63 @@ function TreeNodeInner(props: TreeNodeProps) {
     'aria-checked': ariaChecked as string | boolean | undefined,
   });
 
+  /**
+   * Always render a toggle slot — even for leaf rows — so siblings
+   * at the same indent level visually align. Leaves get a
+   * non-interactive placeholder (a plain div) so user clicks can't
+   * trigger anything.
+   */
+  const toggleNode = isLeaf ? (
+    <TreeNodeTogglePlaceholder aria-hidden data-element="Toggle" />
+  ) : (
+    <TreeNodeToggle {...expandButtonProps} tabIndex={-1} data-element="Toggle">
+      {isLoading ? (
+        <LoadingIcon />
+      ) : (
+        <DirectionIcon to={isExpanded ? 'bottom' : 'right'} />
+      )}
+    </TreeNodeToggle>
+  );
+
+  const checkboxNode = isRowCheckable ? (
+    <TreeNodeCheckboxWrapper
+      data-element="Checkbox"
+      role="presentation"
+      onClick={handleCheckboxClick}
+      onKeyDown={handleCheckboxClick}
+    >
+      <Checkbox
+        isSelected={isChecked}
+        isIndeterminate={isIndeterminate}
+        isDisabled={isDisabled || data.isCheckboxDisabled}
+        aria-label={
+          typeof data.title === 'string' ? data.title : String(node.key)
+        }
+        // @ts-expect-error AriaCheckboxProps loses `onChange` where InputDOMProps overlaps (react-types).
+        onChange={handleCheckboxChange}
+      />
+    </TreeNodeCheckboxWrapper>
+  ) : null;
+
   return (
     <TreeNodeRow
       {...finalRowProps}
       ref={rowRef}
-      mods={mods}
+      mods={rowMods}
       style={levelStyle}
       data-element="Row"
       data-qa-key={String(node.key)}
     >
-      <div {...gridCellProps} data-element="Cell">
-        <button
-          {...nativeToggleButtonProps}
-          ref={toggleRef}
-          type="button"
-          tabIndex={-1}
-          data-element="Toggle"
-        >
-          {isLoading ? (
-            <LoadingIcon />
-          ) : (
-            <DirectionIcon to={isExpanded ? 'bottom' : 'right'} />
-          )}
-        </button>
-        {isRowCheckable ? (
-          <span
-            data-element="Checkbox"
-            role="presentation"
-            onClick={handleCheckboxClick}
-            onKeyDown={handleCheckboxClick}
-          >
-            <Checkbox
-              isSelected={isChecked}
-              isIndeterminate={isIndeterminate}
-              isDisabled={isDisabled || data.isCheckboxDisabled}
-              aria-label={
-                typeof data.title === 'string' ? data.title : String(node.key)
-              }
-              // @ts-expect-error AriaCheckboxProps loses `onChange` where InputDOMProps overlaps (react-types).
-              onChange={handleCheckboxChange}
-            />
-          </span>
-        ) : null}
-        <span data-element="Title">{data.title}</span>
-      </div>
+      <TreeRowItem
+        {...gridCellProps}
+        isSelected={isSelected}
+        mods={itemMods}
+        icon={toggleNode}
+        prefix={checkboxNode}
+        styles={rowStyles}
+      >
+        {data.title}
+      </TreeRowItem>
     </TreeNodeRow>
   );
 }

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -1,0 +1,200 @@
+import { memo, useMemo, useRef } from 'react';
+import { useButton, useTreeItem } from 'react-aria';
+
+import { useEvent } from '../../../_internal/hooks';
+import { DirectionIcon, LoadingIcon } from '../../../icons';
+import { mergeProps } from '../../../utils/react';
+import { Checkbox } from '../../fields/Checkbox/Checkbox';
+
+import { TreeNodeRow } from './styled';
+
+import type { Node } from '@react-types/shared';
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from 'react';
+import type { TreeState } from 'react-stately';
+import type { CubeTreeNodeData } from './types';
+
+export interface TreeNodeProps {
+  node: Node<CubeTreeNodeData>;
+  /** The original `CubeTreeNodeData` for this row, looked up by key. */
+  data: CubeTreeNodeData;
+  state: TreeState<CubeTreeNodeData>;
+
+  /** Whether the tree as a whole renders checkboxes. */
+  isCheckable: boolean;
+  /** Whether this row is currently expanded. */
+  isExpanded: boolean;
+  /** Whether the row is in an indeterminate (half-checked) state. */
+  isIndeterminate: boolean;
+  /** Whether the row is fully checked. */
+  isChecked: boolean;
+  /** Whether `loadData` is currently fetching this row's children. */
+  isLoading: boolean;
+  /** Whether the entire tree is `blockNode`. */
+  isBlockNode: boolean;
+
+  /** Toggle this row's checkbox (cascades). */
+  onToggleChecked: (key: string) => void;
+}
+
+const ROW_LEVEL_OFFSET = 0; // root nodes start at level 0
+
+function TreeNodeInner(props: TreeNodeProps) {
+  const {
+    node,
+    data,
+    state,
+    isCheckable,
+    isExpanded,
+    isIndeterminate,
+    isChecked,
+    isLoading,
+    isBlockNode,
+    onToggleChecked,
+  } = props;
+
+  const rowRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  const { rowProps, gridCellProps, expandButtonProps } = useTreeItem(
+    { node },
+    state,
+    rowRef,
+  );
+
+  const { buttonProps: nativeToggleButtonProps } = useButton(
+    expandButtonProps,
+    toggleRef,
+  );
+
+  const isDisabled = state.disabledKeys.has(node.key);
+  const isSelected = state.selectionManager.isSelected(node.key);
+  /**
+   * `useTreeItem` reports `aria-expanded` only on rows that *can* expand
+   * (i.e. have child nodes in the collection). For lazy rows with no
+   * children loaded yet but `isLeaf !== true`, we still want to render
+   * a toggle so the consumer can fire `loadData`.
+   */
+  const isLeaf =
+    data.isLeaf === true || (data.isLeaf !== false && !node.hasChildNodes);
+  const isRowCheckable = isCheckable && data.isCheckable !== false;
+
+  const handleCheckboxClick = useEvent(
+    (e: ReactMouseEvent | ReactKeyboardEvent) => {
+      e.stopPropagation();
+    },
+  );
+
+  const handleCheckboxChange = useEvent(() => {
+    onToggleChecked(String(node.key));
+  });
+
+  const mods = useMemo(
+    () => ({
+      selected: isSelected,
+      checked: isChecked,
+      indeterminate: isIndeterminate,
+      expanded: isExpanded,
+      disabled: isDisabled,
+      loading: isLoading,
+      leaf: isLeaf,
+      'block-node': isBlockNode,
+      'has-checkbox': isRowCheckable,
+    }),
+    [
+      isSelected,
+      isChecked,
+      isIndeterminate,
+      isExpanded,
+      isDisabled,
+      isLoading,
+      isLeaf,
+      isBlockNode,
+      isRowCheckable,
+    ],
+  );
+
+  /**
+   * Indent each row by its depth. `node.level` is 0-based at the root.
+   * Pushed down via a CSS custom property so the styled element can
+   * compute padding without re-extracting styles per row.
+   */
+  const levelStyle = useMemo<CSSProperties>(
+    () => ({
+      ['--tree-level' as keyof CSSProperties]: String(
+        (node.level ?? ROW_LEVEL_OFFSET) - ROW_LEVEL_OFFSET,
+      ),
+    }),
+    [node.level],
+  );
+
+  /**
+   * `aria-checked` for treegrid rows that act as multi-state checkboxes.
+   * Only set when the tree is checkable, so we don't pollute the row
+   * with checkbox semantics in select-only mode.
+   */
+  const ariaChecked: ReactNode = isRowCheckable
+    ? isIndeterminate
+      ? 'mixed'
+      : isChecked
+        ? 'true'
+        : 'false'
+    : undefined;
+
+  const finalRowProps = mergeProps(rowProps, {
+    'aria-checked': ariaChecked as string | boolean | undefined,
+  });
+
+  return (
+    <TreeNodeRow
+      {...finalRowProps}
+      ref={rowRef}
+      mods={mods}
+      style={levelStyle}
+      data-element="Row"
+      data-qa-key={String(node.key)}
+    >
+      <div {...gridCellProps} data-element="Cell">
+        <button
+          {...nativeToggleButtonProps}
+          ref={toggleRef}
+          type="button"
+          tabIndex={-1}
+          data-element="Toggle"
+        >
+          {isLoading ? (
+            <LoadingIcon />
+          ) : (
+            <DirectionIcon to={isExpanded ? 'bottom' : 'right'} />
+          )}
+        </button>
+        {isRowCheckable ? (
+          <span
+            data-element="Checkbox"
+            role="presentation"
+            onClick={handleCheckboxClick}
+            onKeyDown={handleCheckboxClick}
+          >
+            <Checkbox
+              isSelected={isChecked}
+              isIndeterminate={isIndeterminate}
+              isDisabled={isDisabled || data.isCheckboxDisabled}
+              aria-label={
+                typeof data.title === 'string' ? data.title : String(node.key)
+              }
+              // @ts-expect-error AriaCheckboxProps loses `onChange` where InputDOMProps overlaps (react-types).
+              onChange={handleCheckboxChange}
+            />
+          </span>
+        ) : null}
+        <span data-element="Title">{data.title}</span>
+      </div>
+    </TreeNodeRow>
+  );
+}
+
+export const TreeNode = memo(TreeNodeInner);

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, useRef } from 'react';
-import { useTreeItem } from 'react-aria';
+import { useHover, useTreeItem } from 'react-aria';
 
 import { useEvent } from '../../../_internal/hooks';
 import { DirectionIcon, LoadingIcon } from '../../../icons';
@@ -70,7 +70,7 @@ function TreeNodeInner(props: TreeNodeProps) {
 
   const rowRef = useRef<HTMLDivElement>(null);
 
-  const { rowProps, gridCellProps, expandButtonProps } = useTreeItem(
+  const { rowProps, gridCellProps, expandButtonProps, isPressed } = useTreeItem(
     { node },
     state,
     rowRef,
@@ -78,6 +78,25 @@ function TreeNodeInner(props: TreeNodeProps) {
 
   const isDisabled = state.disabledKeys.has(node.key);
   const isSelected = state.selectionManager.isSelected(node.key);
+
+  /**
+   * `useTreeItem` doesn't track hover. The `Item` variant we extend
+   * (`default.item`) uses the `hovered` mod (compiled to
+   * `[data-hovered]`), so we run `useHover` ourselves and wire its
+   * `hoverProps` into the row.
+   */
+  const { hoverProps, isHovered } = useHover({ isDisabled });
+  /**
+   * React Aria uses a roving-tabindex "virtual focus" model for treegrid:
+   * only the row matching `selectionManager.focusedKey` is tabbable, and
+   * arrow-key navigation updates that key instead of moving DOM focus
+   * between every row. No `data-focused` / `:focus-visible` lands on the
+   * row, so we mirror the focused key as a `focused` mod on the item
+   * to make it stylable.
+   */
+  const isFocused =
+    state.selectionManager.isFocused &&
+    state.selectionManager.focusedKey === node.key;
   /**
    * `useTreeItem` reports `aria-expanded` only on rows that *can* expand
    * (i.e. have child nodes in the collection). For lazy rows with no
@@ -128,9 +147,22 @@ function TreeNodeInner(props: TreeNodeProps) {
       expanded: isExpanded,
       loading: isLoading,
       leaf: isLeaf,
+      focused: isFocused,
+      hovered: isHovered,
+      pressed: isPressed,
       'has-checkbox': isRowCheckable,
     }),
-    [isChecked, isIndeterminate, isExpanded, isLoading, isLeaf, isRowCheckable],
+    [
+      isChecked,
+      isIndeterminate,
+      isExpanded,
+      isLoading,
+      isLeaf,
+      isFocused,
+      isHovered,
+      isPressed,
+      isRowCheckable,
+    ],
   );
 
   /**
@@ -160,7 +192,7 @@ function TreeNodeInner(props: TreeNodeProps) {
         : 'false'
     : undefined;
 
-  const finalRowProps = mergeProps(rowProps, {
+  const finalRowProps = mergeProps(rowProps, hoverProps, {
     'aria-checked': ariaChecked as string | boolean | undefined,
   });
 

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -16,14 +16,13 @@ import {
 
 import type { Node } from '@react-types/shared';
 import type { Styles } from '@tenphi/tasty';
-import type {
-  CSSProperties,
-  KeyboardEvent as ReactKeyboardEvent,
-  MouseEvent as ReactMouseEvent,
-  ReactNode,
-} from 'react';
+import type { CSSProperties, SyntheticEvent } from 'react';
 import type { TreeState } from 'react-stately';
 import type { CubeTreeNodeData } from './types';
+
+const stopPropagation = (e: SyntheticEvent) => {
+  e.stopPropagation();
+};
 
 export interface TreeNodeProps {
   node: Node<CubeTreeNodeData>;
@@ -41,8 +40,6 @@ export interface TreeNodeProps {
   isChecked: boolean;
   /** Whether `loadData` is currently fetching this row's children. */
   isLoading: boolean;
-  /** Whether the entire tree is `blockNode`. */
-  isBlockNode: boolean;
 
   /** Toggle this row's checkbox (cascades). */
   onToggleChecked: (key: string) => void;
@@ -50,8 +47,6 @@ export interface TreeNodeProps {
   /** Styles applied to the visible row (`TreeRowItem`). */
   rowStyles?: Styles;
 }
-
-const ROW_LEVEL_OFFSET = 0; // root nodes start at level 0
 
 function TreeNodeInner(props: TreeNodeProps) {
   const {
@@ -63,7 +58,6 @@ function TreeNodeInner(props: TreeNodeProps) {
     isIndeterminate,
     isChecked,
     isLoading,
-    isBlockNode,
     onToggleChecked,
     rowStyles,
   } = props;
@@ -79,112 +73,59 @@ function TreeNodeInner(props: TreeNodeProps) {
   const isDisabled = state.disabledKeys.has(node.key);
   const isSelected = state.selectionManager.isSelected(node.key);
 
-  /**
-   * `useTreeItem` doesn't track hover. The `Item` variant we extend
-   * (`default.item`) uses the `hovered` mod (compiled to
-   * `[data-hovered]`), so we run `useHover` ourselves and wire its
-   * `hoverProps` into the row.
-   */
+  // `useTreeItem` doesn't track hover; we need it for the `hovered` mod.
   const { hoverProps, isHovered } = useHover({ isDisabled });
-  /**
-   * React Aria uses a roving-tabindex "virtual focus" model for treegrid:
-   * only the row matching `selectionManager.focusedKey` is tabbable, and
-   * arrow-key navigation updates that key instead of moving DOM focus
-   * between every row. No `data-focused` / `:focus-visible` lands on the
-   * row, so we mirror the focused key as a `focused` mod on the item
-   * to make it stylable.
-   */
+  // React Aria's treegrid uses roving tabindex, so no `data-focused`
+  // attribute lands on the row — mirror it as a mod manually.
   const isFocused =
     state.selectionManager.isFocused &&
     state.selectionManager.focusedKey === node.key;
-  /**
-   * `useTreeItem` reports `aria-expanded` only on rows that *can* expand
-   * (i.e. have child nodes in the collection). For lazy rows with no
-   * children loaded yet but `isLeaf !== true`, we still want to render
-   * a toggle so the consumer can fire `loadData`.
-   */
+  // For lazy rows with no children yet, still render a toggle unless
+  // explicitly marked as leaf.
   const isLeaf =
     data.isLeaf === true || (data.isLeaf !== false && !node.hasChildNodes);
   const isRowCheckable = isCheckable && data.isCheckable !== false;
-
-  const handleCheckboxClick = useEvent(
-    (e: ReactMouseEvent | ReactKeyboardEvent) => {
-      e.stopPropagation();
-    },
-  );
 
   const handleCheckboxChange = useEvent(() => {
     onToggleChecked(String(node.key));
   });
 
-  const rowMods = useMemo(
+  const sharedMods = useMemo(
     () => ({
       checked: isChecked,
       indeterminate: isIndeterminate,
       expanded: isExpanded,
-      disabled: isDisabled,
       loading: isLoading,
       leaf: isLeaf,
-      'block-node': isBlockNode,
       'has-checkbox': isRowCheckable,
     }),
-    [
-      isChecked,
-      isIndeterminate,
-      isExpanded,
-      isDisabled,
-      isLoading,
-      isLeaf,
-      isBlockNode,
-      isRowCheckable,
-    ],
+    [isChecked, isIndeterminate, isExpanded, isLoading, isLeaf, isRowCheckable],
+  );
+
+  const rowMods = useMemo(
+    () => ({ ...sharedMods, disabled: isDisabled }),
+    [sharedMods, isDisabled],
   );
 
   const itemMods = useMemo(
     () => ({
-      checked: isChecked,
-      indeterminate: isIndeterminate,
-      expanded: isExpanded,
-      loading: isLoading,
-      leaf: isLeaf,
+      ...sharedMods,
       focused: isFocused,
       hovered: isHovered,
       pressed: isPressed,
-      'has-checkbox': isRowCheckable,
     }),
-    [
-      isChecked,
-      isIndeterminate,
-      isExpanded,
-      isLoading,
-      isLeaf,
-      isFocused,
-      isHovered,
-      isPressed,
-      isRowCheckable,
-    ],
+    [sharedMods, isFocused, isHovered, isPressed],
   );
 
-  /**
-   * Indent each row by its depth. `node.level` is 0-based at the root.
-   * Pushed down via a CSS custom property so the styled element can
-   * compute padding without re-extracting styles per row.
-   */
   const levelStyle = useMemo<CSSProperties>(
     () => ({
-      ['--tree-level' as keyof CSSProperties]: String(
-        (node.level ?? ROW_LEVEL_OFFSET) - ROW_LEVEL_OFFSET,
-      ),
+      ['--tree-level' as keyof CSSProperties]: String(node.level ?? 0),
     }),
     [node.level],
   );
 
-  /**
-   * `aria-checked` for treegrid rows that act as multi-state checkboxes.
-   * Only set when the tree is checkable, so we don't pollute the row
-   * with checkbox semantics in select-only mode.
-   */
-  const ariaChecked: ReactNode = isRowCheckable
+  // Only emit `aria-checked` when the tree is in checkable mode.
+  const ariaChecked: 'mixed' | 'true' | 'false' | undefined = isRowCheckable
     ? isIndeterminate
       ? 'mixed'
       : isChecked
@@ -193,15 +134,10 @@ function TreeNodeInner(props: TreeNodeProps) {
     : undefined;
 
   const finalRowProps = mergeProps(rowProps, hoverProps, {
-    'aria-checked': ariaChecked as string | boolean | undefined,
+    'aria-checked': ariaChecked,
   });
 
-  /**
-   * Always render a toggle slot — even for leaf rows — so siblings
-   * at the same indent level visually align. Leaves get a
-   * non-interactive placeholder (a plain div) so user clicks can't
-   * trigger anything.
-   */
+  // Leaf rows get a placeholder so sibling indents align.
   const toggleNode = isLeaf ? (
     <TreeNodeTogglePlaceholder aria-hidden data-element="Toggle" />
   ) : (
@@ -218,8 +154,8 @@ function TreeNodeInner(props: TreeNodeProps) {
     <TreeNodeCheckboxWrapper
       data-element="Checkbox"
       role="presentation"
-      onClick={handleCheckboxClick}
-      onKeyDown={handleCheckboxClick}
+      onClick={stopPropagation}
+      onKeyDown={stopPropagation}
     >
       <Checkbox
         isSelected={isChecked}

--- a/src/components/content/Tree/index.ts
+++ b/src/components/content/Tree/index.ts
@@ -1,0 +1,10 @@
+export { Tree } from './Tree';
+export type {
+  CubeTreeProps,
+  CubeTreeNodeData,
+  TreeOnCheckInfo,
+  TreeOnExpandInfo,
+  TreeOnSelectInfo,
+  TreeLoadDataNode,
+  TreeSelectionMode,
+} from './types';

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -1,0 +1,157 @@
+import { Styles, tasty } from '@tenphi/tasty';
+
+import { Action } from '../../actions/Action/Action';
+import { Item } from '../Item';
+
+/**
+ * Tree root.
+ *
+ * Renders as `role="treegrid"` (set on `gridProps` from `useTree`).
+ *
+ * Tree-wide modifiers (set on `TreeElement` itself):
+ * - `has-height` — paired with `--tree-height` on inline `style`
+ *   when the consumer passes a numeric `height` prop.
+ * - `block-node` — propagated from the Tree-level `blockNode` prop
+ *   to every row through the root state context.
+ */
+export const TreeElement = tasty({
+  qa: 'Tree',
+  styles: {
+    display: 'flex',
+    flow: 'column',
+    width: '100%',
+    height: { '': 'auto', 'has-height': 'fixed $tree-height' },
+    flexGrow: { '': 1, 'has-height': 0 },
+    flexShrink: { '': 1, 'has-height': 0 },
+    flexBasis: { '': 0, 'has-height': 'auto' },
+    minHeight: 0,
+    overflow: 'auto',
+    scrollbar: 'thin',
+    fill: '#clear',
+    color: '#dark',
+    transition: 'theme',
+    outline: 0,
+    gap: '1bw',
+    padding: '.5x',
+  },
+});
+
+/**
+ * Per-row wrapper carrying `role="row"`, `rowProps` from
+ * `useTreeItem`, and the `--tree-level` CSS custom property used by
+ * `TreeRowItem` to compute its left padding.
+ *
+ * Has no visual styles of its own — the row's appearance lives on
+ * the inner `TreeRowItem` (which extends `Item`). Hover, focus, and
+ * focus-visible state set on this wrapper by React Aria are read by
+ * `TreeRowItem` via `@parent(...)` selectors.
+ */
+export const TreeNodeRow = tasty({
+  qa: 'TreeRow',
+  styles: {
+    display: 'block',
+    width: '100%',
+    outline: 0,
+  },
+});
+
+/**
+ * The visible row: an `Item` extension that owns layout (full-width,
+ * tree indent) and the interaction styles. Hover/focus pulls from
+ * the parent `TreeNodeRow` (`@parent(...)`) since the row is what
+ * React Aria attaches `data-hovered` / `data-focused` /
+ * `data-focus-visible` to.
+ */
+export const TreeRowItem = tasty(Item, {
+  qa: 'TreeItem',
+  type: 'neutral',
+  size: 'small',
+  as: 'div',
+  styles: {
+    width: '100%',
+    /**
+     * Per-level indent. `$tree-indent` is a local token that reads
+     * `--tree-level` (set inline on the parent `TreeNodeRow`) with a
+     * `0` fallback. Using `padding` shorthand (instead of
+     * `paddingInlineStart`) so it overrides `Item`'s default
+     * `padding: 0` reliably — a longhand override on a shorthand
+     * loses to it in the cascade when both are emitted from the same
+     * declaration block.
+     */
+    padding: 'left ($tree-indent * 1x)',
+    '$tree-indent': '($tree-level, 0)',
+    cursor: {
+      '': 'pointer',
+      '@parent(disabled) | disabled': 'not-allowed',
+    },
+    fill: {
+      '': '#clear',
+      '@parent(hovered) | @parent(focused)': '#dark.04',
+      selected: '#primary.10',
+      'selected & (@parent(hovered) | @parent(focused))': '#primary.15',
+      disabled: '#clear',
+    },
+    color: {
+      '': '#dark',
+      '@parent(disabled) | disabled': '#dark-04',
+    },
+    outline: {
+      '': '#clear',
+      '@parent(focus-visible)': '#purple-03',
+    },
+    outlineOffset: 0,
+    transition: 'theme',
+  },
+});
+
+/**
+ * Wraps the checkbox sitting in `Item`'s `prefix` slot. `Item`'s
+ * built-in Prefix padding collapses to `0` whenever there's an icon
+ * (which is always true for tree rows because the toggle/placeholder
+ * occupies the icon slot). We re-introduce a small inline gap on
+ * both sides so the checkbox isn't flush against the chevron and the
+ * title.
+ */
+export const TreeNodeCheckboxWrapper = tasty({
+  qa: 'TreeNodeCheckboxWrapper',
+  styles: {
+    display: 'grid',
+    placeItems: 'center',
+    placeContent: 'center',
+    padding: '0 1x',
+  },
+});
+
+const TOGGLE_BASE_STYLES: Styles = {
+  display: 'grid',
+  placeItems: 'center',
+  placeContent: 'center',
+  width: '3x',
+  height: '3x',
+  radius: true,
+  transition: 'theme',
+};
+
+/**
+ * Chevron toggle button placed in `Item`'s `icon` slot. Spreads
+ * `expandButtonProps` from `useTreeItem` (an AriaButtonProps) and
+ * stops the press from bubbling to the row's selection handler via
+ * React Aria's PressResponder.
+ */
+export const TreeNodeToggle = tasty(Action, {
+  qa: 'TreeNodeToggle',
+  styles: {
+    ...TOGGLE_BASE_STYLES,
+    color: { '': '#dark-02', ':hover': '#dark' },
+    fill: { '': '#clear', ':hover': '#dark.04' },
+  },
+});
+
+/**
+ * Non-interactive placeholder that occupies the same footprint as
+ * `TreeNodeToggle` so leaf rows visually align with siblings that
+ * have a chevron.
+ */
+export const TreeNodeTogglePlaceholder = tasty({
+  styles: TOGGLE_BASE_STYLES,
+});

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -42,9 +42,7 @@ export const TreeElement = tasty({
  * `TreeRowItem` to compute its left padding.
  *
  * Has no visual styles of its own — the row's appearance lives on
- * the inner `TreeRowItem` (which extends `Item`). Hover, focus, and
- * focus-visible state set on this wrapper by React Aria are read by
- * `TreeRowItem` via `@parent(...)` selectors.
+ * the inner `TreeRowItem` (which extends `Item`).
  */
 export const TreeNodeRow = tasty({
   qa: 'TreeRow',
@@ -57,14 +55,17 @@ export const TreeNodeRow = tasty({
 
 /**
  * The visible row: an `Item` extension that owns layout (full-width,
- * tree indent) and the interaction styles. Hover/focus pulls from
- * the parent `TreeNodeRow` (`@parent(...)`) since the row is what
- * React Aria attaches `data-hovered` / `data-focused` /
- * `data-focus-visible` to.
+ * tree indent) only. Color treatment is delegated to the
+ * `default.item` variant (see `DEFAULT_ITEM_STYLES` in
+ * `data/item-themes.ts`) so the Tree row matches the canonical Item
+ * look out of the box. `hovered` / `focused` / `pressed` mods are
+ * propagated from `TreeNode` because react-aria's treegrid uses a
+ * roving-tabindex "virtual focus" model and never sets those data
+ * attributes itself.
  */
 export const TreeRowItem = tasty(Item, {
   qa: 'TreeItem',
-  type: 'neutral',
+  type: 'item',
   size: 'small',
   as: 'div',
   styles: {
@@ -82,25 +83,8 @@ export const TreeRowItem = tasty(Item, {
     '$tree-indent': '($tree-level, 0)',
     cursor: {
       '': 'pointer',
-      '@parent(disabled) | disabled': 'not-allowed',
+      disabled: 'not-allowed',
     },
-    fill: {
-      '': '#clear',
-      '@parent(hovered) | @parent(focused)': '#dark.04',
-      selected: '#primary.10',
-      'selected & (@parent(hovered) | @parent(focused))': '#primary.15',
-      disabled: '#clear',
-    },
-    color: {
-      '': '#dark',
-      '@parent(disabled) | disabled': '#dark-04',
-    },
-    outline: {
-      '': '#clear',
-      '@parent(focus-visible)': '#purple-03',
-    },
-    outlineOffset: 0,
-    transition: 'theme',
   },
 });
 

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -69,6 +69,13 @@ export const TreeRowItem = tasty(Item, {
   size: 'small',
   as: 'div',
   styles: {
+    /**
+     * `Item` is `inline-grid` by default, which leaves baseline
+     * descender space below the row inside the block-level
+     * `TreeNodeRow` and visually inflates the gap between rows
+     * past the intended `1bw`. Force block-level grid here.
+     */
+    display: 'grid',
     width: '100%',
     /**
      * Per-level indent. `$tree-indent` is a local token that reads

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -11,8 +11,6 @@ import { Item } from '../Item';
  * Tree-wide modifiers (set on `TreeElement` itself):
  * - `has-height` — paired with `--tree-height` on inline `style`
  *   when the consumer passes a numeric `height` prop.
- * - `block-node` — propagated from the Tree-level `blockNode` prop
- *   to every row through the root state context.
  */
 export const TreeElement = tasty({
   qa: 'Tree',

--- a/src/components/content/Tree/tree-index.ts
+++ b/src/components/content/Tree/tree-index.ts
@@ -1,0 +1,41 @@
+import type { CubeTreeNodeData } from './types';
+
+/**
+ * Map of `key -> { node, parentKey, childKeys }` for fast cascading lookups.
+ *
+ * Built from the public `treeData` rather than from React Stately's
+ * collection, because we need the consumer's original (controlled)
+ * shape to derive parent/child relationships and to call back with the
+ * actual `node` objects.
+ *
+ * Shared between `Tree.tsx` (for `nodesByKey` / `parentOf`) and
+ * `useCheckboxTree` (cascading checked state) so a single tree walk
+ * powers all three maps.
+ */
+export interface TreeIndex {
+  byKey: Map<string, CubeTreeNodeData>;
+  parentOf: Map<string, string | null>;
+  childrenOf: Map<string, string[]>;
+}
+
+export function buildTreeIndex(treeData: CubeTreeNodeData[]): TreeIndex {
+  const byKey = new Map<string, CubeTreeNodeData>();
+  const parentOf = new Map<string, string | null>();
+  const childrenOf = new Map<string, string[]>();
+
+  const visit = (nodes: CubeTreeNodeData[], parent: string | null) => {
+    for (const node of nodes) {
+      byKey.set(node.key, node);
+      parentOf.set(node.key, parent);
+      const childKeys = (node.children ?? []).map((c) => c.key);
+      childrenOf.set(node.key, childKeys);
+      if (node.children) {
+        visit(node.children, node.key);
+      }
+    }
+  };
+
+  visit(treeData, null);
+
+  return { byKey, parentOf, childrenOf };
+}

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -1,0 +1,158 @@
+import type { Key } from '@react-types/shared';
+import type { BaseProps, OuterStyleProps, Styles } from '@tenphi/tasty';
+import type { ReactNode } from 'react';
+
+/** Selection cardinality, mirroring React Aria/Stately's `selectionMode`. */
+export type TreeSelectionMode = 'none' | 'single' | 'multiple';
+
+/**
+ * A single node in the `treeData` array.
+ *
+ * Mirrors AntD's `DataNode` shape but renames boolean flags to the
+ * `is*` convention used throughout `@cube-dev/ui-kit`.
+ */
+export interface CubeTreeNodeData {
+  /** Unique identifier of the node. */
+  key: string;
+  /** Visible label (any `ReactNode`). */
+  title: ReactNode;
+  /** Children. Pass `undefined` together with `isLeaf={false}` for lazy nodes. */
+  children?: CubeTreeNodeData[];
+  /** Force leaf rendering (no expand toggle, no `loadData` call). */
+  isLeaf?: boolean;
+  /** Disable interactions on this row (focus / select / expand / check). */
+  isDisabled?: boolean;
+  /** Disable only the checkbox of this row. */
+  isCheckboxDisabled?: boolean;
+  /**
+   * Per-node `isCheckable` override.
+   *
+   * - `undefined` (default): inherits the tree-level `isCheckable`.
+   * - `false`: hide the checkbox for this row even when the tree is `isCheckable`.
+   */
+  isCheckable?: boolean;
+}
+
+/** Info passed as the second argument to `onCheck`. */
+export interface TreeOnCheckInfo {
+  /** Whether the toggled node ended up checked. */
+  checked: boolean;
+  /** The toggled node. */
+  node: CubeTreeNodeData;
+  /** All currently checked nodes (flat). */
+  checkedNodes: CubeTreeNodeData[];
+  /** Keys of nodes in indeterminate state. */
+  halfCheckedKeys: Key[];
+}
+
+/** Info passed as the second argument to `onExpand`. */
+export interface TreeOnExpandInfo {
+  /** Whether the toggled node ended up expanded. */
+  expanded: boolean;
+  /** The toggled node. */
+  node: CubeTreeNodeData;
+}
+
+/** Info passed as the second argument to `onSelect`. */
+export interface TreeOnSelectInfo {
+  /** Whether the toggled node ended up selected. */
+  selected: boolean;
+  /** The toggled node. */
+  node: CubeTreeNodeData;
+  /** All currently selected nodes (flat). */
+  selectedNodes: CubeTreeNodeData[];
+}
+
+/** Argument shape for the `loadData` callback. */
+export interface TreeLoadDataNode {
+  key: Key;
+  children?: CubeTreeNodeData[];
+}
+
+/**
+ * Public props for the `Tree` component.
+ *
+ * Designed to be a drop-in (modulo `is*` renames) for the AntD `Tree`
+ * `treeData` API, scoped to the v1 feature set.
+ */
+export interface CubeTreeProps extends BaseProps, OuterStyleProps {
+  /** Hierarchical data describing the tree. */
+  treeData: CubeTreeNodeData[];
+
+  /** Render a checkbox in front of every (eligible) row. */
+  isCheckable?: boolean;
+
+  /** Allow row selection. Sugar for `selectionMode="none"` when `false`. */
+  isSelectable?: boolean;
+
+  /** Selection cardinality. Defaults to `'single'`. */
+  selectionMode?: TreeSelectionMode;
+
+  /** Stretch each row to the full width of the container. */
+  blockNode?: boolean;
+
+  /** Disable the entire tree. */
+  isDisabled?: boolean;
+
+  /** Default expanded keys (uncontrolled). */
+  defaultExpandedKeys?: string[];
+  /** Controlled expanded keys. */
+  expandedKeys?: string[];
+  /**
+   * Auto-expand parents of currently expanded keys.
+   *
+   * Useful while filtering: passing matched leaf keys with this flag will
+   * keep their parents expanded as well.
+   */
+  autoExpandParent?: boolean;
+
+  /** Default checked keys (uncontrolled). */
+  defaultCheckedKeys?: string[];
+  /**
+   * Controlled checked keys.
+   *
+   * Accepts either an array of keys or AntD's `{ checked, halfChecked }` shape.
+   */
+  checkedKeys?: string[] | { checked: string[]; halfChecked?: string[] };
+
+  /** Default selected keys (uncontrolled). */
+  defaultSelectedKeys?: string[];
+  /** Controlled selected keys. */
+  selectedKeys?: string[];
+
+  /**
+   * Fixed height in pixels. When omitted, the tree fills the available
+   * vertical space and scrolls internally.
+   */
+  height?: number;
+
+  /**
+   * Async loader called the first time a non-leaf node with no `children`
+   * is expanded. The consumer is expected to merge new children into
+   * `treeData` (typical AntD pattern).
+   */
+  loadData?: (node: TreeLoadDataNode) => Promise<void>;
+
+  /** Called when a node is expanded or collapsed. */
+  onExpand?: (expandedKeys: Key[], info: TreeOnExpandInfo) => void;
+
+  /**
+   * Called when a node is checked or unchecked.
+   *
+   * The first argument is `Key[]` by default; pass `checkedKeys` as
+   * `{ checked, halfChecked }` to receive the same shape back.
+   */
+  onCheck?: (
+    checked: Key[] | { checked: Key[]; halfChecked: Key[] },
+    info: TreeOnCheckInfo,
+  ) => void;
+
+  /** Called when row selection changes. */
+  onSelect?: (selectedKeys: Key[], info: TreeOnSelectInfo) => void;
+
+  /** Override styles for `[data-element="Row"]` (per-row root). */
+  rowStyles?: Styles;
+
+  /** QA selector. */
+  qa?: string;
+}

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -88,9 +88,6 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
   /** Selection cardinality. Defaults to `'single'`. */
   selectionMode?: TreeSelectionMode;
 
-  /** Stretch each row to the full width of the container. */
-  blockNode?: boolean;
-
   /** Disable the entire tree. */
   isDisabled?: boolean;
 
@@ -152,6 +149,9 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
 
   /** Override styles for `[data-element="Row"]` (per-row root). */
   rowStyles?: Styles;
+
+  /** Accessible label for the tree. Defaults to `"Tree"`. */
+  ariaLabel?: string;
 
   /** QA selector. */
   qa?: string;

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -140,7 +140,18 @@ export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
     onCheck,
   } = opts;
 
-  const controlled = normalizeControlledChecked(checkedKeys);
+  /**
+   * Normalize the controlled `checkedKeys` prop into stable `Set` instances.
+   * Memoized on the `checkedKeys` reference so unrelated re-renders don't
+   * invalidate the derivation memo below — `normalizeControlledChecked`
+   * allocates fresh `Set`s each call, which would otherwise force
+   * `deriveCheckedState` to re-walk the entire tree on every render in
+   * controlled mode.
+   */
+  const controlled = useMemo(
+    () => normalizeControlledChecked(checkedKeys),
+    [checkedKeys],
+  );
   const isControlled = controlled != null;
   const wantsObjectShape = checkedKeys != null && !Array.isArray(checkedKeys);
 

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -145,7 +145,14 @@ export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
       };
     }
 
-    if (isControlled) {
+    /**
+     * If the consumer passed the object shape (`{ checked, halfChecked }`),
+     * they own the half-checked set and we use it as-is. With the array
+     * shape we still need to derive `halfChecked` ourselves — the consumer
+     * only provides `checked`, so parents should still light up
+     * indeterminate when only some descendants are checked.
+     */
+    if (isControlled && wantsObjectShape) {
       return {
         checkedSet: new Set(sourceChecked),
         halfCheckedSet: new Set(controlled!.halfChecked),
@@ -209,7 +216,15 @@ export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
     }
 
     return { checkedSet: checked, halfCheckedSet: half };
-  }, [isCheckable, isControlled, sourceChecked, controlled, treeData, index]);
+  }, [
+    isCheckable,
+    isControlled,
+    wantsObjectShape,
+    sourceChecked,
+    controlled,
+    treeData,
+    index,
+  ]);
 
   const toggle = useEvent((key: string) => {
     const node = index.byKey.get(key);

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -1,0 +1,345 @@
+import { useMemo, useState } from 'react';
+
+import { useEvent } from '../../../_internal/hooks';
+
+import type { Key } from '@react-types/shared';
+import type { CubeTreeNodeData, TreeOnCheckInfo } from './types';
+
+export interface UseCheckboxTreeOptions {
+  treeData: CubeTreeNodeData[];
+  isCheckable: boolean;
+  defaultCheckedKeys?: string[];
+  /** Either an array (AntD's default) or `{ checked, halfChecked }`. */
+  checkedKeys?: string[] | { checked: string[]; halfChecked?: string[] };
+  onCheck?: (
+    checked: Key[] | { checked: Key[]; halfChecked: Key[] },
+    info: TreeOnCheckInfo,
+  ) => void;
+}
+
+export interface CheckboxTree {
+  /** Set of keys that are fully checked. */
+  checkedSet: Set<string>;
+  /** Set of keys that are in the indeterminate (half-checked) state. */
+  halfCheckedSet: Set<string>;
+  /** Toggle a key, propagating to descendants and updating ancestors. */
+  toggle: (key: string) => void;
+}
+
+/**
+ * Map of `key -> { node, parentKey, childKeys }` for fast cascading lookups.
+ *
+ * Built from the public `treeData` rather than from React Stately's
+ * collection, because we need the consumer's original (controlled)
+ * shape to derive parent/child relationships and to call back with the
+ * actual `node` objects in `onCheck`'s `info`.
+ */
+interface NodeIndex {
+  byKey: Map<string, CubeTreeNodeData>;
+  parentOf: Map<string, string | null>;
+  childrenOf: Map<string, string[]>;
+}
+
+function buildIndex(treeData: CubeTreeNodeData[]): NodeIndex {
+  const byKey = new Map<string, CubeTreeNodeData>();
+  const parentOf = new Map<string, string | null>();
+  const childrenOf = new Map<string, string[]>();
+
+  const visit = (nodes: CubeTreeNodeData[], parent: string | null) => {
+    for (const node of nodes) {
+      byKey.set(node.key, node);
+      parentOf.set(node.key, parent);
+      const childKeys = (node.children ?? []).map((c) => c.key);
+      childrenOf.set(node.key, childKeys);
+      if (node.children) {
+        visit(node.children, node.key);
+      }
+    }
+  };
+
+  visit(treeData, null);
+
+  return { byKey, parentOf, childrenOf };
+}
+
+/**
+ * Returns whether a node should be checkable (i.e. clicking the
+ * checkbox should affect it).
+ *
+ * Skips:
+ * - explicitly disabled nodes (`isDisabled === true`)
+ * - explicitly disabled checkboxes (`isCheckboxDisabled === true`)
+ * - nodes that opted out via `isCheckable === false`
+ */
+function isNodeEligible(node: CubeTreeNodeData | undefined): boolean {
+  if (!node) return false;
+  if (node.isDisabled) return false;
+  if (node.isCheckboxDisabled) return false;
+  if (node.isCheckable === false) return false;
+  return true;
+}
+
+function normalizeControlledChecked(
+  controlled: UseCheckboxTreeOptions['checkedKeys'],
+): { checked: Set<string>; halfChecked: Set<string> } | null {
+  if (controlled == null) return null;
+  if (Array.isArray(controlled)) {
+    return {
+      checked: new Set(controlled),
+      halfChecked: new Set(),
+    };
+  }
+  return {
+    checked: new Set(controlled.checked ?? []),
+    halfChecked: new Set(controlled.halfChecked ?? []),
+  };
+}
+
+/**
+ * Local hook implementing AntD-style cascading checkbox state.
+ *
+ * - `checked` and `halfChecked` are always derived together from a single
+ *   `checked` set (the source of truth) so callers don't need to track
+ *   indeterminate keys themselves.
+ * - When the consumer passes `checkedKeys` as `{ checked, halfChecked }`,
+ *   we keep the wire shape on the way out — same as AntD.
+ * - Toggling a node propagates *down* (skipping ineligible descendants)
+ *   and recomputes ancestors *up* in a single pass.
+ */
+export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
+  const { treeData, isCheckable, defaultCheckedKeys, checkedKeys, onCheck } =
+    opts;
+
+  const index = useMemo(() => buildIndex(treeData), [treeData]);
+
+  const controlled = normalizeControlledChecked(checkedKeys);
+  const isControlled = controlled != null;
+  const wantsObjectShape = checkedKeys != null && !Array.isArray(checkedKeys);
+
+  const [uncontrolledChecked, setUncontrolledChecked] = useState<Set<string>>(
+    () => new Set(defaultCheckedKeys ?? []),
+  );
+
+  const sourceChecked = isControlled
+    ? controlled!.checked
+    : uncontrolledChecked;
+
+  /**
+   * Derive `{ checked, halfChecked }` from the source-of-truth `checked` set
+   * by walking the tree bottom-up:
+   *
+   * - A parent is considered fully checked iff every eligible descendant
+   *   leaf is checked.
+   * - A parent is half-checked iff at least one eligible descendant is
+   *   checked or half-checked, but not all.
+   *
+   * Ineligible nodes (disabled / opt-out) are ignored when computing the
+   * parent's state — they neither force a parent into the unchecked nor
+   * half state.
+   */
+  const { checkedSet, halfCheckedSet } = useMemo(() => {
+    if (!isCheckable) {
+      return {
+        checkedSet: new Set<string>(),
+        halfCheckedSet: new Set<string>(),
+      };
+    }
+
+    if (isControlled) {
+      return {
+        checkedSet: new Set(sourceChecked),
+        halfCheckedSet: new Set(controlled!.halfChecked),
+      };
+    }
+
+    const checked = new Set(sourceChecked);
+    const half = new Set<string>();
+
+    const visit = (
+      node: CubeTreeNodeData,
+    ): { allChecked: boolean; anyChecked: boolean; anyEligible: boolean } => {
+      const childKeys = index.childrenOf.get(node.key) ?? [];
+
+      if (childKeys.length === 0) {
+        const eligible = isNodeEligible(node);
+        const isChecked = checked.has(node.key);
+        return {
+          allChecked: !eligible || isChecked,
+          anyChecked: isChecked,
+          anyEligible: eligible,
+        };
+      }
+
+      let allChecked = true;
+      let anyChecked = false;
+      let anyEligible = false;
+
+      for (const childKey of childKeys) {
+        const child = index.byKey.get(childKey);
+        if (!child) continue;
+        const r = visit(child);
+        if (r.anyEligible) anyEligible = true;
+        if (!r.allChecked) allChecked = false;
+        if (r.anyChecked) anyChecked = true;
+      }
+
+      const eligible = isNodeEligible(node);
+
+      if (anyEligible && allChecked) {
+        checked.add(node.key);
+        half.delete(node.key);
+      } else if (anyChecked || half.has(node.key)) {
+        checked.delete(node.key);
+        half.add(node.key);
+      } else {
+        checked.delete(node.key);
+      }
+
+      return {
+        allChecked: !eligible
+          ? allChecked
+          : checked.has(node.key) && allChecked,
+        anyChecked: anyChecked || checked.has(node.key),
+        anyEligible: anyEligible || eligible,
+      };
+    };
+
+    for (const root of treeData) {
+      visit(root);
+    }
+
+    return { checkedSet: checked, halfCheckedSet: half };
+  }, [isCheckable, isControlled, sourceChecked, controlled, treeData, index]);
+
+  const toggle = useEvent((key: string) => {
+    const node = index.byKey.get(key);
+    if (!node || !isNodeEligible(node)) return;
+
+    const isCurrentlyChecked = checkedSet.has(key);
+    const willCheck = !isCurrentlyChecked;
+
+    const next = new Set(sourceChecked);
+
+    const apply = (n: CubeTreeNodeData, value: boolean) => {
+      if (!isNodeEligible(n)) return;
+      if (value) next.add(n.key);
+      else next.delete(n.key);
+      const childKeys = index.childrenOf.get(n.key) ?? [];
+      for (const ck of childKeys) {
+        const child = index.byKey.get(ck);
+        if (child) apply(child, value);
+      }
+    };
+
+    apply(node, willCheck);
+
+    /**
+     * After the cascade, recompute ancestors so the public `checked` set
+     * doesn't carry parent keys that should be half-checked instead.
+     * Ancestors of `key` get visited bottom-up here.
+     */
+    let parentKey = index.parentOf.get(key);
+    while (parentKey) {
+      const parent = index.byKey.get(parentKey);
+      if (!parent) break;
+      const childKeys = index.childrenOf.get(parentKey) ?? [];
+      let allEligibleChecked = true;
+      let anyEligible = false;
+      for (const ck of childKeys) {
+        const child = index.byKey.get(ck);
+        if (!child) continue;
+        if (!isNodeEligible(child)) continue;
+        anyEligible = true;
+        if (!next.has(ck)) {
+          allEligibleChecked = false;
+          break;
+        }
+      }
+      if (anyEligible && allEligibleChecked && isNodeEligible(parent)) {
+        next.add(parentKey);
+      } else {
+        next.delete(parentKey);
+      }
+      parentKey = index.parentOf.get(parentKey);
+    }
+
+    if (!isControlled) {
+      setUncontrolledChecked(next);
+    }
+
+    if (onCheck) {
+      const finalChecked = new Set(next);
+      const finalHalf = new Set<string>();
+
+      const recompute = (
+        n: CubeTreeNodeData,
+      ): {
+        allChecked: boolean;
+        anyChecked: boolean;
+        anyEligible: boolean;
+      } => {
+        const childKeys = index.childrenOf.get(n.key) ?? [];
+        if (childKeys.length === 0) {
+          const eligible = isNodeEligible(n);
+          const isChecked = finalChecked.has(n.key);
+          return {
+            allChecked: !eligible || isChecked,
+            anyChecked: isChecked,
+            anyEligible: eligible,
+          };
+        }
+        let allChecked = true;
+        let anyChecked = false;
+        let anyEligible = false;
+        for (const ck of childKeys) {
+          const child = index.byKey.get(ck);
+          if (!child) continue;
+          const r = recompute(child);
+          if (r.anyEligible) anyEligible = true;
+          if (!r.allChecked) allChecked = false;
+          if (r.anyChecked) anyChecked = true;
+        }
+        const eligible = isNodeEligible(n);
+        if (anyEligible && allChecked) {
+          finalChecked.add(n.key);
+          finalHalf.delete(n.key);
+        } else if (anyChecked) {
+          finalChecked.delete(n.key);
+          finalHalf.add(n.key);
+        } else {
+          finalChecked.delete(n.key);
+        }
+        return {
+          allChecked: !eligible
+            ? allChecked
+            : finalChecked.has(n.key) && allChecked,
+          anyChecked: anyChecked || finalChecked.has(n.key),
+          anyEligible: anyEligible || eligible,
+        };
+      };
+
+      for (const root of treeData) recompute(root);
+
+      const checkedArr = Array.from(finalChecked);
+      const halfArr = Array.from(finalHalf);
+      const checkedNodes: CubeTreeNodeData[] = checkedArr
+        .map((k) => index.byKey.get(k))
+        .filter((n): n is CubeTreeNodeData => !!n);
+
+      const info: TreeOnCheckInfo = {
+        checked: willCheck,
+        node,
+        checkedNodes,
+        halfCheckedKeys: halfArr,
+      };
+
+      if (wantsObjectShape) {
+        onCheck({ checked: checkedArr, halfChecked: halfArr }, info);
+      } else {
+        onCheck(checkedArr, info);
+      }
+    }
+  });
+
+  return { checkedSet, halfCheckedSet, toggle };
+}

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -86,7 +86,11 @@ function deriveCheckedState(
 
   const eligible = isNodeEligible(node);
 
-  if (anyEligible && allChecked) {
+  if (!anyEligible) {
+    // No eligible descendants — this node behaves like a leaf for
+    // checking purposes: its own checked state stands as-is.
+    half.delete(node.key);
+  } else if (allChecked) {
     checked.add(node.key);
     half.delete(node.key);
   } else if (anyChecked) {
@@ -94,6 +98,7 @@ function deriveCheckedState(
     half.add(node.key);
   } else {
     checked.delete(node.key);
+    half.delete(node.key);
   }
 
   return {

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -223,7 +223,20 @@ export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
     const isCurrentlyChecked = checkedSet.has(key);
     const willCheck = !isCurrentlyChecked;
 
-    const next = new Set(sourceChecked);
+    /**
+     * Seed from the derived `checkedSet`, not `sourceChecked`. The
+     * source-of-truth set may only contain leaf keys (e.g. when
+     * `defaultCheckedKeys` is leaf-only, or a consumer in controlled-array
+     * mode passes only leaves). The ancestor walk below decides whether
+     * each ancestor is fully checked by inspecting its direct children
+     * via `next.has(ck)` — those children may themselves be inner nodes
+     * whose "fully checked" status only exists in the derived set. Seeding
+     * from `sourceChecked` causes a sibling subtree's parent key to be
+     * missing from `next`, which would incorrectly drop the grandparent
+     * from the stored state (the next render's `useMemo` self-corrects,
+     * but the intermediate stored value violates the cascade invariant).
+     */
+    const next = new Set(checkedSet);
 
     const apply = (n: CubeTreeNodeData, value: boolean) => {
       if (!isNodeEligible(n)) return;

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -3,10 +3,16 @@ import { useMemo, useState } from 'react';
 import { useEvent } from '../../../_internal/hooks';
 
 import type { Key } from '@react-types/shared';
+import type { TreeIndex } from './tree-index';
 import type { CubeTreeNodeData, TreeOnCheckInfo } from './types';
 
 export interface UseCheckboxTreeOptions {
   treeData: CubeTreeNodeData[];
+  /**
+   * Pre-built tree index, shared with `Tree.tsx` so that `treeData`
+   * is walked exactly once per change rather than once per consumer.
+   */
+  index: TreeIndex;
   isCheckable: boolean;
   defaultCheckedKeys?: string[];
   /** Either an array (AntD's default) or `{ checked, halfChecked }`. */
@@ -24,42 +30,6 @@ export interface CheckboxTree {
   halfCheckedSet: Set<string>;
   /** Toggle a key, propagating to descendants and updating ancestors. */
   toggle: (key: string) => void;
-}
-
-/**
- * Map of `key -> { node, parentKey, childKeys }` for fast cascading lookups.
- *
- * Built from the public `treeData` rather than from React Stately's
- * collection, because we need the consumer's original (controlled)
- * shape to derive parent/child relationships and to call back with the
- * actual `node` objects in `onCheck`'s `info`.
- */
-interface NodeIndex {
-  byKey: Map<string, CubeTreeNodeData>;
-  parentOf: Map<string, string | null>;
-  childrenOf: Map<string, string[]>;
-}
-
-function buildIndex(treeData: CubeTreeNodeData[]): NodeIndex {
-  const byKey = new Map<string, CubeTreeNodeData>();
-  const parentOf = new Map<string, string | null>();
-  const childrenOf = new Map<string, string[]>();
-
-  const visit = (nodes: CubeTreeNodeData[], parent: string | null) => {
-    for (const node of nodes) {
-      byKey.set(node.key, node);
-      parentOf.set(node.key, parent);
-      const childKeys = (node.children ?? []).map((c) => c.key);
-      childrenOf.set(node.key, childKeys);
-      if (node.children) {
-        visit(node.children, node.key);
-      }
-    }
-  };
-
-  visit(treeData, null);
-
-  return { byKey, parentOf, childrenOf };
 }
 
 /**
@@ -107,10 +77,14 @@ function normalizeControlledChecked(
  *   and recomputes ancestors *up* in a single pass.
  */
 export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
-  const { treeData, isCheckable, defaultCheckedKeys, checkedKeys, onCheck } =
-    opts;
-
-  const index = useMemo(() => buildIndex(treeData), [treeData]);
+  const {
+    treeData,
+    index,
+    isCheckable,
+    defaultCheckedKeys,
+    checkedKeys,
+    onCheck,
+  } = opts;
 
   const controlled = normalizeControlledChecked(checkedKeys);
   const isControlled = controlled != null;

--- a/src/components/content/Tree/use-checkbox-tree.ts
+++ b/src/components/content/Tree/use-checkbox-tree.ts
@@ -49,6 +49,60 @@ function isNodeEligible(node: CubeTreeNodeData | undefined): boolean {
   return true;
 }
 
+/**
+ * Recursively walk a subtree bottom-up, deriving which nodes are fully
+ * checked vs half-checked.  Mutates `checked` and `half` in place.
+ */
+function deriveCheckedState(
+  node: CubeTreeNodeData,
+  index: TreeIndex,
+  checked: Set<string>,
+  half: Set<string>,
+): { allChecked: boolean; anyChecked: boolean; anyEligible: boolean } {
+  const childKeys = index.childrenOf.get(node.key) ?? [];
+
+  if (childKeys.length === 0) {
+    const eligible = isNodeEligible(node);
+    const isChecked = checked.has(node.key);
+    return {
+      allChecked: !eligible || isChecked,
+      anyChecked: isChecked,
+      anyEligible: eligible,
+    };
+  }
+
+  let allChecked = true;
+  let anyChecked = false;
+  let anyEligible = false;
+
+  for (const childKey of childKeys) {
+    const child = index.byKey.get(childKey);
+    if (!child) continue;
+    const r = deriveCheckedState(child, index, checked, half);
+    if (r.anyEligible) anyEligible = true;
+    if (!r.allChecked) allChecked = false;
+    if (r.anyChecked) anyChecked = true;
+  }
+
+  const eligible = isNodeEligible(node);
+
+  if (anyEligible && allChecked) {
+    checked.add(node.key);
+    half.delete(node.key);
+  } else if (anyChecked) {
+    checked.delete(node.key);
+    half.add(node.key);
+  } else {
+    checked.delete(node.key);
+  }
+
+  return {
+    allChecked: !eligible ? allChecked : checked.has(node.key) && allChecked,
+    anyChecked: anyChecked || checked.has(node.key),
+    anyEligible: anyEligible || eligible,
+  };
+}
+
 function normalizeControlledChecked(
   controlled: UseCheckboxTreeOptions['checkedKeys'],
 ): { checked: Set<string>; halfChecked: Set<string> } | null {
@@ -136,57 +190,8 @@ export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
     const checked = new Set(sourceChecked);
     const half = new Set<string>();
 
-    const visit = (
-      node: CubeTreeNodeData,
-    ): { allChecked: boolean; anyChecked: boolean; anyEligible: boolean } => {
-      const childKeys = index.childrenOf.get(node.key) ?? [];
-
-      if (childKeys.length === 0) {
-        const eligible = isNodeEligible(node);
-        const isChecked = checked.has(node.key);
-        return {
-          allChecked: !eligible || isChecked,
-          anyChecked: isChecked,
-          anyEligible: eligible,
-        };
-      }
-
-      let allChecked = true;
-      let anyChecked = false;
-      let anyEligible = false;
-
-      for (const childKey of childKeys) {
-        const child = index.byKey.get(childKey);
-        if (!child) continue;
-        const r = visit(child);
-        if (r.anyEligible) anyEligible = true;
-        if (!r.allChecked) allChecked = false;
-        if (r.anyChecked) anyChecked = true;
-      }
-
-      const eligible = isNodeEligible(node);
-
-      if (anyEligible && allChecked) {
-        checked.add(node.key);
-        half.delete(node.key);
-      } else if (anyChecked || half.has(node.key)) {
-        checked.delete(node.key);
-        half.add(node.key);
-      } else {
-        checked.delete(node.key);
-      }
-
-      return {
-        allChecked: !eligible
-          ? allChecked
-          : checked.has(node.key) && allChecked,
-        anyChecked: anyChecked || checked.has(node.key),
-        anyEligible: anyEligible || eligible,
-      };
-    };
-
     for (const root of treeData) {
-      visit(root);
+      deriveCheckedState(root, index, checked, half);
     }
 
     return { checkedSet: checked, halfCheckedSet: half };
@@ -260,54 +265,9 @@ export function useCheckboxTree(opts: UseCheckboxTreeOptions): CheckboxTree {
       const finalChecked = new Set(next);
       const finalHalf = new Set<string>();
 
-      const recompute = (
-        n: CubeTreeNodeData,
-      ): {
-        allChecked: boolean;
-        anyChecked: boolean;
-        anyEligible: boolean;
-      } => {
-        const childKeys = index.childrenOf.get(n.key) ?? [];
-        if (childKeys.length === 0) {
-          const eligible = isNodeEligible(n);
-          const isChecked = finalChecked.has(n.key);
-          return {
-            allChecked: !eligible || isChecked,
-            anyChecked: isChecked,
-            anyEligible: eligible,
-          };
-        }
-        let allChecked = true;
-        let anyChecked = false;
-        let anyEligible = false;
-        for (const ck of childKeys) {
-          const child = index.byKey.get(ck);
-          if (!child) continue;
-          const r = recompute(child);
-          if (r.anyEligible) anyEligible = true;
-          if (!r.allChecked) allChecked = false;
-          if (r.anyChecked) anyChecked = true;
-        }
-        const eligible = isNodeEligible(n);
-        if (anyEligible && allChecked) {
-          finalChecked.add(n.key);
-          finalHalf.delete(n.key);
-        } else if (anyChecked) {
-          finalChecked.delete(n.key);
-          finalHalf.add(n.key);
-        } else {
-          finalChecked.delete(n.key);
-        }
-        return {
-          allChecked: !eligible
-            ? allChecked
-            : finalChecked.has(n.key) && allChecked,
-          anyChecked: anyChecked || finalChecked.has(n.key),
-          anyEligible: anyEligible || eligible,
-        };
-      };
-
-      for (const root of treeData) recompute(root);
+      for (const root of treeData) {
+        deriveCheckedState(root, index, finalChecked, finalHalf);
+      }
 
       const checkedArr = Array.from(finalChecked);
       const halfArr = Array.from(finalHalf);

--- a/src/components/content/Tree/use-load-data.ts
+++ b/src/components/content/Tree/use-load-data.ts
@@ -10,6 +10,12 @@ export interface UseLoadDataOptions {
    */
   nodesByKey: Map<string, CubeTreeNodeData>;
   loadData?: (node: TreeLoadDataNode) => Promise<void>;
+  /**
+   * Keys that are expanded at mount time (controlled or default).
+   * Seeds `previousExpandedRef` so the first `onExpandedChanged` call
+   * doesn't misidentify them as user-triggered expansions.
+   */
+  initialExpandedKeys?: Iterable<string>;
 }
 
 export interface LoadDataController {
@@ -39,9 +45,9 @@ export interface LoadDataController {
  * `treeData` themselves (matching AntD's pattern).
  */
 export function useLoadData(opts: UseLoadDataOptions): LoadDataController {
-  const { nodesByKey, loadData } = opts;
+  const { nodesByKey, loadData, initialExpandedKeys } = opts;
   const [loadingKeys, setLoadingKeys] = useState<Set<string>>(() => new Set());
-  const previousExpandedRef = useRef<Set<string>>(new Set());
+  const previousExpandedRef = useRef<Set<string>>(new Set(initialExpandedKeys));
   const inFlightRef = useRef<Set<string>>(new Set());
 
   const onExpandedChanged = useCallback(

--- a/src/components/content/Tree/use-load-data.ts
+++ b/src/components/content/Tree/use-load-data.ts
@@ -1,4 +1,6 @@
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+
+import { useEvent } from '../../../_internal/hooks';
 
 import type { Key } from '@react-types/shared';
 import type { CubeTreeNodeData, TreeLoadDataNode } from './types';
@@ -50,60 +52,57 @@ export function useLoadData(opts: UseLoadDataOptions): LoadDataController {
   const previousExpandedRef = useRef<Set<string>>(new Set(initialExpandedKeys));
   const inFlightRef = useRef<Set<string>>(new Set());
 
-  const onExpandedChanged = useCallback(
-    (expandedKeys: Iterable<Key>) => {
-      const next = new Set<string>();
-      for (const k of expandedKeys) next.add(String(k));
+  const onExpandedChanged = useEvent((expandedKeys: Iterable<Key>) => {
+    const next = new Set<string>();
+    for (const k of expandedKeys) next.add(String(k));
 
-      const prev = previousExpandedRef.current;
-      const newlyExpanded: string[] = [];
-      for (const k of next) {
-        if (!prev.has(k)) newlyExpanded.push(k);
-      }
-      previousExpandedRef.current = next;
+    const prev = previousExpandedRef.current;
+    const newlyExpanded: string[] = [];
+    for (const k of next) {
+      if (!prev.has(k)) newlyExpanded.push(k);
+    }
+    previousExpandedRef.current = next;
 
-      if (!loadData || newlyExpanded.length === 0) return;
+    if (!loadData || newlyExpanded.length === 0) return;
 
-      let added = false;
-      const toLoad: string[] = [];
-      for (const key of newlyExpanded) {
-        const node = nodesByKey.get(key);
-        if (!node) continue;
-        if (node.isLeaf) continue;
-        if (node.children && node.children.length > 0) continue;
-        if (inFlightRef.current.has(key)) continue;
-        inFlightRef.current.add(key);
-        toLoad.push(key);
-        added = true;
-      }
+    const toLoad: string[] = [];
+    for (const key of newlyExpanded) {
+      const node = nodesByKey.get(key);
+      if (!node) continue;
+      if (node.isLeaf) continue;
+      if (node.children && node.children.length > 0) continue;
+      if (inFlightRef.current.has(key)) continue;
+      inFlightRef.current.add(key);
+      toLoad.push(key);
+    }
 
-      if (!added) return;
+    if (toLoad.length === 0) return;
 
-      setLoadingKeys((current) => {
-        const updated = new Set(current);
-        for (const k of toLoad) updated.add(k);
-        return updated;
-      });
+    setLoadingKeys((current) => {
+      const updated = new Set(current);
+      for (const k of toLoad) updated.add(k);
+      return updated;
+    });
 
-      for (const key of toLoad) {
-        Promise.resolve(loadData({ key }))
-          .catch(() => {
-            // Allow consumers to re-trigger after a rejected load by
-            // letting the next expand event re-enter this branch.
-          })
-          .finally(() => {
-            inFlightRef.current.delete(key);
-            setLoadingKeys((current) => {
-              if (!current.has(key)) return current;
-              const updated = new Set(current);
-              updated.delete(key);
-              return updated;
-            });
+    for (const key of toLoad) {
+      const loadNode = nodesByKey.get(key);
+      Promise.resolve(loadData({ key, children: loadNode?.children }))
+        .catch((err) => {
+          if (process.env.NODE_ENV !== 'production') {
+            console.error(`[Tree] loadData failed for key "${key}":`, err);
+          }
+        })
+        .finally(() => {
+          inFlightRef.current.delete(key);
+          setLoadingKeys((current) => {
+            if (!current.has(key)) return current;
+            const updated = new Set(current);
+            updated.delete(key);
+            return updated;
           });
-      }
-    },
-    [loadData, nodesByKey],
-  );
+        });
+    }
+  });
 
   return { loadingKeys, onExpandedChanged };
 }

--- a/src/components/content/Tree/use-load-data.ts
+++ b/src/components/content/Tree/use-load-data.ts
@@ -1,0 +1,103 @@
+import { useCallback, useRef, useState } from 'react';
+
+import type { Key } from '@react-types/shared';
+import type { CubeTreeNodeData, TreeLoadDataNode } from './types';
+
+export interface UseLoadDataOptions {
+  /**
+   * Map of `key -> node` built from the consumer's `treeData`. Used to
+   * find the node being expanded when `loadData` fires.
+   */
+  nodesByKey: Map<string, CubeTreeNodeData>;
+  loadData?: (node: TreeLoadDataNode) => Promise<void>;
+}
+
+export interface LoadDataController {
+  /** Set of keys that are currently waiting on `loadData`. */
+  loadingKeys: Set<string>;
+  /**
+   * Called by `Tree.tsx` whenever the underlying React Stately state's
+   * `expandedKeys` change. We diff against the previous set, and for
+   * each newly-expanded key we trigger `loadData` if appropriate.
+   */
+  onExpandedChanged: (expandedKeys: Iterable<Key>) => void;
+}
+
+/**
+ * Tracks which rows are currently fetching their children via `loadData`
+ * and exposes a setter for the Tree to call after every expand change.
+ *
+ * `loadData` is fired exactly once per key per "first expand" event:
+ *
+ * - Skipped if there is no `loadData` callback.
+ * - Skipped for leaf nodes (`isLeaf === true`).
+ * - Skipped if the node already has `children` (already loaded).
+ * - Skipped if a previous fetch for the same key is still in flight.
+ *
+ * The promise's resolution is awaited only to clear the `loading` mod;
+ * the consumer is expected to commit the new children to the controlled
+ * `treeData` themselves (matching AntD's pattern).
+ */
+export function useLoadData(opts: UseLoadDataOptions): LoadDataController {
+  const { nodesByKey, loadData } = opts;
+  const [loadingKeys, setLoadingKeys] = useState<Set<string>>(() => new Set());
+  const previousExpandedRef = useRef<Set<string>>(new Set());
+  const inFlightRef = useRef<Set<string>>(new Set());
+
+  const onExpandedChanged = useCallback(
+    (expandedKeys: Iterable<Key>) => {
+      const next = new Set<string>();
+      for (const k of expandedKeys) next.add(String(k));
+
+      const prev = previousExpandedRef.current;
+      const newlyExpanded: string[] = [];
+      for (const k of next) {
+        if (!prev.has(k)) newlyExpanded.push(k);
+      }
+      previousExpandedRef.current = next;
+
+      if (!loadData || newlyExpanded.length === 0) return;
+
+      let added = false;
+      const toLoad: string[] = [];
+      for (const key of newlyExpanded) {
+        const node = nodesByKey.get(key);
+        if (!node) continue;
+        if (node.isLeaf) continue;
+        if (node.children && node.children.length > 0) continue;
+        if (inFlightRef.current.has(key)) continue;
+        inFlightRef.current.add(key);
+        toLoad.push(key);
+        added = true;
+      }
+
+      if (!added) return;
+
+      setLoadingKeys((current) => {
+        const updated = new Set(current);
+        for (const k of toLoad) updated.add(k);
+        return updated;
+      });
+
+      for (const key of toLoad) {
+        Promise.resolve(loadData({ key }))
+          .catch(() => {
+            // Allow consumers to re-trigger after a rejected load by
+            // letting the next expand event re-enter this branch.
+          })
+          .finally(() => {
+            inFlightRef.current.delete(key);
+            setLoadingKeys((current) => {
+              if (!current.has(key)) return current;
+              const updated = new Set(current);
+              updated.delete(key);
+              return updated;
+            });
+          });
+      }
+    },
+    [loadData, nodesByKey],
+  );
+
+  return { loadingKeys, onExpandedChanged };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,16 @@ export type {
   CubeDisclosureItemProps,
   DisclosureStateContext,
 } from './components/content/Disclosure';
+export { Tree } from './components/content/Tree';
+export type {
+  CubeTreeProps,
+  CubeTreeNodeData,
+  TreeOnCheckInfo,
+  TreeOnExpandInfo,
+  TreeOnSelectInfo,
+  TreeLoadDataNode,
+  TreeSelectionMode,
+} from './components/content/Tree';
 export { GridProvider } from './components/GridProvider';
 export type { CubeGridProviderProps } from './components/GridProvider';
 export { Content } from './components/content/Content';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large new interactive component with non-trivial selection/checkbox cascade and async loading logic, plus a styling dependency bump and increased bundle budget; regressions are most likely in accessibility/keyboard and state sync edge cases.
> 
> **Overview**
> Adds a new `Tree` component (exported from `src/index.ts`) providing an Ant Design–compatible `treeData` API with **controlled/uncontrolled** expansion, selection (`single`/`multiple`/`none`), optional **cascading checkboxes** (including `halfChecked` reporting), and per-node/per-tree disabling.
> 
> Implements async `loadData` support with per-row loading state, `autoExpandParent` handling, ref-forwarding fixes for React Aria keyboard behavior, plus full Storybook docs/stories and a comprehensive test suite for expansion/selection/checkbox cascade/lazy loading.
> 
> Updates `@tenphi/tasty` to `2.1.1` (with a noted selector fix and a `TreeNode` typing workaround), updates lockfile, and raises the overall `size-limit` budget from `380kB` to `390kB`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50f60d0689eb73fca679ffdd4bcfe62cdea3d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->