### PR TITLE
feat(Tree): add shape prop and container padding

### DIFF
--- a/.changeset/tree-padding-and-shape.md
+++ b/.changeset/tree-padding-and-shape.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": minor
+---
+
+Added `shape` prop to `Tree` with `default` and `card` values for controlling border and radius. Added `containerPadding` prop for adjustable padding around the tree content via virtualizer configuration.

--- a/src/components/content/Tree/Tree.stories.tsx
+++ b/src/components/content/Tree/Tree.stories.tsx
@@ -142,6 +142,23 @@ const meta = {
     },
 
     /* Presentation */
+    shape: {
+      control: 'radio',
+      options: ['default', 'card'],
+      description: 'Visual shape of the tree container',
+      table: {
+        defaultValue: { summary: 'default' },
+        type: { summary: "'default' | 'card'" },
+      },
+    },
+    containerPadding: {
+      control: 'number',
+      description: 'Padding (px) around the tree content',
+      table: {
+        defaultValue: { summary: '4' },
+        type: { summary: 'number' },
+      },
+    },
     height: {
       control: 'number',
       description:
@@ -409,6 +426,13 @@ export const AutoExpandParent: Story = {
   render: AutoExpandParentRender,
 };
 
+export const CardShape: Story = {
+  args: {
+    shape: 'card',
+    defaultExpandedKeys: ['src', 'src/components'],
+  },
+};
+
 export const Empty: Story = {
   args: {
     treeData: [],
@@ -426,11 +450,10 @@ const WrappedFileIcon = () => (
 export const DirectoryTree: Story = {
   args: {
     selectionMode: 'none',
+    shape: 'card',
     defaultExpandedKeys: ['src', 'src/components'],
     styles: {
       width: '200px',
-      border: true,
-      radius: '1cr',
     },
     itemProps: (data, { isExpanded }) => {
       const isFolder = !!data.children;

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -116,6 +116,8 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     isSelectable,
     selectionMode: selectionModeProp,
     size = 'medium',
+    shape = 'default',
+    containerPadding = 4,
     isDisabled = false,
     defaultExpandedKeys,
     expandedKeys,
@@ -348,6 +350,8 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     estimateSize: () => SIZES[SIZE_NAME_TO_KEY[size]],
     gap: 1,
     overscan: 10,
+    paddingStart: containerPadding,
+    paddingEnd: containerPadding,
   });
 
   const containerStyle = useMemo<CSSProperties>(() => {
@@ -380,8 +384,9 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
   const mods = useMemo(
     () => ({
       'has-height': height != null,
+      shape,
     }),
-    [height],
+    [height, shape],
   );
 
   // Both `useTree` and the consumer need the same DOM node.
@@ -422,8 +427,8 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
             virtualStyle={{
               position: 'absolute',
               top: 0,
-              left: 0,
-              right: 0,
+              left: containerPadding,
+              right: containerPadding,
               transform: `translateY(${virtualItem.start}px)`,
             }}
             virtualRef={rowVirtualizer.measureElement}

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -30,7 +30,7 @@ export const TreeElement = tasty({
     transition: 'theme',
     outline: 0,
     padding: 0,
-    radius: { '': 0, 'shape=card': true },
+    radius: { '': 0, 'shape=card': '1cr' },
     border: { '': 0, 'shape=card': true },
   },
 });

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -30,6 +30,8 @@ export const TreeElement = tasty({
     transition: 'theme',
     outline: 0,
     padding: 0,
+    radius: { '': 0, 'shape=card': true },
+    border: { '': 0, 'shape=card': true },
   },
 });
 
@@ -45,7 +47,6 @@ export const TreeNodeRow = tasty({
   qa: 'TreeRow',
   styles: {
     display: 'block',
-    width: '100%',
     outline: 0,
   },
 });

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -121,6 +121,17 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
   /** Row size. Defaults to `'medium'`. */
   size?: SizeName;
 
+  /**
+   * Visual shape of the tree container.
+   * - `default` — no border or radius
+   * - `card` — rounded corners with a border
+   * @default "default"
+   */
+  shape?: 'default' | 'card';
+
+  /** Padding (px) around the tree content. Applied via the virtualizer for vertical and CSS for horizontal. @default 4 */
+  containerPadding?: number;
+
   /** Disable the entire tree. */
   isDisabled?: boolean;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Tree virtualization layout (padding and row positioning) and container styling, which could affect scrolling/measurement and visual regressions in existing consumers.
> 
> **Overview**
> Adds new presentation options to `Tree`: a `shape` prop (`default`/`card`) that toggles border + radius on the root container, and a `containerPadding` prop (default `4`) that applies vertical padding via the virtualizer and horizontal insets by offsetting virtualized row positioning.
> 
> Updates Storybook controls and examples to demonstrate the new card styling, and includes a changeset bumping `@cube-dev/ui-kit` minor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3782e5f1212c4c33a0731ee1c6349797a467204d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->