### PR TITLE
feat(Tabs): add changeset for reorderable tab picker

### DIFF
--- a/.changeset/reorderable-tab-picker.md
+++ b/.changeset/reorderable-tab-picker.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+**Tabs**: reorderable tab picker — when `isReorderable` is enabled and a tab picker is shown, items in the picker dropdown can be reordered via drag-and-drop or `Alt+Arrow` keyboard shortcuts.


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets markdown file affecting versioning/release notes, with no code or behavior changes.
> 
> **Overview**
> Adds a Changesets entry to release `@cube-dev/ui-kit` as a **minor** version bump, documenting the new **Tabs** capability: when `isReorderable` is enabled and the tab picker is shown, picker items can be reordered via drag-and-drop or `Alt+Arrow` shortcuts.
> 
> No runtime code changes are included in this PR; it only updates release notes/versioning metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451eb612621d0b8c50cce9b210361ef5c07de220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->