### PR TITLE
fix(input-autofill): cover internal autofill pseudo-classes

### DIFF
--- a/.changeset/input-autofill-internal-pseudo.md
+++ b/.changeset/input-autofill-internal-pseudo.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`TextInput` and other inputs that consume the `input-autofill` recipe now correctly suppress Chrome's autofill background and `appearance: menulist-button` when a suggestion is selected or previewed. The `@autofill` alias was extended to cover `:autofill`, `:-internal-autofill-selected`, and `:-internal-autofill-previewed` in addition to `:-webkit-autofill`, and the inset background now uses the `#surface` token instead of a hard-coded white.

--- a/.changeset/input-autofill-internal-pseudo.md
+++ b/.changeset/input-autofill-internal-pseudo.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': patch
 ---
 
-`TextInput` and other inputs that consume the `input-autofill` recipe now correctly suppress Chrome's autofill background and `appearance: menulist-button` when a suggestion is selected or previewed. The `@autofill` alias was extended to cover `:autofill`, `:-internal-autofill-selected`, and `:-internal-autofill-previewed` in addition to `:-webkit-autofill`, and the inset background now uses the `#surface` token instead of a hard-coded white.
+`TextInput` and other inputs that consume the `input-autofill` recipe now correctly suppress Chrome's autofill background and `appearance: menulist-button` when a suggestion is selected or previewed. The `@autofill` alias was extended (via `:is()` so unsupported pseudo-classes are gracefully ignored in Firefox / Safari instead of invalidating the whole rule) to cover `:autofill`, `:-internal-autofill-selected`, and `:-internal-autofill-previewed` in addition to `:-webkit-autofill`, and the inset background now uses the `#surface` token instead of a hard-coded white.

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -59,7 +59,11 @@ configure({
       fill: '#clear',
     },
     'input-autofill': {
-      '@autofill': ':-webkit-autofill',
+      '@autofill':
+        ':-webkit-autofill | :autofill | :-internal-autofill-selected | :-internal-autofill-previewed',
+      appearance: {
+        '@autofill | (@autofill & :hover) | (@autofill & :focus)': 'none',
+      },
       '-webkit-text-fill-color': {
         '': 'currentColor',
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': '#primary',
@@ -69,7 +73,7 @@ configure({
       },
       shadow: {
         '@autofill | (@autofill & :hover) | (@autofill & :focus)':
-          '0 0 0 9999rem rgb(255 255 255) inset',
+          '0 0 0 9999rem #surface inset',
       },
       preset: {
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': 'inherit',

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -60,7 +60,7 @@ configure({
     },
     'input-autofill': {
       '@autofill':
-        ':-webkit-autofill | :autofill | :-internal-autofill-selected | :-internal-autofill-previewed',
+        ':is(:-webkit-autofill, :autofill, :-internal-autofill-selected, :-internal-autofill-previewed)',
       appearance: {
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': 'none',
       },

--- a/src/stories/Usage.docs.mdx
+++ b/src/stories/Usage.docs.mdx
@@ -214,7 +214,7 @@ Reusable style presets applied via the `recipe` style property. Defined in `src/
 | `reset` | Zero out margin, padding, border, outline; set `box-sizing: border-box` |
 | `button` | Base button appearance: no native styling, `touch-action: manipulation` |
 | `input` | Base input appearance: no native styling, inherit color |
-| `input-autofill` | Handle `:-webkit-autofill` styling |
+| `input-autofill` | Handle browser autofill styling (`:autofill`, `:-webkit-autofill`, `:-internal-autofill-*`) |
 | `input-placeholder` | Placeholder text styling via `-webkit-text-fill-color` |
 | `input-search-cancel-button` | Hide native search cancel button |
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk styling-only change, but it affects the shared `input-autofill` recipe used across inputs and could subtly alter autofill appearance in some browsers.
> 
> **Overview**
> Improves the shared `input-autofill` recipe to match additional browser autofill pseudo-classes (including Chrome’s internal selected/previewed states) via `:is()` so unsupported selectors don’t invalidate the rule.
> 
> Also forces `appearance: none` for autofilled states and switches the autofill inset background from hard-coded white to the `#surface` token; docs were updated to reflect the broader autofill coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ecc428b8ddb8b5865bc39684cf47cbadc38145c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->