### PR TITLE
feat(Tree): add per-row menu, contextMenu, and expandOnFolderClick

### DIFF
--- a/.changeset/tree-expand-on-folder-click.md
+++ b/.changeset/tree-expand-on-folder-click.md
@@ -2,4 +2,10 @@
 '@cube-dev/ui-kit': minor
 ---
 
-Add `expandOnFolderClick` prop to `Tree`. When enabled, activating a non-leaf row (mouse click or `Enter` / `Space`) toggles its expansion instead of triggering selection — useful for file-tree UX where only leaves are meaningful selection targets. Leaves still select normally; the chevron toggle, keyboard navigation, and right-click context menu continue to work independently.
+Add `expandOnFolderClick` prop to `Tree`. When enabled, activating a non-leaf row toggles its expansion instead of triggering selection — useful for file-tree UX where only leaves are meaningful selection targets. Leaves still select normally; the chevron toggle, keyboard navigation, and right-click context menu continue to work independently.
+
+Activation rules:
+
+- Mouse click on a folder row → expand / collapse.
+- `Enter` on a folder row → expand / collapse (always, including in `isCheckable` trees, where it does NOT toggle the checkbox).
+- `Space` on a folder row → expand / collapse in non-checkable trees; in `isCheckable` trees `Space` is reserved for toggling the row's checkbox.

--- a/.changeset/tree-expand-on-folder-click.md
+++ b/.changeset/tree-expand-on-folder-click.md
@@ -9,3 +9,5 @@ Activation rules:
 - Mouse click on a folder row → expand / collapse.
 - `Enter` on a folder row → expand / collapse (always, including in `isCheckable` trees, where it does NOT toggle the checkbox).
 - `Space` on a folder row → expand / collapse in non-checkable trees; in `isCheckable` trees `Space` is reserved for toggling the row's checkbox.
+
+Clicks that originate inside an interactive descendant of a folder row (chevron, checkbox, overflow `⋮` trigger, user-supplied buttons / links / inputs in the `prefix` and `actions` slots) no longer bubble up to the row's expand-on-click handler, so the chevron does not visibly double-toggle and inner controls do not have the side effect of expanding / collapsing the row.

--- a/.changeset/tree-expand-on-folder-click.md
+++ b/.changeset/tree-expand-on-folder-click.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': minor
 ---
 
-Add `expandOnFolderClick` prop to `Tree`. When enabled, pressing a non-leaf row toggles its expansion instead of triggering selection — useful for file-tree UX where only leaves are meaningful selection targets. The chevron toggle and keyboard navigation continue to work independently.
+Add `expandOnFolderClick` prop to `Tree`. When enabled, activating a non-leaf row (mouse click or `Enter` / `Space`) toggles its expansion instead of triggering selection — useful for file-tree UX where only leaves are meaningful selection targets. Leaves still select normally; the chevron toggle, keyboard navigation, and right-click context menu continue to work independently.

--- a/.changeset/tree-expand-on-folder-click.md
+++ b/.changeset/tree-expand-on-folder-click.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `expandOnFolderClick` prop to `Tree`. When enabled, pressing a non-leaf row toggles its expansion instead of triggering selection — useful for file-tree UX where only leaves are meaningful selection targets. The chevron toggle and keyboard navigation continue to work independently.

--- a/.changeset/tree-row-menu.md
+++ b/.changeset/tree-row-menu.md
@@ -3,3 +3,5 @@
 ---
 
 Add `menu`, `contextMenu`, `onAction`, `menuTriggerProps`, and `menuProps` to `Tree`. The new props mirror the `Tabs` API: `contextMenu={true}` renders a built-in `⋮` overflow trigger AND opens the same menu on right-click / Shift+F10; `'context-only'` keeps the right-click menu but hides the overflow trigger. Per-node overrides (`data.menu`, `data.contextMenu`, `data.onAction`) take precedence over tree-level defaults. An `onAction` supplied via `menuProps` is chained with the tree-level / per-node `onAction` callbacks so consumer-supplied handlers also fire.
+
+While re-wiring the row's `onKeyDown` for the menu / `expandOnFolderClick` shortcuts, the chained behavior of `Space` in `isCheckable` trees was preserved: pressing `Space` on a focused row toggles the row's checkbox AND continues to fire the tree's selection logic (matching the previous `mergeProps`-based chaining), so existing consumers see no change.

--- a/.changeset/tree-row-menu.md
+++ b/.changeset/tree-row-menu.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': minor
 ---
 
-Add `menu`, `contextMenu`, `onAction`, `menuTriggerProps`, and `menuProps` to `Tree`. The new props mirror the `Tabs` API: `contextMenu={true}` renders a built-in `⋮` overflow trigger AND opens the same menu on right-click / Shift+F10; `'context-only'` keeps the right-click menu but hides the overflow trigger. Per-node overrides (`data.menu`, `data.contextMenu`, `data.onAction`) take precedence over tree-level defaults.
+Add `menu`, `contextMenu`, `onAction`, `menuTriggerProps`, and `menuProps` to `Tree`. The new props mirror the `Tabs` API: `contextMenu={true}` renders a built-in `⋮` overflow trigger AND opens the same menu on right-click / Shift+F10; `'context-only'` keeps the right-click menu but hides the overflow trigger. Per-node overrides (`data.menu`, `data.contextMenu`, `data.onAction`) take precedence over tree-level defaults. An `onAction` supplied via `menuProps` is chained with the tree-level / per-node `onAction` callbacks so consumer-supplied handlers also fire.

--- a/.changeset/tree-row-menu.md
+++ b/.changeset/tree-row-menu.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `menu`, `contextMenu`, `onAction`, `menuTriggerProps`, and `menuProps` to `Tree`. The new props mirror the `Tabs` API: `contextMenu={true}` renders a built-in `⋮` overflow trigger AND opens the same menu on right-click / Shift+F10; `'context-only'` keeps the right-click menu but hides the overflow trigger. Per-node overrides (`data.menu`, `data.contextMenu`, `data.onAction`) take precedence over tree-level defaults.

--- a/src/components/content/Tree/Tree.docs.mdx
+++ b/src/components/content/Tree/Tree.docs.mdx
@@ -68,9 +68,11 @@ consumers can be migrated with minimal churn.
 - **`onSelect`** `(selectedKeys: Key[], info: TreeOnSelectInfo) => void` —
   Called when row selection changes.
 - **`expandOnFolderClick`** `boolean` (default: `false`) — When `true`,
-  pressing a non-leaf row toggles its expansion instead of selecting
-  it. The chevron and keyboard navigation continue to work
-  independently. Useful for file-tree UX where only leaves are
+  activating a non-leaf row toggles its expansion instead of selecting
+  it. Activation happens on mouse click, `Enter`, or `Space` (in
+  checkable trees `Space` is reserved for the row checkbox; `Enter`
+  always expands). The chevron and keyboard navigation continue to
+  work independently. Useful for file-tree UX where only leaves are
   meaningful selection targets.
 - **`menu`** `ReactNode | ((data, state) => ReactNode | null)` — Default
   `Menu.Item` children rendered on every row that doesn't override via
@@ -352,9 +354,16 @@ or `null` to hide it entirely. `data.contextMenu` and
 ### Expand on Folder Click
 
 `expandOnFolderClick` makes folder rows toggle their expansion when
-pressed instead of triggering selection. Leaves still select normally,
+activated instead of triggering selection. Leaves still select normally,
 which mirrors typical file-tree UX. Folder rows remain focusable for
 keyboard navigation, and the chevron toggle keeps working.
+
+Activation rules for folder rows:
+
+- Mouse click → expand / collapse.
+- `Enter` → expand / collapse (always, including in `isCheckable` trees).
+- `Space` → expand / collapse in non-checkable trees; in `isCheckable`
+  trees `Space` toggles the row's checkbox instead.
 
 ```jsx
 <Tree treeData={data} expandOnFolderClick />

--- a/src/components/content/Tree/Tree.docs.mdx
+++ b/src/components/content/Tree/Tree.docs.mdx
@@ -1,4 +1,5 @@
-import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
 import { Tree } from './Tree';
 import * as TreeStories from './Tree.stories';
 
@@ -77,12 +78,14 @@ consumers can be migrated with minimal churn.
   that specific row.
 - **`contextMenu`** `boolean | 'context-only'` (default: `false`) — How
   the row menu is exposed.
+
   - `false` — no menu at all.
   - `true` — render an overflow `⋮` trigger inside `actions` AND open
     the same menu on right-click / Shift+F10.
   - `'context-only'` — right-click / Shift+F10 only; no `⋮` trigger.
 
   Per-node `data.contextMenu` wins when provided.
+
 - **`onAction`** `(action: string, key: Key) => void` — Called when a
   menu action is triggered on any row. Receives the action key (with
   React's `.$` prefix stripped) and the row key. Per-node
@@ -90,7 +93,10 @@ consumers can be migrated with minimal churn.
 - **`menuTriggerProps`** `Partial<CubeMenuTriggerProps>` — Forwarded to
   every per-row `MenuTrigger`.
 - **`menuProps`** `Partial<CubeMenuProps<object>>` — Forwarded to every
-  per-row `Menu`.
+  per-row `Menu` (both the overflow `⋮` menu and the right-click context
+  menu). If you pass `onAction` here, it is **chained with** the
+  tree-level `onAction`/per-node `data.onAction` callbacks (it does not
+  override them) and receives the same normalized action key.
 - **`rowStyles`** `Styles` — Override styles for `[data-element="Row"]`.
 
 #### `CubeTreeNodeData`
@@ -155,17 +161,17 @@ These properties allow direct style application without using the `styles` prop:
 The following row-level modifiers are emitted automatically. They are
 useful when overriding `rowStyles`:
 
-| Modifier        | Type      | Description                                            |
-| --------------- | --------- | ------------------------------------------------------ |
-| `selected`      | `boolean` | Row is selected.                                       |
-| `checked`       | `boolean` | Row is fully checked.                                  |
-| `indeterminate` | `boolean` | Row is in the half-checked state.                      |
-| `expanded`      | `boolean` | Row is expanded.                                       |
-| `disabled`      | `boolean` | Row is disabled.                                       |
-| `loading`       | `boolean` | The row's children are being fetched via `loadData`.   |
-| `leaf`          | `boolean` | Row has no children.                                   |
-| `has-checkbox`  | `boolean` | Row renders a checkbox.                                |
-| `has-menu`      | `boolean` | Row resolves a non-empty menu.                         |
+| Modifier        | Type      | Description                                          |
+| --------------- | --------- | ---------------------------------------------------- |
+| `selected`      | `boolean` | Row is selected.                                     |
+| `checked`       | `boolean` | Row is fully checked.                                |
+| `indeterminate` | `boolean` | Row is in the half-checked state.                    |
+| `expanded`      | `boolean` | Row is expanded.                                     |
+| `disabled`      | `boolean` | Row is disabled.                                     |
+| `loading`       | `boolean` | The row's children are being fetched via `loadData`. |
+| `leaf`          | `boolean` | Row has no children.                                 |
+| `has-checkbox`  | `boolean` | Row renders a checkbox.                              |
+| `has-menu`      | `boolean` | Row resolves a non-empty menu.                       |
 
 ## Variants
 
@@ -182,13 +188,19 @@ useful when overriding `rowStyles`:
 
 ```jsx
 const data = [
-  { key: 'fruits', title: 'Fruits', children: [
-    { key: 'apple', title: 'Apple' },
-    { key: 'banana', title: 'Banana' },
-  ]},
-  { key: 'vegetables', title: 'Vegetables', children: [
-    { key: 'carrot', title: 'Carrot' },
-  ]},
+  {
+    key: 'fruits',
+    title: 'Fruits',
+    children: [
+      { key: 'apple', title: 'Apple' },
+      { key: 'banana', title: 'Banana' },
+    ],
+  },
+  {
+    key: 'vegetables',
+    title: 'Vegetables',
+    children: [{ key: 'carrot', title: 'Carrot' }],
+  },
 ];
 
 <Tree treeData={data} defaultExpandedKeys={['fruits']} />;
@@ -222,14 +234,17 @@ To match AntD's object-shape API, pass `checkedKeys` as
 `{ checked, halfChecked }`. `onCheck` returns the same shape.
 
 ```jsx
-const [checkedKeys, setCheckedKeys] = useState({ checked: [], halfChecked: [] });
+const [checkedKeys, setCheckedKeys] = useState({
+  checked: [],
+  halfChecked: [],
+});
 
 <Tree
   treeData={data}
   isCheckable
   checkedKeys={checkedKeys}
   onCheck={(next) => setCheckedKeys(next)}
-/>
+/>;
 ```
 
 <Story of={TreeStories.ControlledChecked} />
@@ -247,7 +262,7 @@ const handleLoadData = (node) =>
     .then((r) => r.json())
     .then((children) => mergeIntoTreeData(node.key, children));
 
-<Tree treeData={data} loadData={handleLoadData} />
+<Tree treeData={data} loadData={handleLoadData} />;
 ```
 
 <Story of={TreeStories.LazyLoading} />
@@ -258,11 +273,7 @@ Pass the matching keys via `expandedKeys` and set `autoExpandParent` to
 keep their ancestors expanded.
 
 ```jsx
-<Tree
-  treeData={data}
-  expandedKeys={matchedKeys}
-  autoExpandParent
-/>
+<Tree treeData={data} expandedKeys={matchedKeys} autoExpandParent />
 ```
 
 <Story of={TreeStories.AutoExpandParent} />
@@ -274,14 +285,18 @@ node-level flags.
 
 ```jsx
 const data = [
-  { key: 'a', title: 'A', children: [
-    { key: 'a-1', title: 'A-1', isDisabled: true },
-    { key: 'a-2', title: 'A-2', isCheckboxDisabled: true },
-    { key: 'a-3', title: 'A-3', isCheckable: false },
-  ]},
+  {
+    key: 'a',
+    title: 'A',
+    children: [
+      { key: 'a-1', title: 'A-1', isDisabled: true },
+      { key: 'a-2', title: 'A-2', isCheckboxDisabled: true },
+      { key: 'a-3', title: 'A-3', isCheckable: false },
+    ],
+  },
 ];
 
-<Tree treeData={data} isCheckable defaultExpandedKeys={['a']} />
+<Tree treeData={data} isCheckable defaultExpandedKeys={['a']} />;
 ```
 
 <Story of={TreeStories.PerNodeDisable} />

--- a/src/components/content/Tree/Tree.docs.mdx
+++ b/src/components/content/Tree/Tree.docs.mdx
@@ -66,6 +66,31 @@ consumers can be migrated with minimal churn.
   — Called when a node is checked or unchecked.
 - **`onSelect`** `(selectedKeys: Key[], info: TreeOnSelectInfo) => void` —
   Called when row selection changes.
+- **`expandOnFolderClick`** `boolean` (default: `false`) — When `true`,
+  pressing a non-leaf row toggles its expansion instead of selecting
+  it. The chevron and keyboard navigation continue to work
+  independently. Useful for file-tree UX where only leaves are
+  meaningful selection targets.
+- **`menu`** `ReactNode | ((data, state) => ReactNode | null)` — Default
+  `Menu.Item` children rendered on every row that doesn't override via
+  `data.menu`. Returning `null` from the callback hides the menu for
+  that specific row.
+- **`contextMenu`** `boolean | 'context-only'` (default: `false`) — How
+  the row menu is exposed.
+  - `false` — no menu at all.
+  - `true` — render an overflow `⋮` trigger inside `actions` AND open
+    the same menu on right-click / Shift+F10.
+  - `'context-only'` — right-click / Shift+F10 only; no `⋮` trigger.
+
+  Per-node `data.contextMenu` wins when provided.
+- **`onAction`** `(action: string, key: Key) => void` — Called when a
+  menu action is triggered on any row. Receives the action key (with
+  React's `.$` prefix stripped) and the row key. Per-node
+  `data.onAction` is called first.
+- **`menuTriggerProps`** `Partial<CubeMenuTriggerProps>` — Forwarded to
+  every per-row `MenuTrigger`.
+- **`menuProps`** `Partial<CubeMenuProps<object>>` — Forwarded to every
+  per-row `Menu`.
 - **`rowStyles`** `Styles` — Override styles for `[data-element="Row"]`.
 
 #### `CubeTreeNodeData`
@@ -82,6 +107,13 @@ consumers can be migrated with minimal churn.
   row.
 - **`isCheckable`** `boolean` — Per-node override; `false` hides the
   checkbox for this row even when the tree is `isCheckable`.
+- **`menu`** `ReactNode | null` — Per-node menu override. Wins over
+  the tree-level `menu`. Pass `null` to hide the menu for this row
+  when the tree provides a default.
+- **`contextMenu`** `boolean | 'context-only'` — Per-node override of
+  the tree-level `contextMenu`.
+- **`onAction`** `(action: string) => void` — Per-node action callback.
+  Called before the tree-level `onAction`.
 
 ### Base Properties
 
@@ -110,6 +142,14 @@ spacing, hover/selected colors, or cell layout without re-targeting via
 - `Checkbox` — The checkbox slot (visible only when `isCheckable`).
 - `Title` — The title label.
 
+### Style Properties
+
+These properties allow direct style application without using the `styles` prop:
+
+- **Position:** `gridArea`, `order`, `gridColumn`, `gridRow`, `placeSelf`, `alignSelf`, `justifySelf`, `zIndex`, `margin`, `inset`, `position`, `scrollMargin`
+- **Dimension:** `width`, `height`, `flexBasis`, `flexGrow`, `flexShrink`, `flex`
+- **Block:** `border`, `radius`, `shadow`, `outline`
+
 ### Modifiers
 
 The following row-level modifiers are emitted automatically. They are
@@ -125,6 +165,7 @@ useful when overriding `rowStyles`:
 | `loading`       | `boolean` | The row's children are being fetched via `loadData`.   |
 | `leaf`          | `boolean` | Row has no children.                                   |
 | `has-checkbox`  | `boolean` | Row renders a checkbox.                                |
+| `has-menu`      | `boolean` | Row resolves a non-empty menu.                         |
 
 ## Variants
 
@@ -253,6 +294,59 @@ const data = [
 
 <Story of={TreeStories.FixedHeight} />
 
+### Per-row Menu (Overflow + Right-Click)
+
+Pass `menu` (a `ReactNode` of `Menu.Item`s, or a callback) plus
+`contextMenu={true}` to render a built-in `⋮` overflow trigger AND
+open the same menu on right-click / `Shift+F10`. Use
+`onAction(action, key)` at the tree level to handle actions, or
+`data.onAction` for per-node behavior.
+
+```jsx
+<Tree
+  treeData={data}
+  contextMenu
+  menu={
+    <>
+      <Menu.Item key="rename">Rename</Menu.Item>
+      <Menu.Item key="duplicate">Duplicate</Menu.Item>
+      <Menu.Item key="delete">Delete</Menu.Item>
+    </>
+  }
+  onAction={(action, key) => console.log(action, 'on', key)}
+/>
+```
+
+<Story of={TreeStories.WithContextMenu} />
+
+### Right-Click Only
+
+`contextMenu="context-only"` keeps the right-click / `Shift+F10`
+behavior but hides the `⋮` trigger — handy for clean file-tree UIs.
+
+<Story of={TreeStories.WithContextMenuOnly} />
+
+### Per-Node Menu Overrides
+
+Set `data.menu` to override the tree-level menu for a specific row,
+or `null` to hide it entirely. `data.contextMenu` and
+`data.onAction` follow the same per-row override pattern.
+
+<Story of={TreeStories.PerNodeMenu} />
+
+### Expand on Folder Click
+
+`expandOnFolderClick` makes folder rows toggle their expansion when
+pressed instead of triggering selection. Leaves still select normally,
+which mirrors typical file-tree UX. Folder rows remain focusable for
+keyboard navigation, and the chevron toggle keeps working.
+
+```jsx
+<Tree treeData={data} expandOnFolderClick />
+```
+
+<Story of={TreeStories.ExpandOnFolderClick} />
+
 ## Accessibility
 
 Tree implements the
@@ -307,7 +401,6 @@ via `useTree` from React Aria.
 
 - Built-in virtualization for very large trees (10k+ rows).
 - Drag-and-drop reordering, mirroring AntD's `draggable` API.
-- An `onRightClick`/context menu hook.
 - Reveal-on-mount: scroll the focused row into view when expanded
   programmatically.
 - Optional inline title editing.

--- a/src/components/content/Tree/Tree.stories.tsx
+++ b/src/components/content/Tree/Tree.stories.tsx
@@ -1,4 +1,4 @@
-import { IconEdit, IconFile, IconTrash } from '@tabler/icons-react';
+import { IconCopy, IconEdit, IconFile, IconTrash } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 
 import { FolderIcon, FolderOpenIcon, Icon, MoreIcon } from '../../../icons';
@@ -171,6 +171,56 @@ const meta = {
       table: {
         type: { summary: '(node: TreeLoadDataNode) => Promise<void>' },
       },
+    },
+    expandOnFolderClick: {
+      control: 'boolean',
+      description:
+        'Pressing a non-leaf row toggles its expansion instead of triggering selection',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+
+    /* Per-row menu */
+    menu: {
+      control: { type: null },
+      description:
+        'Default `Menu.Item` children rendered on every row. Either a `ReactNode` or a callback `(data, state) => ReactNode | null`. Per-node `data.menu` wins.',
+      table: {
+        type: {
+          summary:
+            'ReactNode | ((data: CubeTreeNodeData, state: TreeNodeState) => ReactNode | null)',
+        },
+      },
+    },
+    contextMenu: {
+      control: 'inline-radio',
+      options: [false, true, 'context-only'],
+      description:
+        "How the row menu is exposed: `false` no menu, `true` ⋮ trigger + right-click, `'context-only'` right-click only.",
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: "boolean | 'context-only'" },
+      },
+    },
+    onAction: {
+      action: 'action',
+      description:
+        'Called when a menu action is triggered on any row. Receives `(action, key)`.',
+      table: {
+        type: { summary: '(action: string, key: Key) => void' },
+      },
+    },
+    menuTriggerProps: {
+      control: { type: null },
+      description: 'Forwarded to every per-row `MenuTrigger`',
+      table: { type: { summary: 'Partial<CubeMenuTriggerProps>' } },
+    },
+    menuProps: {
+      control: { type: null },
+      description: 'Forwarded to every per-row `Menu`',
+      table: { type: { summary: 'Partial<CubeMenuProps<object>>' } },
     },
 
     /* Events */
@@ -460,5 +510,87 @@ export const DirectoryTree: Story = {
         autoHideActions: true,
       };
     },
+  },
+};
+
+const sharedMenu = (
+  <>
+    <Menu.Item key="rename" icon={<IconEdit />}>
+      Rename
+    </Menu.Item>
+    <Menu.Item key="duplicate" icon={<IconCopy />}>
+      Duplicate
+    </Menu.Item>
+    <Menu.Item key="delete" icon={<IconTrash />}>
+      Delete
+    </Menu.Item>
+  </>
+);
+
+/**
+ * `menu` + `contextMenu={true}` adds a built-in `⋮` overflow trigger
+ * to every row. Right-clicking the row (or pressing Shift+F10) opens
+ * the same menu at the pointer position.
+ */
+export const WithContextMenu: Story = {
+  args: {
+    defaultExpandedKeys: ['src', 'src/components'],
+    menu: sharedMenu,
+    contextMenu: true,
+  },
+};
+
+/**
+ * `contextMenu="context-only"` hides the `⋮` trigger but keeps the
+ * right-click / Shift+F10 menu — useful for clean file-tree UIs.
+ */
+export const WithContextMenuOnly: Story = {
+  args: {
+    defaultExpandedKeys: ['src', 'src/components'],
+    menu: sharedMenu,
+    contextMenu: 'context-only',
+  },
+};
+
+/**
+ * Per-node `data.menu` wins over the tree-level `menu` callback. Pass
+ * `null` to disable the menu for a specific row.
+ */
+export const PerNodeMenu: Story = {
+  args: {
+    defaultExpandedKeys: ['root'],
+    contextMenu: true,
+    menu: sharedMenu,
+    treeData: [
+      {
+        key: 'root',
+        title: 'Root (uses tree-level menu)',
+        children: [
+          {
+            key: 'no-menu',
+            title: 'Has no menu',
+            menu: null,
+          },
+          {
+            key: 'custom',
+            title: 'Has custom menu (Open only)',
+            menu: <Menu.Item key="open">Open</Menu.Item>,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+/**
+ * `expandOnFolderClick` makes folder rows toggle their expansion on
+ * click instead of selecting. Leaves still trigger selection. Useful
+ * for file-tree UX where only files are meaningful targets.
+ */
+export const ExpandOnFolderClick: Story = {
+  args: {
+    expandOnFolderClick: true,
+    defaultExpandedKeys: ['src'],
+    selectionMode: 'single',
   },
 };

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -594,6 +594,53 @@ describe('<Tree />', () => {
 
       expect(onAction).toHaveBeenCalledWith('rename', 'fruits');
     });
+
+    it('forwards menu actions to a consumer-supplied `menuProps.onAction`', async () => {
+      const treeOnAction = vi.fn();
+      const menuOnAction = vi.fn();
+      const { getAllByLabelText, getByText } = renderWithRoot(
+        <Tree
+          contextMenu
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          menu={TREE_MENU}
+          menuProps={{ onAction: menuOnAction }}
+          onAction={treeOnAction}
+        />,
+      );
+
+      const triggers = getAllByLabelText('Actions');
+      await act(async () => await userEvent.click(triggers[0]));
+      await act(async () => await userEvent.click(getByText('Rename')));
+
+      expect(treeOnAction).toHaveBeenCalledWith('rename', 'fruits');
+      // Consumer's onAction must also fire with the same normalized key.
+      expect(menuOnAction).toHaveBeenCalledWith('rename');
+    });
+
+    it('forwards `menuProps.onAction` for the right-click context menu too', async () => {
+      const treeOnAction = vi.fn();
+      const menuOnAction = vi.fn();
+      const { getAllByRole, getByText } = renderWithRoot(
+        <Tree
+          contextMenu="context-only"
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          menu={TREE_MENU}
+          menuProps={{ onAction: menuOnAction }}
+          onAction={treeOnAction}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      await act(async () => {
+        await userEvent.pointer({ keys: '[MouseRight>]', target: rows[0] });
+      });
+      await act(async () => await userEvent.click(getByText('Delete')));
+
+      expect(treeOnAction).toHaveBeenCalledWith('delete', 'fruits');
+      expect(menuOnAction).toHaveBeenCalledWith('delete');
+    });
   });
 
   describe('expandOnFolderClick', () => {
@@ -631,6 +678,56 @@ describe('<Tree />', () => {
       expect(onSelect).toHaveBeenCalled();
       const [keys] = onSelect.mock.calls[0];
       expect(keys).toContain('apple');
+    });
+
+    it('toggles expansion via Enter without selecting the folder', async () => {
+      const onSelect = vi.fn();
+      const onExpand = vi.fn();
+      const { getByText, queryByText, getAllByRole } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          treeData={SAMPLE}
+          onSelect={onSelect}
+          onExpand={onExpand}
+        />,
+      );
+
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+
+      const rows = getAllByRole('row');
+      await act(async () => {
+        rows[0].focus();
+        await userEvent.keyboard('{Enter}');
+      });
+
+      expect(getByText('Apple')).toBeInTheDocument();
+      expect(onExpand).toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('toggles expansion via Space without selecting the folder', async () => {
+      const onSelect = vi.fn();
+      const onExpand = vi.fn();
+      const { getByText, queryByText, getAllByRole } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          treeData={SAMPLE}
+          onSelect={onSelect}
+          onExpand={onExpand}
+        />,
+      );
+
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+
+      const rows = getAllByRole('row');
+      await act(async () => {
+        rows[0].focus();
+        await userEvent.keyboard(' ');
+      });
+
+      expect(getByText('Apple')).toBeInTheDocument();
+      expect(onExpand).toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -763,13 +763,11 @@ describe('<Tree />', () => {
     it('Space still toggles the checkbox in checkable trees, not folder expansion', async () => {
       const onCheck = vi.fn();
       const onExpand = vi.fn();
-      const onSelect = vi.fn();
       const { queryByText, getAllByRole } = renderWithRoot(
         <Tree
           expandOnFolderClick
           isCheckable
           treeData={SAMPLE}
-          onSelect={onSelect}
           onExpand={onExpand}
           onCheck={onCheck}
         />,
@@ -783,8 +781,126 @@ describe('<Tree />', () => {
 
       expect(onCheck).toHaveBeenCalled();
       expect(onExpand).not.toHaveBeenCalled();
-      expect(onSelect).not.toHaveBeenCalled();
       expect(queryByText('Apple')).not.toBeInTheDocument();
+    });
+
+    it('does not double-toggle when clicking the chevron', async () => {
+      const { getByText, queryByText, getAllByRole } = renderWithRoot(
+        <Tree expandOnFolderClick treeData={SAMPLE} />,
+      );
+
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+
+      const rows = getAllByRole('row');
+      const fruitsToggle = rows[0].querySelector(
+        'button[data-element="Toggle"]',
+      ) as HTMLButtonElement;
+      await act(async () => await userEvent.click(fruitsToggle));
+
+      // If the row's onClick also fired, the chevron would toggle the
+      // expansion twice (open → close) and Apple would NOT be visible.
+      expect(getByText('Apple')).toBeInTheDocument();
+    });
+
+    it('does not toggle expansion when clicking the overflow menu trigger', async () => {
+      const onExpand = vi.fn();
+      const TREE_MENU = (
+        <>
+          <Menu.Item key="delete">Delete</Menu.Item>
+        </>
+      );
+      const { queryByText, getAllByRole } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          contextMenu
+          treeData={SAMPLE}
+          menu={TREE_MENU}
+          onExpand={onExpand}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      const overflowTrigger = rows[0].querySelector(
+        '[aria-label="Actions"]',
+      ) as HTMLButtonElement;
+      expect(overflowTrigger).not.toBeNull();
+
+      await act(async () => await userEvent.click(overflowTrigger));
+
+      // The overflow trigger should open the menu, NOT expand the folder.
+      expect(onExpand).not.toHaveBeenCalled();
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+    });
+
+    it('does not toggle expansion when clicking inside the prefix slot', async () => {
+      // The `actions` slot already calls `e.stopPropagation()` for us
+      // (see `ACTIONS_EVENT_HANDLERS` in `Item.tsx`), but other slots
+      // — the user-supplied `prefix`, the row label, etc. — don't.
+      // A plain `<button>` rendered there must NOT bubble its click
+      // up into the row's expansion toggle.
+      const onPrefixClick = vi.fn();
+      const onExpand = vi.fn();
+      const { queryByText, container } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          treeData={SAMPLE}
+          itemProps={() => ({
+            prefix: (
+              <button
+                type="button"
+                data-testid="row-prefix-action"
+                onClick={onPrefixClick}
+              >
+                Custom
+              </button>
+            ),
+          })}
+          onExpand={onExpand}
+        />,
+      );
+
+      // Both rows get the prefix button — pick the first (Fruits).
+      const prefixButtons = container.querySelectorAll<HTMLButtonElement>(
+        '[data-testid="row-prefix-action"]',
+      );
+      expect(prefixButtons.length).toBeGreaterThan(0);
+      await act(async () => await userEvent.click(prefixButtons[0]));
+
+      expect(onPrefixClick).toHaveBeenCalledTimes(1);
+      // Row toggle MUST NOT fire — the click is for the inner control.
+      expect(onExpand).not.toHaveBeenCalled();
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Space chaining in checkable trees', () => {
+    it('toggles the checkbox AND selects the row in selectionMode=single', async () => {
+      const onCheck = vi.fn();
+      const onSelect = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          isCheckable
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          onCheck={onCheck}
+          onSelect={onSelect}
+        />,
+      );
+
+      // Apple (a leaf) is the second row when Fruits is expanded.
+      const rows = getAllByRole('row');
+      await act(async () => {
+        rows[1].focus();
+        await userEvent.keyboard(' ');
+      });
+
+      // Pre-Phase-1 behavior: react-aria's onKeyDown was chained via
+      // mergeProps, so Space toggled the checkbox AND selected the
+      // focused row. Both must continue to fire after the refactor.
+      expect(onCheck).toHaveBeenCalled();
+      expect(onSelect).toHaveBeenCalled();
+      const [keys] = onSelect.mock.calls[0];
+      expect(keys).toContain('apple');
     });
   });
 });

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { createRef, useState } from 'react';
 
 import { act, renderWithRoot, waitFor } from '../../../test';
+import { Menu } from '../../actions/Menu';
 
 import { Tree } from './Tree';
 
@@ -506,6 +507,130 @@ describe('<Tree />', () => {
       await waitFor(() => {
         expect(document.activeElement).toBe(rows[1]);
       });
+    });
+  });
+
+  describe('per-row menu', () => {
+    const TREE_MENU = (
+      <>
+        <Menu.Item key="rename">Rename</Menu.Item>
+        <Menu.Item key="delete">Delete</Menu.Item>
+      </>
+    );
+
+    it('renders a `⋮` overflow trigger when contextMenu is `true`', () => {
+      const { getAllByLabelText } = renderWithRoot(
+        <Tree
+          contextMenu
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          menu={TREE_MENU}
+        />,
+      );
+
+      // 3 visible non-empty menus in expanded subtree (Fruits + Apple + Banana
+      // + Vegetables = 4 visible rows total).
+      const triggers = getAllByLabelText('Actions');
+      expect(triggers.length).toBe(4);
+    });
+
+    it('hides the `⋮` trigger when contextMenu is `"context-only"`', () => {
+      const { queryAllByLabelText } = renderWithRoot(
+        <Tree
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          menu={TREE_MENU}
+          contextMenu="context-only"
+        />,
+      );
+
+      expect(queryAllByLabelText('Actions').length).toBe(0);
+    });
+
+    it('does not render any menu when contextMenu is omitted', () => {
+      const { queryAllByLabelText } = renderWithRoot(
+        <Tree
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          menu={TREE_MENU}
+        />,
+      );
+
+      expect(queryAllByLabelText('Actions').length).toBe(0);
+    });
+
+    it('per-node `data.menu` overrides the tree-level menu', () => {
+      const data: CubeTreeNodeData[] = [
+        { key: 'a', title: 'A', menu: null },
+        { key: 'b', title: 'B' },
+      ];
+      const { queryAllByLabelText } = renderWithRoot(
+        <Tree contextMenu treeData={data} menu={TREE_MENU} />,
+      );
+
+      // Row "a" has `menu: null` → no overflow trigger.
+      // Row "b" inherits → has overflow trigger.
+      expect(queryAllByLabelText('Actions').length).toBe(1);
+    });
+
+    it('fires onAction with (action, key) when a menu item is selected', async () => {
+      const onAction = vi.fn();
+      const { getAllByLabelText, getByText } = renderWithRoot(
+        <Tree
+          contextMenu
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          menu={TREE_MENU}
+          onAction={onAction}
+        />,
+      );
+
+      // Open the first row's overflow menu (row "Fruits").
+      const triggers = getAllByLabelText('Actions');
+      await act(async () => await userEvent.click(triggers[0]));
+
+      // Click the "Rename" item.
+      await act(async () => await userEvent.click(getByText('Rename')));
+
+      expect(onAction).toHaveBeenCalledWith('rename', 'fruits');
+    });
+  });
+
+  describe('expandOnFolderClick', () => {
+    it('toggles expansion when a folder row is clicked', async () => {
+      const onSelect = vi.fn();
+      const { getByText, queryByText, getAllByRole } = renderWithRoot(
+        <Tree expandOnFolderClick treeData={SAMPLE} onSelect={onSelect} />,
+      );
+
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+
+      // Click the "Fruits" folder row body (not the chevron).
+      const rows = getAllByRole('row');
+      await act(async () => await userEvent.click(rows[0]));
+
+      expect(getByText('Apple')).toBeInTheDocument();
+      // Folder click should NOT trigger selection.
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('still selects leaves when expandOnFolderClick is on', async () => {
+      const onSelect = vi.fn();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits']}
+          onSelect={onSelect}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      await act(async () => await userEvent.click(rows[1])); // Apple
+
+      expect(onSelect).toHaveBeenCalled();
+      const [keys] = onSelect.mock.calls[0];
+      expect(keys).toContain('apple');
     });
   });
 });

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -729,5 +729,62 @@ describe('<Tree />', () => {
       expect(onExpand).toHaveBeenCalled();
       expect(onSelect).not.toHaveBeenCalled();
     });
+
+    it('expands on Enter even when isCheckable is on (matches mouse-click behavior)', async () => {
+      const onSelect = vi.fn();
+      const onExpand = vi.fn();
+      const onCheck = vi.fn();
+      const { getByText, queryByText, getAllByRole } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          isCheckable
+          treeData={SAMPLE}
+          onSelect={onSelect}
+          onExpand={onExpand}
+          onCheck={onCheck}
+        />,
+      );
+
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+
+      const rows = getAllByRole('row');
+      await act(async () => {
+        rows[0].focus();
+        await userEvent.keyboard('{Enter}');
+      });
+
+      expect(getByText('Apple')).toBeInTheDocument();
+      expect(onExpand).toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
+      // Enter must NOT toggle the checkbox — that's Space's job.
+      expect(onCheck).not.toHaveBeenCalled();
+    });
+
+    it('Space still toggles the checkbox in checkable trees, not folder expansion', async () => {
+      const onCheck = vi.fn();
+      const onExpand = vi.fn();
+      const onSelect = vi.fn();
+      const { queryByText, getAllByRole } = renderWithRoot(
+        <Tree
+          expandOnFolderClick
+          isCheckable
+          treeData={SAMPLE}
+          onSelect={onSelect}
+          onExpand={onExpand}
+          onCheck={onCheck}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      await act(async () => {
+        rows[0].focus();
+        await userEvent.keyboard(' ');
+      });
+
+      expect(onCheck).toHaveBeenCalled();
+      expect(onExpand).not.toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(queryByText('Apple')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -133,6 +133,12 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     rowStyles,
     ariaLabel,
     qa,
+    expandOnFolderClick = false,
+    menu: treeMenu,
+    contextMenu: treeContextMenu,
+    onAction: treeOnAction,
+    menuTriggerProps,
+    menuProps,
     ...otherProps
   } = props;
 
@@ -428,7 +434,13 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
             }}
             virtualRef={rowVirtualizer.measureElement}
             virtualIndex={virtualItem.index}
+            menu={treeMenu}
+            contextMenu={treeContextMenu}
+            menuTriggerProps={menuTriggerProps}
+            menuProps={menuProps}
+            expandOnFolderClick={expandOnFolderClick}
             onToggleChecked={checkbox.toggle}
+            onAction={treeOnAction}
           />
         );
       })}

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -1,9 +1,12 @@
-import { memo, useMemo, useRef } from 'react';
+import { Children, memo, useMemo, useRef, useState } from 'react';
 import { useHover, useTreeItem } from 'react-aria';
 
 import { useEvent } from '../../../_internal/hooks';
-import { DirectionIcon, LoadingIcon } from '../../../icons';
+import { DirectionIcon, LoadingIcon, MoreIcon } from '../../../icons';
 import { mergeProps, mergeRefs } from '../../../utils/react';
+import { CubeItemActionProps, ItemAction } from '../../actions/ItemAction';
+import { CubeMenuProps, Menu, MenuTrigger } from '../../actions/Menu';
+import { useContextMenu } from '../../actions/use-context-menu';
 import { Checkbox } from '../../fields/Checkbox/Checkbox';
 
 import {
@@ -14,15 +17,34 @@ import {
   TreeRowItem,
 } from './styled';
 
-import type { Node } from '@react-types/shared';
+import type { Key, Node } from '@react-types/shared';
 import type { Styles } from '@tenphi/tasty';
-import type { CSSProperties, KeyboardEvent, SyntheticEvent } from 'react';
+import type {
+  CSSProperties,
+  KeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  PointerEvent as ReactPointerEvent,
+  Ref,
+  SyntheticEvent,
+} from 'react';
 import type { TreeState } from 'react-stately';
-import type { CubeTreeNodeData, TreeItemProps, TreeNodeState } from './types';
+import type {
+  CubeTreeNodeData,
+  TreeContextMenu,
+  TreeItemProps,
+  TreeNodeState,
+} from './types';
 
 const stopPropagation = (e: SyntheticEvent) => {
   e.stopPropagation();
 };
+
+/** Check whether a `menu` ReactNode actually contains anything. */
+function isMenuEmpty(menu: ReactNode): boolean {
+  if (menu === null || menu === undefined || menu === false) return true;
+  return Children.toArray(menu).length === 0;
+}
 
 export interface TreeNodeProps {
   node: Node<CubeTreeNodeData>;
@@ -61,6 +83,25 @@ export interface TreeNodeProps {
   virtualRef?: (element: HTMLElement | null) => void;
   /** Virtual index for `data-index` attribute. */
   virtualIndex?: number;
+
+  /** Tree-wide menu default (resolved against `data.menu`). */
+  menu?:
+    | ReactNode
+    | ((data: CubeTreeNodeData, state: TreeNodeState) => ReactNode | null);
+  /** Tree-wide `contextMenu` default. */
+  contextMenu?: TreeContextMenu;
+  /** Tree-wide `onAction` callback. */
+  onAction?: (action: string, key: Key) => void;
+  /** Forwarded to every per-row `MenuTrigger`. */
+  menuTriggerProps?: Partial<CubeItemActionProps>;
+  /** Forwarded to every per-row `Menu`. */
+  menuProps?: Partial<CubeMenuProps<object>>;
+
+  /**
+   * When true, pressing a non-leaf row toggles its expansion instead
+   * of triggering selection.
+   */
+  expandOnFolderClick?: boolean;
 }
 
 function TreeNodeInner(props: TreeNodeProps) {
@@ -80,13 +121,15 @@ function TreeNodeInner(props: TreeNodeProps) {
     virtualStyle,
     virtualRef,
     virtualIndex,
+    menu: treeMenu,
+    contextMenu: treeContextMenu,
+    onAction: treeOnAction,
+    menuTriggerProps,
+    menuProps,
+    expandOnFolderClick,
   } = props;
 
   const rowRef = useRef<HTMLDivElement>(null);
-  const combinedRef = useMemo(
-    () => (virtualRef ? mergeRefs(rowRef, virtualRef) : rowRef),
-    [virtualRef],
-  );
 
   const { rowProps, gridCellProps, expandButtonProps, isPressed } = useTreeItem(
     { node },
@@ -110,11 +153,93 @@ function TreeNodeInner(props: TreeNodeProps) {
     data.isLeaf === true || (data.isLeaf !== false && !node.hasChildNodes);
   const isRowCheckable = isCheckable && data.isCheckable !== false;
 
+  const nodeState: TreeNodeState = {
+    isExpanded,
+    isSelected,
+    isChecked,
+    isIndeterminate,
+    isLeaf,
+  };
+
+  // ---- Menu resolution (per-node override > tree-level) --------------------
+
+  const effectiveMenuChildren: ReactNode =
+    data.menu === null
+      ? null
+      : data.menu !== undefined
+        ? data.menu
+        : typeof treeMenu === 'function'
+          ? treeMenu(data, nodeState)
+          : treeMenu ?? null;
+  const hasMenu = !isMenuEmpty(effectiveMenuChildren);
+
+  const effectiveContextMenu: TreeContextMenu =
+    data.contextMenu ?? treeContextMenu ?? false;
+  // The menu is exposed only when the consumer opts in via
+  // `contextMenu`. When `contextMenu` is `false` (default) we render
+  // nothing, even if `menu` is provided — this matches the plan and
+  // keeps default rows visually clean.
+  const menuExposed =
+    hasMenu &&
+    (effectiveContextMenu === true || effectiveContextMenu === 'context-only');
+  const contextMenuOnly = effectiveContextMenu === 'context-only';
+
+  // Controlled state for menu trigger (enables keyboard opening with Shift+F10)
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleMenuAction = useEvent((action: Key) => {
+    // Strip the ".$" prefix that React adds via Children.toArray/map.
+    const actionStr = String(action);
+    const normalizedAction = actionStr.startsWith('.$')
+      ? actionStr.slice(2)
+      : actionStr;
+    data.onAction?.(normalizedAction);
+    treeOnAction?.(normalizedAction, node.key);
+  });
+
+  const rowContextMenu = useContextMenu<HTMLDivElement, CubeMenuProps<object>>(
+    Menu,
+    { placement: 'bottom start' },
+    {
+      ...menuProps,
+      onAction: handleMenuAction,
+      children: effectiveMenuChildren,
+    },
+  );
+
+  // ---- Checkbox ------------------------------------------------------------
+
   const handleCheckboxChange = useEvent(() => {
     onToggleChecked(String(node.key));
   });
 
+  // ---- Folder-click interception ------------------------------------------
+
+  const shouldExpandOnRowClick =
+    !!expandOnFolderClick && !isLeaf && !isDisabled;
+
+  const handleFolderRowClick = useEvent((e: ReactMouseEvent) => {
+    // Only intercept primary-button clicks; let right-click reach
+    // `useContextMenu` (it listens for the `contextmenu` event).
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    state.toggleKey(node.key);
+    state.selectionManager.setFocused(true);
+    state.selectionManager.setFocusedKey(node.key);
+  });
+
+  const handleFolderRowPointerEvent = useEvent((e: ReactPointerEvent) => {
+    if (e.button !== 0) return;
+    // Stop usePress from latching its `isPressed` state — the row is
+    // not a press target anymore in this mode.
+    e.stopPropagation();
+  });
+
+  // ---- Keyboard ------------------------------------------------------------
+
   const handleKeyDown = useEvent((e: KeyboardEvent) => {
+    // Space toggles the checkbox first when checkable.
     if (
       e.key === ' ' &&
       isRowCheckable &&
@@ -123,8 +248,35 @@ function TreeNodeInner(props: TreeNodeProps) {
     ) {
       e.preventDefault();
       onToggleChecked(String(node.key));
+      return;
+    }
+
+    // Shift+F10 opens the row menu (standard accessibility shortcut).
+    if (e.key === 'F10' && e.shiftKey && menuExposed) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (contextMenuOnly) {
+        rowContextMenu.open();
+      } else {
+        setIsMenuOpen(true);
+      }
+      return;
+    }
+
+    // Enter/Space toggles expansion for folders in expandOnFolderClick mode
+    // (matches the row-click behavior).
+    if (
+      shouldExpandOnRowClick &&
+      (e.key === 'Enter' || e.key === ' ') &&
+      !isRowCheckable
+    ) {
+      e.preventDefault();
+      e.stopPropagation();
+      state.toggleKey(node.key);
     }
   });
+
+  // ---- Mods ----------------------------------------------------------------
 
   const sharedMods = useMemo(
     () => ({
@@ -134,8 +286,17 @@ function TreeNodeInner(props: TreeNodeProps) {
       loading: isLoading,
       leaf: isLeaf,
       'has-checkbox': isRowCheckable,
+      'has-menu': menuExposed,
     }),
-    [isChecked, isIndeterminate, isExpanded, isLoading, isLeaf, isRowCheckable],
+    [
+      isChecked,
+      isIndeterminate,
+      isExpanded,
+      isLoading,
+      isLeaf,
+      isRowCheckable,
+      menuExposed,
+    ],
   );
 
   const rowMods = useMemo(
@@ -170,10 +331,29 @@ function TreeNodeInner(props: TreeNodeProps) {
         : 'false'
     : undefined;
 
-  const finalRowProps = mergeProps(rowProps, hoverProps, {
+  // ---- Compose row props ---------------------------------------------------
+
+  const baseRowProps = mergeProps(rowProps, hoverProps, {
     'aria-checked': ariaChecked,
     onKeyDown: handleKeyDown,
   });
+
+  // When `expandOnFolderClick` applies, replace the click + pointer
+  // handlers so usePress (from `useSelectableItem`) doesn't trigger
+  // selection. We still want focus/keyboard nav, so we manually call
+  // `setFocusedKey` + `setFocused`.
+  const finalRowProps = shouldExpandOnRowClick
+    ? {
+        ...baseRowProps,
+        onClick: handleFolderRowClick,
+        onPointerDown: handleFolderRowPointerEvent,
+        onPointerUp: handleFolderRowPointerEvent,
+        onMouseDown: handleFolderRowPointerEvent as unknown as ReactMouseEvent,
+        onMouseUp: handleFolderRowPointerEvent as unknown as ReactMouseEvent,
+      }
+    : baseRowProps;
+
+  // ---- Toggle (chevron) and checkbox slots --------------------------------
 
   // Leaf rows get a placeholder so sibling indents align.
   const toggleNode = isLeaf ? (
@@ -208,16 +388,15 @@ function TreeNodeInner(props: TreeNodeProps) {
     </TreeNodeCheckboxWrapper>
   ) : null;
 
-  const nodeState: TreeNodeState = {
-    isExpanded,
-    isSelected,
-    isChecked,
-    isIndeterminate,
-    isLeaf,
-  };
+  // ---- Resolve user-supplied per-node Item props --------------------------
+
   const resolvedItemProps =
     typeof itemProps === 'function' ? itemProps(data, nodeState) : itemProps;
-  const { prefix: userPrefix, ...restUserProps } = resolvedItemProps ?? {};
+  const {
+    prefix: userPrefix,
+    actions: userActions,
+    ...restUserProps
+  } = resolvedItemProps ?? {};
 
   const composedPrefix =
     checkboxNode || userPrefix ? (
@@ -227,10 +406,47 @@ function TreeNodeInner(props: TreeNodeProps) {
       </>
     ) : null;
 
+  // ---- Built-in overflow `⋮` action ---------------------------------------
+
+  const menuAction =
+    menuExposed && !contextMenuOnly ? (
+      <MenuTrigger isOpen={isMenuOpen} onOpenChange={setIsMenuOpen}>
+        <ItemAction
+          tabIndex={-1}
+          icon={<MoreIcon />}
+          aria-label="Actions"
+          {...menuTriggerProps}
+        />
+        <Menu {...menuProps} onAction={handleMenuAction}>
+          {effectiveMenuChildren}
+        </Menu>
+      </MenuTrigger>
+    ) : null;
+
+  // Compose with user-supplied actions (user actions render first).
+  const composedActions =
+    userActions || menuAction ? (
+      <>
+        {userActions}
+        {menuAction}
+      </>
+    ) : undefined;
+
+  // ---- Refs / context-menu wiring -----------------------------------------
+
+  // When the context menu is enabled for this row, attach the hook's
+  // `targetRef` to the row so right-clicks land on the correct anchor.
+  const refs = useMemo(() => {
+    const list: Ref<HTMLDivElement>[] = [rowRef];
+    if (virtualRef) list.push(virtualRef);
+    if (menuExposed) list.push(rowContextMenu.targetRef);
+    return mergeRefs(...list);
+  }, [virtualRef, menuExposed, rowContextMenu.targetRef]);
+
   return (
     <TreeNodeRow
       {...finalRowProps}
-      ref={combinedRef}
+      ref={refs}
       mods={rowMods}
       style={rowStyle}
       data-element="Row"
@@ -246,10 +462,12 @@ function TreeNodeInner(props: TreeNodeProps) {
         mods={itemMods}
         icon={toggleNode}
         prefix={composedPrefix}
+        actions={composedActions}
         styles={rowStyles}
       >
         {data.title}
       </TreeRowItem>
+      {menuExposed && rowContextMenu.rendered}
     </TreeNodeRow>
   );
 }

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -24,7 +24,6 @@ import type {
   KeyboardEvent,
   MouseEvent as ReactMouseEvent,
   ReactNode,
-  PointerEvent as ReactPointerEvent,
   Ref,
   SyntheticEvent,
 } from 'react';
@@ -233,12 +232,19 @@ function TreeNodeInner(props: TreeNodeProps) {
     state.selectionManager.setFocusedKey(node.key);
   });
 
-  const handleFolderRowPointerEvent = useEvent((e: ReactPointerEvent) => {
-    if (e.button !== 0) return;
-    // Stop usePress from latching its `isPressed` state — the row is
-    // not a press target anymore in this mode.
-    e.stopPropagation();
-  });
+  // Typed against the broader `MouseEvent` because both pointer and
+  // mouse handlers route here. React's `PointerEvent<T>` extends
+  // `MouseEvent<T>`, so via parameter contravariance this single
+  // function is assignable to both `PointerEventHandler<T>` and
+  // `MouseEventHandler<T>` slots without any casts.
+  const handleFolderRowPointerEvent = useEvent(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      // Stop usePress from latching its `isPressed` state — the row is
+      // not a press target anymore in this mode.
+      e.stopPropagation();
+    },
+  );
 
   // ---- Keyboard ------------------------------------------------------------
 
@@ -273,14 +279,17 @@ function TreeNodeInner(props: TreeNodeProps) {
       return true;
     }
 
-    // Enter/Space toggles expansion for folders in expandOnFolderClick
-    // mode (matches the row-click behavior). Must run BEFORE
-    // `useTreeItem`'s onKeyDown so react-aria doesn't also fire
-    // selection on the same keypress.
+    // Folder activation via keyboard in expandOnFolderClick mode.
+    // Must run BEFORE `useTreeItem`'s onKeyDown so react-aria doesn't
+    // also fire selection on the same keypress.
+    //   - Enter always expands (matches the row-click behavior, even
+    //     when the row is also checkable — Enter is not a checkbox key).
+    //   - Space only expands when the row is NOT checkable; in
+    //     checkable trees Space is reserved for the checkbox toggle
+    //     (handled by the earlier branch).
     if (
       shouldExpandOnRowClick &&
-      (e.key === 'Enter' || e.key === ' ') &&
-      !isRowCheckable
+      (e.key === 'Enter' || (e.key === ' ' && !isRowCheckable))
     ) {
       e.preventDefault();
       e.stopPropagation();
@@ -379,8 +388,8 @@ function TreeNodeInner(props: TreeNodeProps) {
         onClick: handleFolderRowClick,
         onPointerDown: handleFolderRowPointerEvent,
         onPointerUp: handleFolderRowPointerEvent,
-        onMouseDown: handleFolderRowPointerEvent as unknown as ReactMouseEvent,
-        onMouseUp: handleFolderRowPointerEvent as unknown as ReactMouseEvent,
+        onMouseDown: handleFolderRowPointerEvent,
+        onMouseUp: handleFolderRowPointerEvent,
       }
     : baseRowProps;
 

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -195,6 +195,10 @@ function TreeNodeInner(props: TreeNodeProps) {
       : actionStr;
     data.onAction?.(normalizedAction);
     treeOnAction?.(normalizedAction, node.key);
+    // Forward to the consumer-supplied `menuProps.onAction` so users
+    // who pass extra `Menu` props through `menuProps` still receive
+    // the action stream alongside the tree-level callback.
+    menuProps?.onAction?.(normalizedAction);
   });
 
   const rowContextMenu = useContextMenu<HTMLDivElement, CubeMenuProps<object>>(
@@ -238,6 +242,11 @@ function TreeNodeInner(props: TreeNodeProps) {
 
   // ---- Keyboard ------------------------------------------------------------
 
+  // Composed keydown handler. Runs BEFORE `rowProps.onKeyDown` from
+  // `useTreeItem` so we can short-circuit the default react-aria
+  // behavior (which would otherwise trigger selection on Enter/Space).
+  // Returns `true` when the event was handled and react-aria's keydown
+  // must NOT run.
   const handleKeyDown = useEvent((e: KeyboardEvent) => {
     // Space toggles the checkbox first when checkable.
     if (
@@ -247,8 +256,9 @@ function TreeNodeInner(props: TreeNodeProps) {
       !data.isCheckboxDisabled
     ) {
       e.preventDefault();
+      e.stopPropagation();
       onToggleChecked(String(node.key));
-      return;
+      return true;
     }
 
     // Shift+F10 opens the row menu (standard accessibility shortcut).
@@ -260,11 +270,13 @@ function TreeNodeInner(props: TreeNodeProps) {
       } else {
         setIsMenuOpen(true);
       }
-      return;
+      return true;
     }
 
-    // Enter/Space toggles expansion for folders in expandOnFolderClick mode
-    // (matches the row-click behavior).
+    // Enter/Space toggles expansion for folders in expandOnFolderClick
+    // mode (matches the row-click behavior). Must run BEFORE
+    // `useTreeItem`'s onKeyDown so react-aria doesn't also fire
+    // selection on the same keypress.
     if (
       shouldExpandOnRowClick &&
       (e.key === 'Enter' || e.key === ' ') &&
@@ -273,7 +285,21 @@ function TreeNodeInner(props: TreeNodeProps) {
       e.preventDefault();
       e.stopPropagation();
       state.toggleKey(node.key);
+      state.selectionManager.setFocused(true);
+      state.selectionManager.setFocusedKey(node.key);
+      return true;
     }
+
+    return false;
+  });
+
+  // Wrapper that delegates to react-aria's default keydown only when
+  // our handler did not claim the event. Replaces (rather than
+  // chains with) `rowProps.onKeyDown` so the order of handlers is
+  // strictly: our shortcuts → react-aria default.
+  const composedKeyDown = useEvent((e: KeyboardEvent<HTMLDivElement>) => {
+    if (handleKeyDown(e)) return;
+    rowProps.onKeyDown?.(e as unknown as globalThis.KeyboardEvent);
   });
 
   // ---- Mods ----------------------------------------------------------------
@@ -333,10 +359,15 @@ function TreeNodeInner(props: TreeNodeProps) {
 
   // ---- Compose row props ---------------------------------------------------
 
-  const baseRowProps = mergeProps(rowProps, hoverProps, {
+  // Merge react-aria + hover props but EXCLUDE `onKeyDown` from the
+  // chain — `composedKeyDown` already wraps `rowProps.onKeyDown` and
+  // must run first to short-circuit Enter/Space selection in
+  // `expandOnFolderClick` mode.
+  const baseRowProps = {
+    ...mergeProps(rowProps, hoverProps),
     'aria-checked': ariaChecked,
-    onKeyDown: handleKeyDown,
-  });
+    onKeyDown: composedKeyDown,
+  };
 
   // When `expandOnFolderClick` applies, replace the click + pointer
   // handlers so usePress (from `useSelectableItem`) doesn't trigger

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -39,6 +39,55 @@ const stopPropagation = (e: SyntheticEvent) => {
   e.stopPropagation();
 };
 
+/**
+ * CSS selector matching focusable / activatable descendants that
+ * should "absorb" a click so the parent row does not also react to
+ * it. Used by the `expandOnFolderClick` row click / pointer guards.
+ *
+ * Covers the standard interactive elements (`button`, `a`, form
+ * controls), explicit ARIA roles (`button`, `menuitem`, `checkbox`,
+ * `link`, `tab`, `option`, etc.), and react-aria's pressable marker.
+ */
+const INTERACTIVE_DESCENDANT_SELECTOR = [
+  'button',
+  'a[href]',
+  'input',
+  'textarea',
+  'select',
+  '[role="button"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[role="checkbox"]',
+  '[role="radio"]',
+  '[role="link"]',
+  '[role="tab"]',
+  '[role="option"]',
+  '[role="switch"]',
+  '[data-react-aria-pressable]',
+].join(',');
+
+/**
+ * Returns `true` when `target` is (or is contained within) an
+ * interactive element that lives BETWEEN `target` and `currentTarget`
+ * — i.e. something the user clearly intended to click instead of the
+ * row itself.
+ */
+function isInteractiveDescendant(
+  target: EventTarget | null,
+  currentTarget: EventTarget | null,
+): boolean {
+  if (!(target instanceof Element) || !(currentTarget instanceof Element)) {
+    return false;
+  }
+  const interactive = target.closest(INTERACTIVE_DESCENDANT_SELECTOR);
+  return (
+    !!interactive &&
+    interactive !== currentTarget &&
+    currentTarget.contains(interactive)
+  );
+}
+
 /** Check whether a `menu` ReactNode actually contains anything. */
 function isMenuEmpty(menu: ReactNode): boolean {
   if (menu === null || menu === undefined || menu === false) return true;
@@ -225,6 +274,16 @@ function TreeNodeInner(props: TreeNodeProps) {
     // Only intercept primary-button clicks; let right-click reach
     // `useContextMenu` (it listens for the `contextmenu` event).
     if (e.button !== 0) return;
+    // If the click originated inside an interactive descendant
+    // (chevron, checkbox, overflow trigger, user-supplied buttons in
+    // `prefix` / `actions`, etc.) DO NOT toggle the row. Most
+    // react-aria buttons stop propagation through `usePress` already,
+    // and the `actions` slot has its own propagation guard, but
+    // user-supplied controls in the `prefix` slot or any non-react-aria
+    // button do not — without this check they would expand/collapse
+    // the row as a side-effect of being clicked, and the chevron
+    // would visibly double-toggle.
+    if (isInteractiveDescendant(e.target, e.currentTarget)) return;
     e.preventDefault();
     e.stopPropagation();
     state.toggleKey(node.key);
@@ -240,6 +299,10 @@ function TreeNodeInner(props: TreeNodeProps) {
   const handleFolderRowPointerEvent = useEvent(
     (e: ReactMouseEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
+      // Skip when the event originated in an interactive descendant
+      // so the descendant's own usePress / press tracking is not
+      // disrupted by the row swallowing pointer propagation.
+      if (isInteractiveDescendant(e.target, e.currentTarget)) return;
       // Stop usePress from latching its `isPressed` state — the row is
       // not a press target anymore in this mode.
       e.stopPropagation();
@@ -252,9 +315,13 @@ function TreeNodeInner(props: TreeNodeProps) {
   // `useTreeItem` so we can short-circuit the default react-aria
   // behavior (which would otherwise trigger selection on Enter/Space).
   // Returns `true` when the event was handled and react-aria's keydown
-  // must NOT run.
+  // must NOT run; returns `false` to chain to react-aria's handler.
   const handleKeyDown = useEvent((e: KeyboardEvent) => {
-    // Space toggles the checkbox first when checkable.
+    // Space toggles the checkbox first when checkable. We DON'T claim
+    // the event (return `false`) so react-aria's onKeyDown still runs
+    // afterwards and the focused row also selects — matching the
+    // pre-refactor behavior when handlers were chained via
+    // `mergeProps`. `preventDefault` is kept to suppress page scroll.
     if (
       e.key === ' ' &&
       isRowCheckable &&
@@ -262,9 +329,8 @@ function TreeNodeInner(props: TreeNodeProps) {
       !data.isCheckboxDisabled
     ) {
       e.preventDefault();
-      e.stopPropagation();
       onToggleChecked(String(node.key));
-      return true;
+      return false;
     }
 
     // Shift+F10 opens the row menu (standard accessibility shortcut).

--- a/src/components/content/Tree/index.ts
+++ b/src/components/content/Tree/index.ts
@@ -7,4 +7,6 @@ export type {
   TreeOnSelectInfo,
   TreeLoadDataNode,
   TreeSelectionMode,
+  TreeContextMenu,
+  TreeNodeState,
 } from './types';

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -2,10 +2,25 @@ import type { Key } from '@react-types/shared';
 import type { BaseProps, OuterStyleProps, Styles } from '@tenphi/tasty';
 import type { ReactNode } from 'react';
 import type { SizeName } from '../../../tokens/sizes';
+import type { CubeItemActionProps } from '../../actions/ItemAction';
+import type { CubeMenuProps } from '../../actions/Menu';
 import type { CubeItemProps } from '../Item/Item';
 
 /** Selection cardinality, mirroring React Aria/Stately's `selectionMode`. */
 export type TreeSelectionMode = 'none' | 'single' | 'multiple';
+
+/**
+ * How the tree row `menu` is exposed.
+ *
+ * - `false` (default) — no menu at all.
+ * - `true` — render the overflow `⋮` trigger inside `actions` AND open
+ *   the same menu on right-click / Shift+F10.
+ * - `'context-only'` — right-click / Shift+F10 only; no `⋮` trigger.
+ *
+ * Mirrors `TabContextMenu` from `Tabs` so consumers see the same API
+ * across components.
+ */
+export type TreeContextMenu = boolean | 'context-only';
 
 /**
  * A single node in the `treeData` array.
@@ -33,6 +48,19 @@ export interface CubeTreeNodeData {
    * - `false`: hide the checkbox for this row even when the tree is `isCheckable`.
    */
   isCheckable?: boolean;
+  /**
+   * Per-node menu override (Menu.Item children). Wins over the
+   * tree-level `menu` prop. Pass `null` to disable the menu for this
+   * specific row when the tree provides a default `menu`.
+   */
+  menu?: ReactNode | null;
+  /** Per-node `contextMenu` override. */
+  contextMenu?: TreeContextMenu;
+  /**
+   * Per-node `onAction` override. Called before the tree-level
+   * `onAction` with the action key from `Menu.Item`.
+   */
+  onAction?: (action: string) => void;
 }
 
 /** Info passed as the second argument to `onCheck`. */
@@ -206,4 +234,50 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
 
   /** QA selector. */
   qa?: string;
+
+  /**
+   * When `true`, pressing a non-leaf row toggles its expansion
+   * instead of selecting it. Useful for file-tree UX where only
+   * leaves are selectable. Folder rows remain focusable for keyboard
+   * navigation, and the chevron toggle keeps working independently.
+   * @default false
+   */
+  expandOnFolderClick?: boolean;
+
+  /**
+   * Per-tree default menu items (Menu.Item children) shown on every
+   * row that doesn't override via `data.menu`.
+   *
+   * Accepts a static `ReactNode` (applied to every row) or a callback
+   * that receives the row data and the derived state and returns the
+   * menu content. Return `null` to hide the menu for that row.
+   */
+  menu?:
+    | ReactNode
+    | ((data: CubeTreeNodeData, state: TreeNodeState) => ReactNode | null);
+
+  /**
+   * Where the menu is exposed. Same semantics as `Tabs#contextMenu`:
+   * - `false` (default) — no menu at all.
+   * - `true` — render an overflow `⋮` trigger inside `actions` AND
+   *   open the same menu on right-click / Shift+F10.
+   * - `'context-only'` — right-click / Shift+F10 only; no `⋮` trigger.
+   *
+   * Per-node `data.contextMenu` wins when provided.
+   * @default false
+   */
+  contextMenu?: TreeContextMenu;
+
+  /**
+   * Called when a menu action is triggered on any row. Receives the
+   * action key (with the React `.$` prefix stripped) and the row key.
+   * Per-node `data.onAction` is called first.
+   */
+  onAction?: (action: string, key: Key) => void;
+
+  /** Forwarded to every per-row `MenuTrigger`. */
+  menuTriggerProps?: Partial<CubeItemActionProps>;
+
+  /** Forwarded to every per-row `Menu`. */
+  menuProps?: Partial<CubeMenuProps<object>>;
 }

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -236,10 +236,19 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
   qa?: string;
 
   /**
-   * When `true`, pressing a non-leaf row toggles its expansion
+   * When `true`, activating a non-leaf row toggles its expansion
    * instead of selecting it. Useful for file-tree UX where only
    * leaves are selectable. Folder rows remain focusable for keyboard
    * navigation, and the chevron toggle keeps working independently.
+   *
+   * Activation rules for folder rows:
+   *   - Mouse click → expand / collapse.
+   *   - `Enter` → expand / collapse (always, including in `isCheckable`
+   *     trees — `Enter` is not a checkbox key).
+   *   - `Space` → expand / collapse in non-checkable trees; in
+   *     `isCheckable` trees `Space` toggles the row's checkbox instead.
+   *
+   * Leaf rows are unaffected and continue to select normally.
    * @default false
    */
   expandOnFolderClick?: boolean;

--- a/src/components/content/Tree/types.ts
+++ b/src/components/content/Tree/types.ts
@@ -278,6 +278,13 @@ export interface CubeTreeProps extends BaseProps, OuterStyleProps {
   /** Forwarded to every per-row `MenuTrigger`. */
   menuTriggerProps?: Partial<CubeItemActionProps>;
 
-  /** Forwarded to every per-row `Menu`. */
+  /**
+   * Forwarded to every per-row `Menu` (both the overflow `⋮` menu and
+   * the right-click context menu).
+   *
+   * If `onAction` is provided here, it is **chained with** the
+   * tree-level `onAction` and per-node `data.onAction` (it does not
+   * override them) and receives the same normalized action key.
+   */
   menuProps?: Partial<CubeMenuProps<object>>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,8 @@ export type {
   TreeOnSelectInfo,
   TreeLoadDataNode,
   TreeSelectionMode,
+  TreeContextMenu,
+  TreeNodeState,
 } from './components/content/Tree';
 export { GridProvider } from './components/GridProvider';
 export type { CubeGridProviderProps } from './components/GridProvider';


### PR DESCRIPTION
## Summary

Extend the `Tree` component with two new feature areas, in preparation for migrating cloud's `DirectoryTree` on top of it.

### Per-row menu (Tabs pattern)

- **`menu`** (`ReactNode | callback`) and **`contextMenu`** (`true` | `'context-only'`) on `Tree` mirror the Tabs API:
  - `contextMenu={true}` renders a built-in `⋮` overflow trigger AND opens the same menu on right-click / `Shift+F10`.
  - `contextMenu="context-only"` keeps the right-click / `Shift+F10` menu but hides the overflow trigger.
  - Default `false` renders no menu UI.
- Per-node `data.menu`, `data.contextMenu`, `data.onAction` win over the tree-level defaults; `data.menu = null` hides the menu for that specific row.
- **`onAction(action, key)`** at tree level + **`data.onAction(action)`** per node.
- **`menuTriggerProps`** / **`menuProps`** are forwarded to every per-row `MenuTrigger` / `Menu`.
- Each row hosts its own `useContextMenu`, mirroring `TabButton.tsx`, so right-click positions the menu at the pointer.

### `expandOnFolderClick`

When enabled, pressing a non-leaf row toggles its expansion instead of triggering selection. The chevron toggle and keyboard navigation continue to work independently. Useful for file-tree UX where only leaves are meaningful selection targets (cloud's `DirectoryTree` semantics).

### Changesets

Two `minor` changesets added (`tree-row-menu.md`, `tree-expand-on-folder-click.md`).

## Test plan

- [x] `pnpm test Tree` — all 30 tests pass (7 new).
- [x] `pnpm lint` — eslint + prettier clean.
- [x] `pnpm build` — tsdown build succeeds.
- [x] `npx tsc --noEmit` — clean.
- [x] New stories: `WithContextMenu`, `WithContextMenuOnly`, `PerNodeMenu`, `ExpandOnFolderClick`.
- [x] `pnpm audit-docs --component=Tree` — no new issues (pre-existing missing `size`/`itemProps`/`ariaLabel`/`scrollMargin` are unchanged from `main`).
- [ ] Manual verification in Storybook: right-click opens the menu at the pointer; `Shift+F10` opens the menu via keyboard; `expandOnFolderClick` keeps the chevron working independently.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `Tree` row interaction handling (click/pointer/keyboard) and adds new per-row menu rendering, which could subtly affect selection/checkbox/expand behavior and accessibility in existing consumers.
> 
> **Overview**
> **`Tree` gains two new interaction features:** a per-row actions menu and a file-tree-style expand-on-activate mode.
> 
> Adds `menu`, `contextMenu`, `onAction`, `menuTriggerProps`, and `menuProps` to render a built-in `⋮` trigger and/or right-click (and `Shift+F10`) context menu, with per-node overrides (`data.menu`, `data.contextMenu`, `data.onAction`) and chained action callbacks (including `menuProps.onAction`).
> 
> Adds `expandOnFolderClick` to make non-leaf row activation expand/collapse instead of selecting, while guarding against clicks originating from interactive descendants (chevron/checkbox/overflow/custom controls) and preserving `Space` checkbox+selection chaining in checkable trees.
> 
> Updates public exports/types (`TreeContextMenu`, `TreeNodeState`), Storybook docs/stories, adds comprehensive tests for menu and expand-on-click behaviors, and includes two minor changesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7de0c0a598b8d586d4086e944697438305de1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->