### PR TITLE
fix(Tree): drive scroll-to-row through the virtualizer

### DIFF
--- a/.changeset/tree-scroll-to-index.md
+++ b/.changeset/tree-scroll-to-index.md
@@ -1,0 +1,8 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+`Tree` now drives all "scroll into view" through the internal virtualizer instead of `querySelector` + `scrollIntoView`. Two changes:
+
+- **Fix:** keyboard navigation now keeps the focused row visible even when the target lies outside the virtualizer's current overscan window. Previously the row's DOM node was queried before it was mounted, so `scrollIntoView` silently no-oped and the focus indicator could leave the viewport.
+- **New behavior:** a controlled `selectedKeys` change scrolls the first selected key into view. This lets parent components (e.g. file-tree consumers opening a file from outside the tree) bring the row into view without owning virtualizer math themselves. The effect retries once parents are expanded, so off-screen targets land correctly even when expansion is staged in a separate render.

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -781,6 +781,59 @@ describe('<Tree />', () => {
         expect(indices).toContain(1);
       });
     });
+
+    it('does not yank the viewport back to selectedKeys after keyboard nav', async () => {
+      // Regression: a single shared "last scrolled" ref between the
+      // focused-key and selectedKeys effects caused them to fight.
+      // After keyboard nav moved focus to row N, the focus effect would
+      // overwrite the ref. The very next parent re-render (e.g. one
+      // that allocates a fresh `selectedKeys={[value]}` array) would
+      // re-run the selectedKeys effect, see the ref no longer matches
+      // its own target, and yank the viewport back.
+      const user = userEvent.setup();
+      function Harness({ selected }: { selected: string }) {
+        return (
+          <Tree
+            treeData={SAMPLE}
+            defaultExpandedKeys={['fruits', 'vegetables']}
+            // Each render creates a fresh array reference — exactly
+            // the pattern that triggered the bug.
+            selectedKeys={[selected]}
+          />
+        );
+      }
+
+      const { getAllByRole, rerender } = renderWithRoot(
+        <Harness selected="apple" />,
+      );
+
+      // Move keyboard focus from apple (row 1) down to banana (row 2).
+      const rows = getAllByRole('row');
+      act(() => rows[1].focus());
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rows[2]);
+      });
+
+      // Drop pre-banana scroll calls so we only assert what happens AFTER
+      // keyboard nav settles.
+      scrollToIndexCalls.length = 0;
+
+      // Force a parent re-render with the SAME selected value but a new
+      // array identity (the realistic trigger). Without the fix, the
+      // selectedKeys effect would re-run and call scrollToIndex(1) for
+      // 'apple', moving the viewport off banana.
+      rerender(<Harness selected="apple" />);
+
+      // Give effects a chance to fire.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const indices = scrollToIndexCalls.map(([i]) => i);
+      // No scroll back to apple's index (1). Effect 1 already wrote to
+      // its own ref for banana, and effect 2's ref still says apple,
+      // so it bails.
+      expect(indices).not.toContain(1);
+    });
   });
 
   describe('Space chaining in checkable trees', () => {

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -1,3 +1,4 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import userEvent from '@testing-library/user-event';
 import { createRef, useState } from 'react';
 
@@ -7,6 +8,39 @@ import { Menu } from '../../actions/Menu';
 import { Tree } from './Tree';
 
 import type { CubeTreeNodeData, TreeLoadDataNode } from './types';
+
+/**
+ * Capture every `scrollToIndex` call across every virtualizer instance.
+ *
+ * The global setup mock creates a fresh `vi.fn()` per render, so a
+ * naive "latest" ref would lose calls when re-renders (e.g. selection
+ * changes triggering Tree re-renders) replace the mock between the
+ * effect's call and the test's assertion. We share one accumulator
+ * across all virtualizer instances instead.
+ */
+const scrollToIndexCalls: Array<[number, unknown]> = [];
+const installVirtualizerSpy = () => {
+  scrollToIndexCalls.length = 0;
+  (useVirtualizer as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    ({ count = 0, getItemKey }: any) => {
+      return {
+        getVirtualItems: () =>
+          Array.from({ length: count }, (_, index) => ({
+            index,
+            key: typeof getItemKey === 'function' ? getItemKey(index) : index,
+            start: index * 40,
+            size: 40,
+          })),
+        getTotalSize: () => count * 40,
+        scrollToIndex: (index: number, options?: unknown) => {
+          scrollToIndexCalls.push([index, options]);
+        },
+        measure: vi.fn(),
+        measureElement: vi.fn(),
+      };
+    },
+  );
+};
 
 const SAMPLE: CubeTreeNodeData[] = [
   {
@@ -642,6 +676,110 @@ describe('<Tree />', () => {
 
       expect(treeOnAction).toHaveBeenCalledWith('delete', 'fruits');
       expect(menuOnAction).toHaveBeenCalledWith('delete');
+    });
+  });
+
+  describe('scroll-into-view via virtualizer', () => {
+    beforeEach(() => {
+      installVirtualizerSpy();
+    });
+
+    it('scrolls focused row into view via the virtualizer (not querySelector)', async () => {
+      // Regression: the previous implementation used
+      // `querySelector + scrollIntoView`, which silently no-ops when the
+      // target row is outside the virtualizer's rendered window.
+      const user = userEvent.setup();
+      const { getAllByRole } = renderWithRoot(
+        <Tree
+          treeData={SAMPLE}
+          defaultExpandedKeys={['fruits', 'vegetables']}
+        />,
+      );
+
+      const rows = getAllByRole('row');
+      act(() => rows[0].focus());
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(document.activeElement).toBe(rows[1]);
+      });
+
+      // After ArrowDown moves focus to row 1 ('apple'), the focused-key
+      // effect should drive the virtualizer to index 1 with align:auto.
+      const indices = scrollToIndexCalls.map(([i]) => i);
+      expect(indices).toContain(1);
+      const aliasedCall = scrollToIndexCalls.find(([i]) => i === 1);
+      expect(aliasedCall?.[1]).toMatchObject({ align: 'auto' });
+    });
+
+    it('scrolls when controlled selectedKeys changes externally', async () => {
+      // The selection manager's `focusedKey` only updates on user
+      // interaction, so a parent flipping `selectedKeys` programmatically
+      // must trigger a separate scroll path. Without this, opening a
+      // file from outside the tree would not bring its row into view.
+      function Harness({ selected }: { selected: string }) {
+        return (
+          <Tree
+            treeData={SAMPLE}
+            defaultExpandedKeys={['fruits', 'vegetables']}
+            selectedKeys={[selected]}
+          />
+        );
+      }
+
+      const { rerender } = renderWithRoot(<Harness selected="apple" />);
+
+      // Reset so we only assert the *next* programmatic update triggers
+      // a scroll (initial mount may have already scrolled to 'apple').
+      scrollToIndexCalls.length = 0;
+
+      rerender(<Harness selected="potato" />);
+
+      await waitFor(() => {
+        // 'potato' is the last visible row when both folders are
+        // expanded: fruits(0), apple(1), banana(2), vegetables(3),
+        // carrot(4), potato(5).
+        const indices = scrollToIndexCalls.map(([i]) => i);
+        expect(indices).toContain(5);
+      });
+    });
+
+    it('does not scroll for selectedKeys whose parents are still collapsed', async () => {
+      // Until parents expand, the row is not in `visibleNodes`, so
+      // `findIndex` returns -1 and we should *not* call scrollToIndex
+      // with a bogus value. The scroll fires once expansion brings the
+      // row into the visible set.
+      function Harness({
+        selected,
+        expanded,
+      }: {
+        selected: string;
+        expanded: string[];
+      }) {
+        return (
+          <Tree
+            treeData={SAMPLE}
+            expandedKeys={expanded}
+            selectedKeys={[selected]}
+          />
+        );
+      }
+
+      const { rerender } = renderWithRoot(
+        <Harness selected="apple" expanded={[]} />,
+      );
+
+      // 'apple' hidden under collapsed 'fruits' — no scroll target yet.
+      // Reset to filter out any incidental calls during initial mount.
+      scrollToIndexCalls.length = 0;
+
+      // Expand parent — now 'apple' is at index 1 and the effect retries.
+      rerender(<Harness selected="apple" expanded={['fruits']} />);
+
+      await waitFor(() => {
+        const indices = scrollToIndexCalls.map(([i]) => i);
+        expect(indices).toContain(1);
+      });
     });
   });
 

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -375,13 +375,20 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
   );
 
   /**
-   * Track which key we last asked the virtualizer to scroll to. Both
-   * scroll effects (`focusedKey` for keyboard nav and the
-   * controlled-`selectedKeys` effect below) write to the same ref so
-   * we don't fire two `scrollToIndex` calls back-to-back when a click
-   * updates focus and selection in the same render.
+   * Each scroll effect tracks its own "last scrolled" target instead
+   * of sharing one ref. A shared ref creates a feedback loop: keyboard
+   * nav updates the focused-key ref to the new row, and any subsequent
+   * `visibleNodes` change OR `selectedKeys` array-identity change
+   * (very common — `selectedKeys={[value]}` allocates a fresh array
+   * every parent render) re-runs the selectedKeys effect, which sees
+   * the ref no longer matches `selectedKeys[0]` and yanks the viewport
+   * back to the selected row. Two refs let each effect dedupe against
+   * its own intent only; the cost is at most one duplicate
+   * `scrollToIndex` call when click updates focus and selection in the
+   * same render (idempotent — both target the same index).
    */
-  const lastScrolledKeyRef = useRef<Key | null>(null);
+  const lastFocusedScrollRef = useRef<Key | null>(null);
+  const lastSelectedScrollRef = useRef<string | null>(null);
 
   /**
    * Keep the focused row visible during keyboard navigation.
@@ -395,7 +402,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
   useLayoutEffect(() => {
     const focusedKey = state.selectionManager.focusedKey;
     if (focusedKey == null) return;
-    if (lastScrolledKeyRef.current === focusedKey) return;
+    if (lastFocusedScrollRef.current === focusedKey) return;
 
     const index = visibleNodesRef.current.findIndex(
       (n) => n.key === focusedKey,
@@ -403,7 +410,7 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     if (index < 0) return;
 
     rowVirtualizer.scrollToIndex(index, { align: 'auto' });
-    lastScrolledKeyRef.current = focusedKey;
+    lastFocusedScrollRef.current = focusedKey;
   }, [state.selectionManager.focusedKey, rowVirtualizer]);
 
   /**
@@ -422,13 +429,13 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     if (selectedKeys == null) return;
     const target = selectedKeys[0];
     if (target == null) return;
-    if (lastScrolledKeyRef.current === target) return;
+    if (lastSelectedScrollRef.current === target) return;
 
     const index = visibleNodes.findIndex((n) => String(n.key) === target);
     if (index < 0) return;
 
     rowVirtualizer.scrollToIndex(index, { align: 'auto' });
-    lastScrolledKeyRef.current = target;
+    lastSelectedScrollRef.current = target;
   }, [selectedKeys, visibleNodes, rowVirtualizer]);
 
   const mods = useMemo(

--- a/src/components/content/Tree/Tree.tsx
+++ b/src/components/content/Tree/Tree.tsx
@@ -374,21 +374,62 @@ function TreeBase(props: CubeTreeProps, ref: ForwardedRef<HTMLDivElement>) {
     [rowVirtualizer.getTotalSize()],
   );
 
-  // Keep focused node visible during keyboard navigation.
+  /**
+   * Track which key we last asked the virtualizer to scroll to. Both
+   * scroll effects (`focusedKey` for keyboard nav and the
+   * controlled-`selectedKeys` effect below) write to the same ref so
+   * we don't fire two `scrollToIndex` calls back-to-back when a click
+   * updates focus and selection in the same render.
+   */
+  const lastScrolledKeyRef = useRef<Key | null>(null);
+
+  /**
+   * Keep the focused row visible during keyboard navigation.
+   *
+   * Uses `rowVirtualizer.scrollToIndex` (instead of
+   * `querySelector + scrollIntoView`) so the scroll lands even when the
+   * target row is outside the virtualizer's currently rendered window.
+   * `align: 'auto'` only scrolls when needed, matching the prior
+   * `scrollIntoView({ block: 'nearest' })` behavior.
+   */
   useLayoutEffect(() => {
     const focusedKey = state.selectionManager.focusedKey;
     if (focusedKey == null) return;
+    if (lastScrolledKeyRef.current === focusedKey) return;
 
-    const scrollElement = scrollRef.current;
-    if (!scrollElement) return;
+    const index = visibleNodesRef.current.findIndex(
+      (n) => n.key === focusedKey,
+    );
+    if (index < 0) return;
 
-    const row = scrollElement.querySelector(
-      `[data-qa-key="${CSS.escape(String(focusedKey))}"]`,
-    ) as HTMLElement | null;
-    if (!row || typeof row.scrollIntoView !== 'function') return;
+    rowVirtualizer.scrollToIndex(index, { align: 'auto' });
+    lastScrolledKeyRef.current = focusedKey;
+  }, [state.selectionManager.focusedKey, rowVirtualizer]);
 
-    row.scrollIntoView({ block: 'nearest' });
-  }, [state.selectionManager.focusedKey]);
+  /**
+   * Scroll into view when controlled `selectedKeys` changes externally.
+   *
+   * Selection-manager `focusedKey` only updates on explicit user
+   * interaction (click / keyboard) — it does NOT track controlled
+   * `selectedKeys` prop changes. So when a parent updates the prop
+   * (e.g. opening a file from elsewhere), we need a separate effect
+   * to bring the row into view.
+   *
+   * Re-runs on `visibleNodes` so we retry once parents are expanded
+   * (the row is invisible to the virtualizer until then).
+   */
+  useLayoutEffect(() => {
+    if (selectedKeys == null) return;
+    const target = selectedKeys[0];
+    if (target == null) return;
+    if (lastScrolledKeyRef.current === target) return;
+
+    const index = visibleNodes.findIndex((n) => String(n.key) === target);
+    if (index < 0) return;
+
+    rowVirtualizer.scrollToIndex(index, { align: 'auto' });
+    lastScrolledKeyRef.current = target;
+  }, [selectedKeys, visibleNodes, rowVirtualizer]);
 
   const mods = useMemo(
     () => ({


### PR DESCRIPTION
The previous focusedKey effect used `querySelector` + `scrollIntoView`, which silently no-ops when the target row is outside the rendered overscan window. Switch to `rowVirtualizer.scrollToIndex(index, { align: 'auto' })` so keyboard navigation lands correctly even past overscan, and add a controlled-`selectedKeys`-change effect so external callers (e.g. file trees opening a file from outside the tree) can rely on Tree to scroll without owning virtualizer math themselves. The new effect retries once parents are expanded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `Tree` scrolling behavior for both keyboard focus and controlled selection updates, which can subtly affect UX and render timing in virtualized lists. The logic is guarded with index checks and dedupe refs, but regressions could still appear in edge navigation/expansion scenarios.
> 
> **Overview**
> `Tree` now scrolls rows into view via `rowVirtualizer.scrollToIndex` (replacing `querySelector` + `scrollIntoView`) so keyboard focus stays visible even when the target row isn’t currently mounted due to overscan.
> 
> Adds a new layout effect that scrolls to the first key in controlled `selectedKeys` on external prop changes, retrying once expansion makes the row visible, and separates “last scrolled” tracking for focus vs selection to avoid the viewport being yanked back after keyboard navigation.
> 
> Extends `Tree.test.tsx` with virtualizer spies and regression tests covering focus scrolling, controlled selection scrolling, collapsed-parent retry behavior, and preventing focus/selection scroll effects from fighting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55402dad4ed103af0c803655fb31a235c3c7e6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->