### PR TITLE
fix(Result): text wrap balance

### DIFF
--- a/.changeset/result-text-wrap-balance.md
+++ b/.changeset/result-text-wrap-balance.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`Result` now applies `text-wrap: balance` to the title and subtitle so multi-line headings break into more even-length lines.

--- a/src/components/content/Result/Result.tsx
+++ b/src/components/content/Result/Result.tsx
@@ -111,6 +111,7 @@ const Container = tasty({
       placeItems: 'inherit',
       gap: '1x',
       placeSelf: 'center',
+      textWrap: 'balance',
     },
   },
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts heading line breaking; main risk is inconsistent `text-wrap: balance` support across browsers causing no-op or differing appearance.
> 
> **Overview**
> Improves `Result` heading layout by applying `text-wrap: balance` to the title/subtitle wrapper so multi-line titles/subtitles break into more even-length lines.
> 
> Adds a patch changeset documenting the styling tweak for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fa7868575b94f7d3c8f5493e05d0f8a0312532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->