### PR TITLE
fix(Tab): selectedKeys in menuProps not matching without `.$` prefix

### DIFF
--- a/.changeset/tab-menu-selected-keys.md
+++ b/.changeset/tab-menu-selected-keys.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Fix `selectedKeys` in `Tab.menuProps` not working without manual `.$` prefix

--- a/src/components/navigation/Tabs/TabButton.tsx
+++ b/src/components/navigation/Tabs/TabButton.tsx
@@ -82,40 +82,58 @@ function processMenuItems(
   effectiveIsEditable: boolean,
   isDeletable: boolean,
 ): ReactNode {
-  return Children.toArray(children).map((child) => {
-    if (!isValidElement(child)) return child;
+  // Use Children.forEach instead of Children.toArray to avoid React prepending
+  // ".$" to element keys, which breaks selectedKeys matching in Menu.
+  const result: ReactNode[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      result.push(child);
+      return;
+    }
 
     const childKey = getRawKey(child);
     const childProps = child.props as MenuItemLikeProps;
 
     // Handle predefined action keys
     if (childKey === 'rename') {
-      return cloneElement(child as ReactElement<MenuItemLikeProps>, {
-        children: childProps.children ?? 'Rename',
-        isDisabled: childProps.isDisabled ?? !effectiveIsEditable,
-      });
+      result.push(
+        cloneElement(child as ReactElement<MenuItemLikeProps>, {
+          children: childProps.children ?? 'Rename',
+          isDisabled: childProps.isDisabled ?? !effectiveIsEditable,
+        }),
+      );
+      return;
     }
     if (childKey === 'delete') {
-      return cloneElement(child as ReactElement<MenuItemLikeProps>, {
-        children: childProps.children ?? 'Delete',
-        theme: childProps.theme ?? 'danger',
-        isDisabled: childProps.isDisabled ?? !isDeletable,
-      });
+      result.push(
+        cloneElement(child as ReactElement<MenuItemLikeProps>, {
+          children: childProps.children ?? 'Delete',
+          theme: childProps.theme ?? 'danger',
+          isDisabled: childProps.isDisabled ?? !isDeletable,
+        }),
+      );
+      return;
     }
 
     // Recursively process Menu.Section children
     if (childProps.children && typeof childProps.children !== 'string') {
-      return cloneElement(child as ReactElement<MenuItemLikeProps>, {
-        children: processMenuItems(
-          childProps.children,
-          effectiveIsEditable,
-          isDeletable,
-        ),
-      });
+      result.push(
+        cloneElement(child as ReactElement<MenuItemLikeProps>, {
+          children: processMenuItems(
+            childProps.children,
+            effectiveIsEditable,
+            isDeletable,
+          ),
+        }),
+      );
+      return;
     }
 
-    return child;
+    result.push(child);
   });
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
Made-with: Cursor

### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to how Tab overflow menu children are iterated to preserve React element keys; behavior impact is limited to menu selection/highlighting for tab menus.
> 
> **Overview**
> Fixes `Tab.menuProps.selectedKeys` not matching menu item keys by changing menu child processing to avoid React’s `Children.toArray` key normalization (which can prepend `.$`).
> 
> Adds a patch changeset and updates `processMenuItems` to iterate with `Children.forEach` while preserving original keys, keeping predefined `rename`/`delete` handling and recursive section processing intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f62153a6bfdb94832c56a12d6ac64a827f5b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->