### PR TITLE
fix(Button): disabled state resolution in Button.Split context

### DIFF
--- a/.changeset/fix-button-split-disabled.md
+++ b/.changeset/fix-button-split-disabled.md
@@ -1,0 +1,9 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix `Button` disabled state resolution in `Button.Split` context.
+
+- Replace `??` chain with `||` so that `isLoading={false}` no longer blocks `splitContext.isDisabled` inheritance
+- Ensure `splitContext.isDisabled` always wins over child props (a disabled split button should disable all children)
+- Fix edge case where `isDisabled={false}` with `isLoading={true}` incorrectly resulted in a clickable loading button

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -400,7 +400,7 @@ export const Button = forwardRef(function Button(
     sizeProp ?? splitContext?.size ?? (type === 'link' ? 'inline' : 'medium');
 
   const isDisabled =
-    props.isDisabled ?? props.isLoading ?? splitContext?.isDisabled;
+    splitContext?.isDisabled || props.isDisabled || props.isLoading;
   const isLoading = props.isLoading;
   const isSelected = props.isSelected;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core `Button` disabled/loading resolution logic, which can subtly affect clickability and interaction behavior across split buttons. Low code churn, but behavior changes may impact consumers relying on previous precedence.
> 
> **Overview**
> Fixes `Button` disabled-state precedence when rendered inside `Button.Split` by switching from a nullish-coalescing chain to boolean `||` evaluation.
> 
> `splitContext.isDisabled` now *always overrides* child `isDisabled`/`isLoading` props, preventing cases where `isLoading={false}` or `isDisabled={false}` could inadvertently keep a split child clickable (including a loading button edge case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7334712a02ecaf9312bcba1668a8f9b88dc148f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->