### PR TITLE
fix(FilterPicker): clear search on popover close

### DIFF
--- a/.changeset/filter-picker-clear-search.md
+++ b/.changeset/filter-picker-clear-search.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+FilterPicker: Clear search value when the popover closes

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -447,6 +447,7 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
     if (!isOpen) {
       selectionsWhenClosed.current = { ...latestSelectionRef.current };
       cachedItemsOrder.current = null;
+      onSearchChange?.('');
     }
     onOpenChange?.(isOpen);
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI state reset on popover close; low risk aside from possible behavior change for consumers relying on search persistence across closes.
> 
> **Overview**
> Ensures `FilterPicker` resets its search state on close by calling `onSearchChange('')` when the popover transitions to closed, so reopening starts with an empty search.
> 
> Adds a patch changeset entry documenting the behavior change for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a62fc5bd78d5a33467ae42b1d3cfa83c50ba5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->