### PR TITLE
feat(Tree): virtualization and customization

### DIFF
--- a/.changeset/tree-item-props.md
+++ b/.changeset/tree-item-props.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `itemProps` prop to Tree for per-node customization of Item slots (prefix, actions, suffix, etc.) with access to node state (expanded, selected, checked)

--- a/.changeset/tree-size-prop.md
+++ b/.changeset/tree-size-prop.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `size` prop to Tree (`'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'`). Default row size changed from `small` to `medium`.

--- a/.changeset/tree-virtualization.md
+++ b/.changeset/tree-virtualization.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add virtualization to the Tree component using `@tanstack/react-virtual` for efficient rendering of large trees

--- a/src/components/content/Tree/Tree.stories.tsx
+++ b/src/components/content/Tree/Tree.stories.tsx
@@ -1,5 +1,9 @@
+import { IconEdit, IconFile, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 
+import { FolderIcon, FolderOpenIcon, Icon, MoreIcon } from '../../../icons';
+import { ItemAction } from '../../actions/ItemAction';
+import { Menu, MenuTrigger } from '../../actions/Menu';
 import { Flow } from '../../layout/Flow';
 import { Space } from '../../layout/Space';
 import { Text } from '../Text';
@@ -408,5 +412,53 @@ export const AutoExpandParent: Story = {
 export const Empty: Story = {
   args: {
     treeData: [],
+  },
+};
+
+const prefixIconStyles = { width: '($size - 2bw)' } as const;
+
+const WrappedFileIcon = () => (
+  <Icon styles={prefixIconStyles}>
+    <IconFile />
+  </Icon>
+);
+
+export const DirectoryTree: Story = {
+  args: {
+    selectionMode: 'none',
+    defaultExpandedKeys: ['src', 'src/components'],
+    styles: {
+      width: '200px',
+      border: true,
+      radius: '1cr',
+    },
+    itemProps: (data, { isExpanded }) => {
+      const isFolder = !!data.children;
+      return {
+        prefix: isFolder ? (
+          isExpanded ? (
+            <FolderOpenIcon styles={prefixIconStyles} />
+          ) : (
+            <FolderIcon styles={prefixIconStyles} />
+          )
+        ) : (
+          <WrappedFileIcon />
+        ),
+        actions: (
+          <MenuTrigger>
+            <ItemAction icon={<MoreIcon />} aria-label="Actions" />
+            <Menu>
+              <Menu.Item key="rename" icon={<IconEdit />}>
+                Rename
+              </Menu.Item>
+              <Menu.Item key="delete" icon={<IconTrash />}>
+                Delete
+              </Menu.Item>
+            </Menu>
+          </MenuTrigger>
+        ),
+        autoHideActions: true,
+      };
+    },
   },
 };

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -1,5 +1,6 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { OUTER_STYLES } from '@tenphi/tasty';
-import { forwardRef, useMemo, useRef } from 'react';
+import { forwardRef, useLayoutEffect, useMemo, useRef } from 'react';
 import { useTree } from 'react-aria';
 import { Item, useTreeState } from 'react-stately';
 
@@ -126,6 +127,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     onExpand,
     onCheck,
     onSelect,
+    itemProps,
     rowStyles,
     ariaLabel,
     qa,
@@ -330,15 +332,47 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     return out;
   }, [state.collection]);
 
-  const heightStyle = useMemo<CSSProperties | undefined>(
-    () =>
-      height != null
-        ? ({
-            ['--tree-height' as keyof CSSProperties]: `${height}px`,
-          } as CSSProperties)
-        : undefined,
-    [height],
-  );
+  const visibleNodesRef = useRef(visibleNodes);
+  visibleNodesRef.current = visibleNodes;
+
+  // ----- Virtualization -----
+  const rowVirtualizer = useVirtualizer({
+    count: visibleNodes.length,
+    getScrollElement: () => treeRef.current,
+    getItemKey: (index: number) => {
+      const node = visibleNodesRef.current[index];
+      return node?.key ?? index;
+    },
+    estimateSize: () => 29,
+    overscan: 10,
+  });
+
+  const containerStyle = useMemo<CSSProperties>(() => {
+    const style: CSSProperties = {
+      position: 'relative',
+      height: `${rowVirtualizer.getTotalSize()}px`,
+    };
+    if (height != null) {
+      (style as any)['--tree-height'] = `${height}px`;
+    }
+    return style;
+  }, [rowVirtualizer.getTotalSize(), height]);
+
+  // Keep focused node visible during keyboard navigation.
+  useLayoutEffect(() => {
+    const focusedKey = state.selectionManager.focusedKey;
+    if (focusedKey == null) return;
+
+    const scrollElement = treeRef.current;
+    if (!scrollElement) return;
+
+    const row = scrollElement.querySelector(
+      `[data-qa-key="${CSS.escape(String(focusedKey))}"]`,
+    ) as HTMLElement | null;
+    if (!row || typeof row.scrollIntoView !== 'function') return;
+
+    row.scrollIntoView({ block: 'nearest' });
+  }, [state.selectionManager.focusedKey]);
 
   const mods = useMemo(
     () => ({
@@ -360,9 +394,11 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
       qa={qa ?? 'Tree'}
       mods={mods}
       styles={baseStyles}
-      style={heightStyle}
+      style={containerStyle}
     >
-      {visibleNodes.map((node) => {
+      {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+        const node = visibleNodes[virtualItem.index];
+        if (!node) return null;
         const keyStr = String(node.key);
         const data = nodesByKey.get(keyStr);
         if (!data) return null;
@@ -377,7 +413,17 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
             isChecked={checkbox.checkedSet.has(keyStr)}
             isIndeterminate={checkbox.halfCheckedSet.has(keyStr)}
             isLoading={loadDataController.loadingKeys.has(keyStr)}
+            itemProps={itemProps}
             rowStyles={rowStyles}
+            virtualStyle={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+            virtualRef={rowVirtualizer.measureElement}
+            virtualIndex={virtualItem.index}
             onToggleChecked={checkbox.toggle}
           />
         );

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -5,6 +5,7 @@ import { useTree } from 'react-aria';
 import { Item, useTreeState } from 'react-stately';
 
 import { useEvent } from '../../../_internal/hooks';
+import { SIZE_NAME_TO_KEY, SIZES } from '../../../tokens/sizes';
 import { mergeProps, mergeRefs } from '../../../utils/react';
 import { extractStyles } from '../../../utils/styles';
 
@@ -114,6 +115,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     isCheckable = false,
     isSelectable,
     selectionMode: selectionModeProp,
+    size = 'medium',
     isDisabled = false,
     defaultExpandedKeys,
     expandedKeys,
@@ -343,7 +345,8 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
       const node = visibleNodesRef.current[index];
       return node?.key ?? index;
     },
-    estimateSize: () => 29,
+    estimateSize: () => SIZES[SIZE_NAME_TO_KEY[size]],
+    gap: 1,
     overscan: 10,
   });
 
@@ -413,6 +416,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
             isChecked={checkbox.checkedSet.has(keyStr)}
             isIndeterminate={checkbox.halfCheckedSet.has(keyStr)}
             isLoading={loadDataController.loadingKeys.has(keyStr)}
+            size={size}
             itemProps={itemProps}
             rowStyles={rowStyles}
             virtualStyle={{

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -16,7 +16,7 @@ import {
 
 import type { Node } from '@react-types/shared';
 import type { Styles } from '@tenphi/tasty';
-import type { CSSProperties, SyntheticEvent } from 'react';
+import type { CSSProperties, KeyboardEvent, SyntheticEvent } from 'react';
 import type { TreeState } from 'react-stately';
 import type { CubeTreeNodeData } from './types';
 
@@ -90,6 +90,18 @@ function TreeNodeInner(props: TreeNodeProps) {
     onToggleChecked(String(node.key));
   });
 
+  const handleKeyDown = useEvent((e: KeyboardEvent) => {
+    if (
+      e.key === ' ' &&
+      isRowCheckable &&
+      !isDisabled &&
+      !data.isCheckboxDisabled
+    ) {
+      e.preventDefault();
+      onToggleChecked(String(node.key));
+    }
+  });
+
   const sharedMods = useMemo(
     () => ({
       checked: isChecked,
@@ -135,6 +147,7 @@ function TreeNodeInner(props: TreeNodeProps) {
 
   const finalRowProps = mergeProps(rowProps, hoverProps, {
     'aria-checked': ariaChecked,
+    onKeyDown: handleKeyDown,
   });
 
   // Leaf rows get a placeholder so sibling indents align.

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -44,6 +44,9 @@ export interface TreeNodeProps {
   /** Toggle this row's checkbox (cascades). */
   onToggleChecked: (key: string) => void;
 
+  /** Row size passed to the underlying Item. */
+  size?: string;
+
   /** Per-node Item customization (static object or callback). */
   itemProps?:
     | TreeItemProps
@@ -71,6 +74,7 @@ function TreeNodeInner(props: TreeNodeProps) {
     isChecked,
     isLoading,
     onToggleChecked,
+    size,
     itemProps,
     rowStyles,
     virtualStyle,
@@ -236,6 +240,7 @@ function TreeNodeInner(props: TreeNodeProps) {
       <TreeRowItem
         {...gridCellProps}
         {...restUserProps}
+        size={size}
         isSelected={isSelected}
         isDisabled={isDisabled}
         mods={itemMods}

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -3,7 +3,7 @@ import { useHover, useTreeItem } from 'react-aria';
 
 import { useEvent } from '../../../_internal/hooks';
 import { DirectionIcon, LoadingIcon } from '../../../icons';
-import { mergeProps } from '../../../utils/react';
+import { mergeProps, mergeRefs } from '../../../utils/react';
 import { Checkbox } from '../../fields/Checkbox/Checkbox';
 
 import {
@@ -18,7 +18,7 @@ import type { Node } from '@react-types/shared';
 import type { Styles } from '@tenphi/tasty';
 import type { CSSProperties, KeyboardEvent, SyntheticEvent } from 'react';
 import type { TreeState } from 'react-stately';
-import type { CubeTreeNodeData } from './types';
+import type { CubeTreeNodeData, TreeItemProps, TreeNodeState } from './types';
 
 const stopPropagation = (e: SyntheticEvent) => {
   e.stopPropagation();
@@ -44,8 +44,20 @@ export interface TreeNodeProps {
   /** Toggle this row's checkbox (cascades). */
   onToggleChecked: (key: string) => void;
 
+  /** Per-node Item customization (static object or callback). */
+  itemProps?:
+    | TreeItemProps
+    | ((data: CubeTreeNodeData, state: TreeNodeState) => TreeItemProps);
+
   /** Styles applied to the visible row (`TreeRowItem`). */
   rowStyles?: Styles;
+
+  /** Inline style for virtualizer absolute positioning. */
+  virtualStyle?: CSSProperties;
+  /** Ref callback from `@tanstack/react-virtual` to measure row height. */
+  virtualRef?: (element: HTMLElement | null) => void;
+  /** Virtual index for `data-index` attribute. */
+  virtualIndex?: number;
 }
 
 function TreeNodeInner(props: TreeNodeProps) {
@@ -59,10 +71,18 @@ function TreeNodeInner(props: TreeNodeProps) {
     isChecked,
     isLoading,
     onToggleChecked,
+    itemProps,
     rowStyles,
+    virtualStyle,
+    virtualRef,
+    virtualIndex,
   } = props;
 
   const rowRef = useRef<HTMLDivElement>(null);
+  const combinedRef = useMemo(
+    () => (virtualRef ? mergeRefs(rowRef, virtualRef) : rowRef),
+    [virtualRef],
+  );
 
   const { rowProps, gridCellProps, expandButtonProps, isPressed } = useTreeItem(
     { node },
@@ -129,11 +149,12 @@ function TreeNodeInner(props: TreeNodeProps) {
     [sharedMods, isFocused, isHovered, isPressed],
   );
 
-  const levelStyle = useMemo<CSSProperties>(
+  const rowStyle = useMemo<CSSProperties>(
     () => ({
       ['--tree-level' as keyof CSSProperties]: String(node.level ?? 0),
+      ...virtualStyle,
     }),
-    [node.level],
+    [node.level, virtualStyle],
   );
 
   // Only emit `aria-checked` when the tree is in checkable mode.
@@ -183,22 +204,43 @@ function TreeNodeInner(props: TreeNodeProps) {
     </TreeNodeCheckboxWrapper>
   ) : null;
 
+  const nodeState: TreeNodeState = {
+    isExpanded,
+    isSelected,
+    isChecked,
+    isIndeterminate,
+    isLeaf,
+  };
+  const resolvedItemProps =
+    typeof itemProps === 'function' ? itemProps(data, nodeState) : itemProps;
+  const { prefix: userPrefix, ...restUserProps } = resolvedItemProps ?? {};
+
+  const composedPrefix =
+    checkboxNode || userPrefix ? (
+      <>
+        {checkboxNode}
+        {userPrefix}
+      </>
+    ) : null;
+
   return (
     <TreeNodeRow
       {...finalRowProps}
-      ref={rowRef}
+      ref={combinedRef}
       mods={rowMods}
-      style={levelStyle}
+      style={rowStyle}
       data-element="Row"
       data-qa-key={String(node.key)}
+      data-index={virtualIndex}
     >
       <TreeRowItem
         {...gridCellProps}
+        {...restUserProps}
         isSelected={isSelected}
         isDisabled={isDisabled}
         mods={itemMods}
         icon={toggleNode}
-        prefix={checkboxNode}
+        prefix={composedPrefix}
         styles={rowStyles}
       >
         {data.title}

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -29,8 +29,7 @@ export const TreeElement = tasty({
     color: '#dark',
     transition: 'theme',
     outline: 0,
-    gap: '1bw',
-    padding: '.5x',
+    padding: 0,
   },
 });
 

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -84,7 +84,7 @@ export const TreeRowItem = tasty(Item, {
      * loses to it in the cascade when both are emitted from the same
      * declaration block.
      */
-    padding: 'left ($tree-indent * 1x)',
+    padding: 'left ($tree-indent * 1.5x)',
     '$tree-indent': '($tree-level, 0)',
     cursor: {
       '': 'pointer',

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -64,7 +64,7 @@ export const TreeNodeRow = tasty({
 export const TreeRowItem = tasty(Item, {
   qa: 'TreeItem',
   type: 'item',
-  size: 'small',
+  size: 'medium',
   as: 'div',
   styles: {
     /**

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -1,6 +1,7 @@
 import type { Key } from '@react-types/shared';
 import type { BaseProps, OuterStyleProps, Styles } from '@tenphi/tasty';
 import type { ReactNode } from 'react';
+import type { CubeItemProps } from '../Item/Item';
 
 /** Selection cardinality, mirroring React Aria/Stately's `selectionMode`. */
 export type TreeSelectionMode = 'none' | 'single' | 'multiple';
@@ -62,6 +63,34 @@ export interface TreeOnSelectInfo {
   /** All currently selected nodes (flat). */
   selectedNodes: CubeTreeNodeData[];
 }
+
+/** Current visual/interaction state of a tree node, passed as the second argument to `itemProps`. */
+export interface TreeNodeState {
+  isExpanded: boolean;
+  isSelected: boolean;
+  isChecked: boolean;
+  isIndeterminate: boolean;
+  isLeaf: boolean;
+}
+
+/** Props that can be customized per tree node via `itemProps`. */
+export type TreeItemProps = Partial<
+  Pick<
+    CubeItemProps,
+    | 'prefix'
+    | 'suffix'
+    | 'actions'
+    | 'autoHideActions'
+    | 'preserveActionsSpace'
+    | 'description'
+    | 'descriptionPlacement'
+    | 'rightIcon'
+    | 'tooltip'
+    | 'highlight'
+    | 'highlightCaseSensitive'
+    | 'highlightStyles'
+  >
+>;
 
 /** Argument shape for the `loadData` callback. */
 export interface TreeLoadDataNode {
@@ -146,6 +175,24 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
 
   /** Called when row selection changes. */
   onSelect?: (selectedKeys: Key[], info: TreeOnSelectInfo) => void;
+
+  /**
+   * Customize Item props per tree node.
+   *
+   * Accepts a static object (applied to every row) or a callback that
+   * receives the node data and returns props for that row.
+   *
+   * Supported props: `prefix`, `suffix`, `actions`, `autoHideActions`,
+   * `preserveActionsSpace`, `description`, `descriptionPlacement`,
+   * `rightIcon`, `tooltip`, `highlight`, `highlightCaseSensitive`,
+   * `highlightStyles`.
+   *
+   * The `icon` slot is reserved for the expand/collapse toggle.
+   * Use `prefix` for custom node icons.
+   */
+  itemProps?:
+    | TreeItemProps
+    | ((data: CubeTreeNodeData, state: TreeNodeState) => TreeItemProps);
 
   /** Override styles for `[data-element="Row"]` (per-row root). */
   rowStyles?: Styles;

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -1,6 +1,7 @@
 import type { Key } from '@react-types/shared';
 import type { BaseProps, OuterStyleProps, Styles } from '@tenphi/tasty';
 import type { ReactNode } from 'react';
+import type { SizeName } from '../../../tokens/sizes';
 import type { CubeItemProps } from '../Item/Item';
 
 /** Selection cardinality, mirroring React Aria/Stately's `selectionMode`. */
@@ -116,6 +117,9 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
 
   /** Selection cardinality. Defaults to `'single'`. */
   selectionMode?: TreeSelectionMode;
+
+  /** Row size. Defaults to `'medium'`. */
+  size?: SizeName;
 
   /** Disable the entire tree. */
   isDisabled?: boolean;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -21,22 +21,24 @@ global.IS_REACT_ACT_ENVIRONMENT = true;
 
 // Mock @tanstack/react-virtual for test environment
 vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: vi.fn().mockImplementation(({ count = 0 }) => ({
-    getVirtualItems: () =>
-      Array.from({ length: count }, (_, index) => ({
-        index,
-        key: index,
-        start: index * 40,
-        size: 40,
-      })),
-    getTotalSize: () => count * 40,
+  useVirtualizer: vi
+    .fn()
+    .mockImplementation(({ count = 0, getItemKey }: any) => ({
+      getVirtualItems: () =>
+        Array.from({ length: count }, (_, index) => ({
+          index,
+          key: typeof getItemKey === 'function' ? getItemKey(index) : index,
+          start: index * 40,
+          size: 40,
+        })),
+      getTotalSize: () => count * 40,
 
-    scrollToIndex: vi.fn(),
+      scrollToIndex: vi.fn(),
 
-    measure: vi.fn(),
+      measure: vi.fn(),
 
-    measureElement: vi.fn(),
-  })),
+      measureElement: vi.fn(),
+    })),
 }));
 
 // Suppress act() warnings from @testing-library/react-hooks


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces virtualization and new rendering/layout behavior for `Tree`, which can affect keyboard navigation, scrolling, and row measurement in edge cases. Also changes default row size/styling and adds a new `itemProps` API that alters how row props are composed.
> 
> **Overview**
> **Tree now virtualizes its rows** using `@tanstack/react-virtual`, rendering only visible nodes and absolutely positioning rows inside a measured container; a `useLayoutEffect` was added to keep the focused row scrolled into view during keyboard navigation.
> 
> Adds new `Tree` props: `size` (default **changed from `small` to `medium`**) and `itemProps` (static or callback) to customize per-node `Item` slots like `prefix/actions/suffix` with access to node state (expanded/selected/checked/etc.). `TreeNode` composes checkbox + custom prefix, forwards these props to `TreeRowItem`, and adds Space-key toggling for checkable rows.
> 
> Updates Tree styling for virtualization (root padding removed, row indent adjusted) and adds a new Storybook example (`DirectoryTree`). Test setup mocks `useVirtualizer` with support for `getItemKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e928e3a9ab7a78f578131d06753ea7a5628eef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->