### PR TITLE
feat(MenuTrigger,Tray): mobileType opt-in and shared shouldCloseOnInteractOutside

### DIFF
--- a/.changeset/menutrigger-mobiletype.md
+++ b/.changeset/menutrigger-mobiletype.md
@@ -1,0 +1,11 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+**Menu / Tray**: gate mobile tray rendering behind a `mobileType` opt-in and let `Tray` accept `shouldCloseOnInteractOutside`.
+
+- `Tray` now accepts a `shouldCloseOnInteractOutside?: (element: Element) => boolean` prop and forwards it to React Aria's `useOverlay`. Without it, the underlying `useOverlay` unconditionally calls `stopPropagation` / `preventDefault` on outside pointer/click events whenever the tray is the topmost overlay, which can swallow clicks on sibling triggers (e.g. a second `MenuTrigger`). The new prop matches the existing API on `Popover`.
+- `MenuTrigger` no longer auto-swaps its `Popover` for a `Tray` on mobile screens. The previous behaviour relied on `useIsMobileDevice()` (which returns `true` in jsdom-style environments where `window.screen.width` is `0`), so the mobile branch could activate unintentionally. Opt in explicitly with `mobileType="tray"` (defaults to `'popover'`), mirroring the established `mobileType` API on `DialogTrigger`.
+- `MenuTrigger` now passes the same `shouldCloseOnInteractOutside` callback to both the `Popover` and `Tray` branches, so sibling-trigger clicks aren't swallowed in either overlay variant.
+
+This is a behavioural change for apps that intentionally relied on the implicit mobile tray. To restore the previous look, pass `mobileType="tray"` to the relevant `MenuTrigger`s.

--- a/.changeset/popover-dismiss-button.md
+++ b/.changeset/popover-dismiss-button.md
@@ -1,0 +1,10 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+**Popover dismiss for plain Button / ItemButton**: a single click on a `Button` or `ItemButton` rendered outside an open popover now closes the popover AND fires the button's `onPress` in the same click. Previously the first click was always swallowed by `useOverlay`'s `shouldCloseOnInteractOutside` (which `stopPropagation`s outside clicks), so users had to click twice.
+
+- `Button` and `ItemButton` now mark their root with `data-popover-dismiss`.
+- `MenuTrigger`, `Select`, `ComboBox`, `FilterPicker`, and `Picker` recognize `[data-popover-dismiss]` outside-click targets and schedule their close via `setTimeout(0)` so the close lands AFTER the click event finishes (i.e. after the button's `onPress` runs). The predicate returns `false` so the click is not stopped.
+
+`Button`/`ItemButton` used as a popover trigger (wrapped by `PressResponder`/`MenuTrigger`) keep their existing trigger behaviour — the trigger branch matches first, the dismiss branch is never reached.

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "eslint-plugin-storybook": "^10.2.3",
     "globals": "^16.0.0",
     "husky": "^6.0.0",
+    "jsdom": "^29.1.1",
     "lint-staged": "^10.0.0",
     "markdown-table": "^3.0.3",
     "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,7 +197,7 @@ importers:
         version: 6.0.1(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@22.17.2)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)))
+        version: 4.1.0(vitest@4.1.0(@types/node@22.17.2)(jsdom@29.1.1)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)))
       best-effort-json-parser:
         specifier: ^1.2.1
         version: 1.2.1
@@ -243,6 +243,9 @@ importers:
       husky:
         specifier: ^6.0.0
         version: 6.0.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       lint-staged:
         specifier: ^10.0.0
         version: 10.0.0
@@ -296,7 +299,7 @@ importers:
         version: 8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.17.2)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+        version: 4.1.0(@types/node@22.17.2)(jsdom@29.1.1)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
 
 packages:
 
@@ -321,6 +324,21 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -1083,6 +1101,10 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@changesets/apply-release-plan@6.1.3':
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
 
@@ -1246,6 +1268,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@discoveryjs/json-ext@0.5.5':
     resolution: {integrity: sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==}
@@ -1467,6 +1525,15 @@ packages:
   '@eslint/plugin-kit@0.2.8':
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
@@ -2917,10 +2984,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
-    engines: {node: '>= 10'}
-
   '@tsconfig/node10@1.0.9':
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
 
@@ -3404,13 +3467,6 @@ packages:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
 
-  abab@2.0.6:
-    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    deprecated: Use your platform's native atob() and btoa() methods instead
-
-  acorn-globals@7.0.1:
-    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
-
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     deprecated: package has been renamed to acorn-import-attributes
@@ -3426,10 +3482,6 @@ packages:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
@@ -3439,15 +3491,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -3604,9 +3647,6 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3673,6 +3713,9 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -3871,10 +3914,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -3955,18 +3994,12 @@ packages:
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
-
-  cssom@0.3.8:
-    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
-
-  cssom@0.5.0:
-    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
-
-  cssstyle@2.3.0:
-    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
-    engines: {node: '>=8'}
 
   csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -3991,9 +4024,9 @@ packages:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
 
-  data-urls@3.0.2:
-    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
-    engines: {node: '>=12'}
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -4093,10 +4126,6 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
@@ -4143,11 +4172,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  domexception@4.0.0:
-    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
-    engines: {node: '>=12'}
-    deprecated: Use your platform's native DOMException instead
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -4208,9 +4232,9 @@ packages:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -4273,11 +4297,6 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
 
   eslint-config-prettier@10.1.2:
     resolution: {integrity: sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==}
@@ -4566,10 +4585,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-
   fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
     engines: {node: '>=14.14'}
@@ -4752,20 +4767,12 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
-  html-encoding-sniffer@3.0.0:
-    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
-    engines: {node: '>=12'}
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -4784,10 +4791,6 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -5078,11 +5081,11 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
-  jsdom@20.0.3:
-    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
-    engines: {node: '>=14'}
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
-      canvas: ^2.5.0
+      canvas: ^3.0.0
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -5340,6 +5343,10 @@ packages:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -5420,6 +5427,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -5652,9 +5662,6 @@ packages:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
     engines: {node: '>=0.10.0'}
 
-  nwsapi@2.2.23:
-    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5774,8 +5781,8 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -5898,9 +5905,6 @@ packages:
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
-  psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
 
@@ -5922,9 +5926,6 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
-
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6100,9 +6101,6 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6572,6 +6570,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -6580,16 +6585,16 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
-    engines: {node: '>=6'}
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  tr46@3.0.0:
-    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
-    engines: {node: '>=12'}
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6747,6 +6752,10 @@ packages:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -6785,10 +6794,6 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-
   universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
@@ -6815,9 +6820,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -6949,9 +6951,9 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
-  w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
@@ -6963,9 +6965,9 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
-  webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -6984,18 +6986,13 @@ packages:
       webpack-cli:
         optional: true
 
-  whatwg-encoding@2.0.0:
-    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
-    engines: {node: '>=12'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
 
-  whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
-
-  whatwg-url@11.0.0:
-    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
-    engines: {node: '>=12'}
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -7072,9 +7069,9 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
-  xml-name-validator@4.0.0:
-    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
-    engines: {node: '>=12'}
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -7160,6 +7157,26 @@ snapshots:
   '@actions/io@1.1.3': {}
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -8099,6 +8116,10 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@changesets/apply-release-plan@6.1.3':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -8456,6 +8477,30 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@discoveryjs/json-ext@0.5.5': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
@@ -8604,6 +8649,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.13.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@fastify/busboy@2.1.1': {}
 
@@ -10457,9 +10504,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tootallnate/once@2.0.0':
-    optional: true
-
   '@tsconfig/node10@1.0.9': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -10929,7 +10973,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@22.17.2)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@22.17.2)(jsdom@29.1.1)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -10941,7 +10985,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@types/node@22.17.2)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+      vitest: 4.1.0(@types/node@22.17.2)(jsdom@29.1.1)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11091,15 +11135,6 @@ snapshots:
       jsonparse: 1.3.1
       through: 2.3.8
 
-  abab@2.0.6:
-    optional: true
-
-  acorn-globals@7.0.1:
-    dependencies:
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-    optional: true
-
   acorn-import-assertions@1.9.0(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
@@ -11110,24 +11145,9 @@ snapshots:
 
   acorn-walk@8.2.0: {}
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-    optional: true
-
   acorn@8.14.1: {}
 
   acorn@8.15.0: {}
-
-  acorn@8.16.0:
-    optional: true
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -11291,9 +11311,6 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  asynckit@0.4.0:
-    optional: true
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
@@ -11384,6 +11401,10 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.2.0: {}
 
@@ -11577,11 +11598,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-    optional: true
-
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -11679,18 +11695,12 @@ snapshots:
 
   crypt@0.0.2: {}
 
-  css.escape@1.5.1: {}
-
-  cssom@0.3.8:
-    optional: true
-
-  cssom@0.5.0:
-    optional: true
-
-  cssstyle@2.3.0:
+  css-tree@3.2.1:
     dependencies:
-      cssom: 0.3.8
-    optional: true
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
 
   csstype@3.1.2: {}
 
@@ -11711,12 +11721,12 @@ snapshots:
 
   dargs@7.0.0: {}
 
-  data-urls@3.0.2:
+  data-urls@7.0.0:
     dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-    optional: true
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -11800,9 +11810,6 @@ snapshots:
 
   defu@6.1.4: {}
 
-  delayed-stream@1.0.0:
-    optional: true
-
   deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
@@ -11836,11 +11843,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  domexception@4.0.0:
-    dependencies:
-      webidl-conversions: 7.0.0
-    optional: true
 
   dot-prop@5.3.0:
     dependencies:
@@ -11885,8 +11887,7 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
 
-  entities@6.0.1:
-    optional: true
+  entities@8.0.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -12030,15 +12031,6 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
-
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-    optional: true
 
   eslint-config-prettier@10.1.2(eslint@9.25.1(jiti@2.6.1)):
     dependencies:
@@ -12454,15 +12446,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-    optional: true
-
   fs-extra@11.1.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -12649,29 +12632,13 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  html-encoding-sniffer@3.0.0:
+  html-encoding-sniffer@6.0.0:
     dependencies:
-      whatwg-encoding: 2.0.0
-    optional: true
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-escaper@2.0.2: {}
-
-  http-proxy-agent@5.0.0:
-    dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   human-id@1.0.2: {}
 
@@ -12684,11 +12651,6 @@ snapshots:
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
-
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-    optional: true
 
   ignore@5.3.2: {}
 
@@ -12821,8 +12783,7 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@2.2.2: {}
 
@@ -12948,39 +12909,31 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@20.0.3:
+  jsdom@29.1.1:
     dependencies:
-      abab: 2.0.6
-      acorn: 8.16.0
-      acorn-globals: 7.0.1
-      cssom: 0.5.0
-      cssstyle: 2.3.0
-      data-urls: 3.0.2
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
       decimal.js: 10.6.0
-      domexception: 4.0.0
-      escodegen: 2.1.0
-      form-data: 4.0.5
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.23
-      parse5: 7.3.0
+      lru-cache: 11.3.6
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.4
-      w3c-xmlserializer: 4.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-      ws: 8.19.0
-      xml-name-validator: 4.0.0
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
+      - '@noble/hashes'
 
   jsesc@0.5.0: {}
 
@@ -13220,6 +13173,8 @@ snapshots:
 
   lru-cache@11.1.0: {}
 
+  lru-cache@11.3.6: {}
+
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -13369,6 +13324,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.3
+
+  mdn-data@2.27.1: {}
 
   memorystream@0.3.1: {}
 
@@ -13708,9 +13665,6 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nwsapi@2.2.23:
-    optional: true
-
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -13845,10 +13799,9 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  parse5@7.3.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
-    optional: true
+      entities: 8.0.0
 
   path-exists@4.0.0: {}
 
@@ -13942,11 +13895,6 @@ snapshots:
 
   pseudomap@1.0.2: {}
 
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
-    optional: true
-
   pump@3.0.0:
     dependencies:
       end-of-stream: 1.4.4
@@ -13954,15 +13902,11 @@ snapshots:
 
   punycode@2.3.0: {}
 
-  punycode@2.3.1:
-    optional: true
+  punycode@2.3.1: {}
 
   q@1.5.1: {}
 
   quansync@1.0.0: {}
-
-  querystringify@2.2.0:
-    optional: true
 
   queue-microtask@1.2.3: {}
 
@@ -14251,9 +14195,6 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
-  requires-port@1.0.0:
-    optional: true
-
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -14413,7 +14354,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-    optional: true
 
   scheduler@0.26.0: {}
 
@@ -14758,8 +14698,7 @@ snapshots:
 
   symbol-observable@1.2.0: {}
 
-  symbol-tree@3.2.4:
-    optional: true
+  symbol-tree@3.2.4: {}
 
   tapable@2.2.1: {}
 
@@ -14809,6 +14748,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -14817,20 +14762,15 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tough-cookie@4.1.4:
+  tough-cookie@6.0.1:
     dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-      universalify: 0.2.0
-      url-parse: 1.5.10
-    optional: true
+      tldts: 7.0.30
 
   tr46@0.0.3: {}
 
-  tr46@3.0.0:
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -15003,6 +14943,8 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
+  undici@7.25.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -15047,9 +14989,6 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  universalify@0.2.0:
-    optional: true
-
   universalify@2.0.0: {}
 
   unplugin@2.3.10:
@@ -15072,12 +15011,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.0
-
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-    optional: true
 
   use-callback-ref@1.3.3(@types/react@19.1.10)(react@19.1.1):
     dependencies:
@@ -15140,7 +15073,7 @@ snapshots:
       jiti: 2.6.1
       terser: 5.31.1
 
-  vitest@4.1.0(@types/node@22.17.2)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)):
+  vitest@4.1.0(@types/node@22.17.2)(jsdom@29.1.1)(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.17.2)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
@@ -15164,16 +15097,15 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.2
-      jsdom: 20.0.3
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
   w3c-keyname@2.2.8: {}
 
-  w3c-xmlserializer@4.0.0:
+  w3c-xmlserializer@5.0.0:
     dependencies:
-      xml-name-validator: 4.0.0
-    optional: true
+      xml-name-validator: 5.0.0
 
   watchpack@2.4.0:
     dependencies:
@@ -15186,8 +15118,7 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@7.0.0:
-    optional: true
+  webidl-conversions@8.0.1: {}
 
   webpack-sources@3.2.3: {}
 
@@ -15224,19 +15155,15 @@ snapshots:
       - esbuild
       - uglify-js
 
-  whatwg-encoding@2.0.0:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
+  whatwg-mimetype@5.0.0: {}
 
-  whatwg-mimetype@3.0.0:
-    optional: true
-
-  whatwg-url@11.0.0:
+  whatwg-url@16.0.1:
     dependencies:
-      tr46: 3.0.0
-      webidl-conversions: 7.0.0
-    optional: true
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -15335,11 +15262,9 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  xml-name-validator@4.0.0:
-    optional: true
+  xml-name-validator@5.0.0: {}
 
-  xmlchars@2.2.0:
-    optional: true
+  xmlchars@2.2.0: {}
 
   y18n@4.0.3: {}
 

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -578,6 +578,7 @@ export const Button = forwardRef(function Button(
         data-theme={theme}
         data-type={type ?? 'outline'}
         data-size={size}
+        data-popover-dismiss=""
         styles={styles}
         tokens={sizeTokenValue ? { $size: sizeTokenValue } : undefined}
       >

--- a/src/components/actions/ItemButton/ItemButton.tsx
+++ b/src/components/actions/ItemButton/ItemButton.tsx
@@ -191,6 +191,7 @@ const ItemButton = forwardRef(function ItemButton(
       showActions={shouldShowActions}
       actions={actions ? true : undefined}
       {...(mergeProps(rest, actionProps) as any)}
+      data-popover-dismiss=""
       htmlType={actionProps.type}
       type={type}
       theme={theme}

--- a/src/components/actions/Menu/Menu.test.tsx
+++ b/src/components/actions/Menu/Menu.test.tsx
@@ -1534,7 +1534,7 @@ describe('Menu synchronization with event bus', () => {
       ));
 
       const {
-        anchorRef: anchorRef3,
+        targetRef: anchorRef3,
         open: open3,
         rendered: rendered3,
       } = useContextMenu(({ onAction }) => (

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -179,7 +179,19 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
       if (!stateIsOpenRef.current) return false;
 
       const menuTriggerEl = el.closest('[data-popover-trigger]');
-      if (!menuTriggerEl) return true;
+      if (!menuTriggerEl) {
+        // Plain interactive controls (Button, ItemButton) opt in via
+        // `data-popover-dismiss`. We schedule the close via setTimeout(0) so
+        // it lands AFTER the click event finishes — the button's onPress
+        // fires first, then the popover closes. Without this, useOverlay
+        // would stopPropagation() the click and the user would need a
+        // second click to actually press the button.
+        if (el.closest('[data-popover-dismiss]')) {
+          setTimeout(() => state.close(), 0);
+          return false;
+        }
+        return true;
+      }
       if (
         isDummy &&
         (menuTriggerEl === menuTriggerRef.current ||
@@ -190,7 +202,7 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
       if (menuTriggerEl === menuTriggerRef.current) return true;
       return false;
     },
-    [isDummy, menuTriggerRef],
+    [isDummy, menuTriggerRef, state],
   );
 
   let overlay;

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -22,7 +22,7 @@ import { MenuTriggerState, useMenuTriggerState } from 'react-stately';
 
 import { generateRandomId } from '../../../utils/random';
 import { SlotProvider } from '../../../utils/react';
-import { useEventBus } from '../../../utils/react/useEventBus';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { Popover, Tray } from '../../overlays/Modal';
 
 import { MenuContext, MenuContextValue } from './context';
@@ -68,9 +68,6 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
-  // Get event bus for menu synchronization
-  const { emit, on } = useEventBus();
-
   if (!Array.isArray(children) || children.length > 2) {
     throw new Error('MenuTrigger must have exactly 2 children');
   }
@@ -78,24 +75,12 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
   let [menuTrigger, menu] = children;
   const state: MenuTriggerState = useMenuTriggerState(props);
 
-  // Listen for other menus opening and close this one if needed
-  useEffect(() => {
-    const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      // If another menu is opening and this menu is open, close this one
-      if (data.menuId !== menuId && state.isOpen && !isDummy) {
-        state.close();
-      }
-    });
-
-    return unsubscribe;
-  }, [on, menuId, state]);
-
-  // Emit event when this menu opens
-  useEffect(() => {
-    if (state.isOpen && !isDummy) {
-      emit('popover:open', { menuId });
-    }
-  }, [state.isOpen, emit, menuId, isDummy]);
+  usePopoverSync({
+    menuId,
+    isOpen: state.isOpen,
+    onClose: () => state.close(),
+    enabled: !isDummy,
+  });
 
   // Restore focus manually when the menu closes
   useEffect(() => {

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -5,7 +5,6 @@ import {
   forwardRef,
   Fragment,
   ReactElement,
-  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -20,6 +19,7 @@ import {
 } from 'react-aria';
 import { MenuTriggerState, useMenuTriggerState } from 'react-stately';
 
+import { useEvent } from '../../../_internal';
 import { generateRandomId } from '../../../utils/random';
 import { SlotProvider } from '../../../utils/react';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
@@ -153,57 +153,53 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
     </>
   );
 
-  // Shared between the Popover and Tray branches so both react-aria `useOverlay`
-  // calls see the same predicate. Without this, the Tray branch falls back to
-  // unconditional dismiss-on-outside-interaction, which `useOverlay` translates
-  // into stopPropagation/preventDefault in the capture phase — that swallows
-  // clicks on sibling triggers (see Menu rapid-open test).
+  // Shared between the Popover and Tray branches so both react-aria
+  // `useOverlay` calls see the same predicate. Without this, the Tray branch
+  // falls back to unconditional dismiss-on-outside-interaction, which
+  // `useOverlay` translates into stopPropagation/preventDefault in the
+  // capture phase — that swallows clicks on sibling triggers (see Menu
+  // rapid-open test).
   //
-  // We capture `state.isOpen` via a ref so the callback identity stays stable
-  // across re-renders (it's passed to react-aria `useOverlay` whose listener
-  // setup keys off the ref equality). The ref is read at click time so a menu
-  // that is logically closed (`state.close()` already ran) but still mounted
-  // inside the `Popover` exit transition does not block sibling-trigger clicks.
-  const stateIsOpenRef = useRef(state.isOpen);
-  useEffect(() => {
-    stateIsOpenRef.current = state.isOpen;
-  }, [state.isOpen]);
-  const shouldCloseOnInteractOutside = useCallback(
-    (el: Element) => {
-      // While `Popover` is animating out, useOverlay's `useInteractOutside`
-      // capture-phase listener is still attached (jsdom 29+ uses
-      // pointerdown/click capture). Without this guard, clicks on a sibling
-      // trigger get stopPropagation()'d during the 350ms exit window and the
-      // sibling's `onClick` never runs — breaking rapid-open and "open menu
-      // again with new props" flows.
-      if (!stateIsOpenRef.current) return false;
+  // `useEvent` gives us a single stable callback reference for the lifetime
+  // of the component while always reading the latest closure values. This
+  // matters because `useMenuTriggerState` returns a fresh `state` object on
+  // every render, so a vanilla `useCallback([..., state])` would produce a
+  // new function every render and defeat any stability guarantees consumers
+  // rely on.
+  const shouldCloseOnInteractOutside = useEvent((el: Element) => {
+    // While `Popover` is animating out, `useInteractOutside`'s capture-phase
+    // listener is still attached (jsdom 29+ uses pointerdown/click capture).
+    // The animation lasts ~350ms; without this guard, clicks on a sibling
+    // trigger during the exit window get stopPropagation()'d and the
+    // sibling's `onClick` never runs — breaking rapid-open and "open menu
+    // again with new props" flows. Reading `state.isOpen` directly is safe
+    // because `useEvent` always sees the latest closure.
+    if (!state.isOpen) return false;
 
-      const menuTriggerEl = el.closest('[data-popover-trigger]');
-      if (!menuTriggerEl) {
-        // Plain interactive controls (Button, ItemButton) opt in via
-        // `data-popover-dismiss`. We schedule the close via setTimeout(0) so
-        // it lands AFTER the click event finishes — the button's onPress
-        // fires first, then the popover closes. Without this, useOverlay
-        // would stopPropagation() the click and the user would need a
-        // second click to actually press the button.
-        if (el.closest('[data-popover-dismiss]')) {
-          setTimeout(() => state.close(), 0);
-          return false;
-        }
-        return true;
+    const menuTriggerEl = el.closest('[data-popover-trigger]');
+    if (!menuTriggerEl) {
+      // Plain interactive controls (Button, ItemButton) opt in via
+      // `data-popover-dismiss`. We schedule the close via setTimeout(0) so
+      // it lands AFTER the click event finishes — the button's onPress
+      // fires first, then the popover closes. Without this, useOverlay
+      // would stopPropagation() the click and the user would need a second
+      // click to actually press the button.
+      if (el.closest('[data-popover-dismiss]')) {
+        setTimeout(() => state.close(), 0);
+        return false;
       }
-      if (
-        isDummy &&
-        (menuTriggerEl === menuTriggerRef.current ||
-          menuTriggerRef.current?.contains(el))
-      ) {
-        return true;
-      }
-      if (menuTriggerEl === menuTriggerRef.current) return true;
-      return false;
-    },
-    [isDummy, menuTriggerRef, state],
-  );
+      return true;
+    }
+    if (
+      isDummy &&
+      (menuTriggerEl === menuTriggerRef.current ||
+        menuTriggerRef.current?.contains(el))
+    ) {
+      return true;
+    }
+    if (menuTriggerEl === menuTriggerRef.current) return true;
+    return false;
+  });
 
   let overlay;
   if (isTray) {

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   Fragment,
   ReactElement,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -38,6 +39,13 @@ export type CubeMenuTriggerProps = AriaMenuTriggerProps &
 
     closeOnSelect?: boolean;
     isDummy?: boolean;
+    /**
+     * Overlay variant to use on mobile screens. Defaults to `'popover'`, which
+     * keeps the desktop overlay even on small viewports. Pass `'tray'` to opt
+     * into the bottom-sheet `Tray` overlay on mobile (the previous implicit
+     * default). Mirrors the `mobileType` API on `DialogTrigger`.
+     */
+    mobileType?: 'popover' | 'tray';
   };
 
 function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
@@ -54,6 +62,7 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
     trigger = 'press',
     isDisabled,
     isDummy,
+    mobileType = 'popover',
   } = props;
 
   // Generate a unique ID for this menu instance
@@ -113,14 +122,19 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
 
   let initialPlacement: Placement = props.placement ?? 'bottom start';
 
-  const isMobile = useIsMobileDevice();
+  // Tray rendering is now opt-in via `mobileType="tray"` (matches DialogTrigger).
+  // Without that opt-in, MenuTrigger always renders a Popover so that environments
+  // like jsdom (where `window.screen.width === 0` makes useIsMobileDevice() true)
+  // don't accidentally swap in the tray overlay.
+  const isMobileDevice = useIsMobileDevice();
+  const isTray = mobileType === 'tray' && isMobileDevice;
   const { overlayProps: positionProps, placement } = useOverlayPosition({
     targetRef: menuTriggerRef,
     overlayRef: menuPopoverRef,
     scrollRef: menuRef,
     placement: initialPlacement,
     shouldFlip: shouldFlip,
-    isOpen: state.isOpen && !isMobile,
+    isOpen: state.isOpen && !isTray,
     onClose: state.close,
     containerPadding: props.containerPadding,
     offset: props.offset ?? 8,
@@ -133,15 +147,15 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
     onClose: state.close,
     closeOnSelect,
     autoFocus: (state.focusStrategy as any) ?? 'first',
-    style: isMobile
+    style: isTray
       ? {
           width: '100%',
           maxHeight: 'inherit',
         }
       : undefined,
     mods: {
-      popover: !isMobile,
-      tray: isMobile,
+      popover: !isTray,
+      tray: isTray,
     },
     isClosing: !state.isOpen,
   } as MenuContextValue;
@@ -154,11 +168,54 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
     </>
   );
 
-  // On small screen devices, the menu is rendered in a tray, otherwise a popover.
+  // Shared between the Popover and Tray branches so both react-aria `useOverlay`
+  // calls see the same predicate. Without this, the Tray branch falls back to
+  // unconditional dismiss-on-outside-interaction, which `useOverlay` translates
+  // into stopPropagation/preventDefault in the capture phase — that swallows
+  // clicks on sibling triggers (see Menu rapid-open test).
+  //
+  // We capture `state.isOpen` via a ref so the callback identity stays stable
+  // across re-renders (it's passed to react-aria `useOverlay` whose listener
+  // setup keys off the ref equality). The ref is read at click time so a menu
+  // that is logically closed (`state.close()` already ran) but still mounted
+  // inside the `Popover` exit transition does not block sibling-trigger clicks.
+  const stateIsOpenRef = useRef(state.isOpen);
+  useEffect(() => {
+    stateIsOpenRef.current = state.isOpen;
+  }, [state.isOpen]);
+  const shouldCloseOnInteractOutside = useCallback(
+    (el: Element) => {
+      // While `Popover` is animating out, useOverlay's `useInteractOutside`
+      // capture-phase listener is still attached (jsdom 29+ uses
+      // pointerdown/click capture). Without this guard, clicks on a sibling
+      // trigger get stopPropagation()'d during the 350ms exit window and the
+      // sibling's `onClick` never runs — breaking rapid-open and "open menu
+      // again with new props" flows.
+      if (!stateIsOpenRef.current) return false;
+
+      const menuTriggerEl = el.closest('[data-popover-trigger]');
+      if (!menuTriggerEl) return true;
+      if (
+        isDummy &&
+        (menuTriggerEl === menuTriggerRef.current ||
+          menuTriggerRef.current?.contains(el))
+      ) {
+        return true;
+      }
+      if (menuTriggerEl === menuTriggerRef.current) return true;
+      return false;
+    },
+    [isDummy, menuTriggerRef],
+  );
+
   let overlay;
-  if (isMobile) {
+  if (isTray) {
     overlay = (
-      <Tray isOpen={state.isOpen} onClose={state.close}>
+      <Tray
+        isOpen={state.isOpen}
+        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+        onClose={state.close}
+      >
         {contents}
       </Tray>
     );
@@ -171,24 +228,7 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
         isOpen={state.isOpen}
         style={positionProps.style}
         placement={placement}
-        shouldCloseOnInteractOutside={(el) => {
-          const menuTriggerEl = el.closest('[data-popover-trigger]');
-          // If no menu trigger was clicked, allow closing
-          if (!menuTriggerEl) return true;
-          // For dummy triggers (like useAnchoredMenu), check if the clicked element
-          // is the target element or its descendant
-          if (
-            isDummy &&
-            (menuTriggerEl === menuTriggerRef.current ||
-              menuTriggerRef.current?.contains(el))
-          ) {
-            return true;
-          }
-          // If the same trigger that opened this menu was clicked, allow closing
-          if (menuTriggerEl === menuTriggerRef.current) return true;
-          // Otherwise, don't close (let event mechanism handle it)
-          return false;
-        }}
+        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         onClose={state.close}
       >
         {contents}

--- a/src/components/actions/Menu/SubMenuTrigger.tsx
+++ b/src/components/actions/Menu/SubMenuTrigger.tsx
@@ -18,7 +18,7 @@ import {
 import { useMenuTriggerState } from 'react-stately';
 
 import { generateRandomId } from '../../../utils/random';
-import { useEventBus } from '../../../utils/react/useEventBus';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { Popover } from '../../overlays/Modal';
 
 import { MenuContext, MenuContextValue, useMenuContext } from './context';
@@ -105,8 +105,11 @@ function InternalSubMenuTrigger(props: InternalSubMenuTriggerProps) {
   // Generate a unique ID for this submenu instance
   const submenuId = useMemo(() => generateRandomId(), []);
 
-  // Get event bus for submenu synchronization
-  const { emit, on } = useEventBus();
+  usePopoverSync({
+    menuId: submenuId,
+    isOpen: state.isOpen,
+    onClose: () => state.close(),
+  });
 
   // Refs – trigger (MenuItem <li>) and overlay (<div> from Popover)
   const domTriggerRef = useRef<HTMLElement>(null);
@@ -182,25 +185,6 @@ function InternalSubMenuTrigger(props: InternalSubMenuTriggerProps) {
 
   // Sync the parent selection manager focus with DOM ref (for virtual focus scenarios)
   useSyncRef(parentContext, domTriggerRef);
-
-  // Listen for other menus opening and close this submenu if needed
-  useEffect(() => {
-    const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      // If another menu is opening and this submenu is open, close this one
-      if (data.menuId !== submenuId && state.isOpen) {
-        state.close();
-      }
-    });
-
-    return unsubscribe;
-  }, [on, submenuId, state]);
-
-  // Emit event when this submenu opens
-  useEffect(() => {
-    if (state.isOpen) {
-      emit('popover:open', { menuId: submenuId });
-    }
-  }, [state.isOpen, emit, submenuId]);
 
   // Cleanup hover timers and reset refs on unmount
   useEffect(() => {

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -86,22 +86,36 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   // Get event bus for menu synchronization
   const { emit, on } = useEventBus();
 
+  // Read isOpen through a ref so the listener subscription stays stable across
+  // open/close transitions. With isOpen in the deps the listener was being
+  // resubscribed mid-flight during rapid trigger switching, which let the
+  // wrong menu win the race.
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   // Listen for other menus opening and close this one if needed
   useEffect(() => {
     const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      // If another menu is opening and this menu is open, close this one
-      if (data.menuId !== menuId && isOpen) {
+      if (data.menuId !== menuId && isOpenRef.current) {
         setIsOpen(false);
       }
     });
 
     return unsubscribe;
-  }, [on, menuId, isOpen]);
+  }, [on, menuId]);
 
-  // Emit event when this menu opens
+  // Emit event only on the false -> true transition. A re-render where isOpen
+  // is still true must not re-emit (otherwise it could trigger the listener
+  // above on a peer that just opened in the same render flush).
+  const wasOpenForEmitRef = useRef(false);
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !wasOpenForEmitRef.current) {
+      wasOpenForEmitRef.current = true;
       emit('popover:open', { menuId });
+    } else if (!isOpen) {
+      wasOpenForEmitRef.current = false;
     }
   }, [isOpen, emit, menuId]);
 

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -14,7 +14,7 @@ import { VisuallyHidden } from 'react-aria';
 import { useEvent } from '../../_internal';
 import { generateRandomId } from '../../utils/random';
 import { mergeProps } from '../../utils/react';
-import { useEventBus } from '../../utils/react/useEventBus';
+import { usePopoverSync } from '../../utils/react/usePopoverSync';
 
 import { MenuTrigger } from './Menu';
 
@@ -83,41 +83,11 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
-  // Get event bus for menu synchronization
-  const { emit, on } = useEventBus();
-
-  // Read isOpen through a ref so the listener subscription stays stable across
-  // open/close transitions. With isOpen in the deps the listener was being
-  // resubscribed mid-flight during rapid trigger switching, which let the
-  // wrong menu win the race.
-  const isOpenRef = useRef(isOpen);
-  useEffect(() => {
-    isOpenRef.current = isOpen;
-  }, [isOpen]);
-
-  // Listen for other menus opening and close this one if needed
-  useEffect(() => {
-    const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      if (data.menuId !== menuId && isOpenRef.current) {
-        setIsOpen(false);
-      }
-    });
-
-    return unsubscribe;
-  }, [on, menuId]);
-
-  // Emit event only on the false -> true transition. A re-render where isOpen
-  // is still true must not re-emit (otherwise it could trigger the listener
-  // above on a peer that just opened in the same render flush).
-  const wasOpenForEmitRef = useRef(false);
-  useEffect(() => {
-    if (isOpen && !wasOpenForEmitRef.current) {
-      wasOpenForEmitRef.current = true;
-      emit('popover:open', { menuId });
-    } else if (!isOpen) {
-      wasOpenForEmitRef.current = false;
-    }
-  }, [isOpen, emit, menuId]);
+  usePopoverSync({
+    menuId,
+    isOpen,
+    onClose: () => setIsOpen(false),
+  });
 
   function setupCheck() {
     if (!setupRef.current) {

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -96,6 +96,21 @@ export function useContextMenu<
   const invisibleAnchorRef = useRef<HTMLSpanElement>(null);
   const setupRef = useRef(false);
 
+  // Mark the container as a popover trigger so that other open menus' close-on-
+  // outside predicates treat clicks inside it (including programmatic
+  // open buttons rendered alongside a context-menu target) as a legitimate
+  // trigger interaction instead of a generic outside click. This mirrors the
+  // pattern in `useAnchoredMenu`.
+  useEffect(() => {
+    const el = targetRef.current;
+    if (el) {
+      el.dataset.popoverTrigger = '';
+      return () => {
+        delete el.dataset.popoverTrigger;
+      };
+    }
+  }, []);
+
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -16,7 +16,7 @@ import { VisuallyHidden } from 'react-aria';
 import { useEvent } from '../../_internal';
 import { generateRandomId } from '../../utils/random';
 import { mergeProps } from '../../utils/react';
-import { useEventBus } from '../../utils/react/useEventBus';
+import { usePopoverSync } from '../../utils/react/usePopoverSync';
 
 import { MenuTrigger } from './Menu';
 
@@ -114,43 +114,14 @@ export function useContextMenu<
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
-  // Get event bus for menu synchronization
-  const { emit, on } = useEventBus();
-
-  // Read isOpen through a ref so the listener subscription stays stable across
-  // open/close transitions. With isOpen in the deps the listener was being
-  // resubscribed mid-flight during rapid trigger switching, which let the
-  // wrong menu win the race. Mirrors useAnchoredMenu.
-  const isOpenRef = useRef(isOpen);
-  useEffect(() => {
-    isOpenRef.current = isOpen;
-  }, [isOpen]);
-
-  // Listen for other menus opening and close this one if needed
-  useEffect(() => {
-    const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      if (data.menuId !== menuId && isOpenRef.current) {
-        setIsOpen(false);
-        setAnchorPosition(null);
-      }
-    });
-
-    return unsubscribe;
-  }, [on, menuId]);
-
-  // Emit event only on the false -> true transition. A re-render where isOpen
-  // is still true must not re-emit (otherwise it could trigger the listener
-  // above on a peer that just opened in the same render flush). Mirrors
-  // useAnchoredMenu.
-  const wasOpenForEmitRef = useRef(false);
-  useEffect(() => {
-    if (isOpen && !wasOpenForEmitRef.current) {
-      wasOpenForEmitRef.current = true;
-      emit('popover:open', { menuId });
-    } else if (!isOpen) {
-      wasOpenForEmitRef.current = false;
-    }
-  }, [isOpen, emit, menuId]);
+  usePopoverSync({
+    menuId,
+    isOpen,
+    onClose: () => {
+      setIsOpen(false);
+      setAnchorPosition(null);
+    },
+  });
 
   function setupCheck() {
     if (!setupRef.current) {

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -117,23 +117,38 @@ export function useContextMenu<
   // Get event bus for menu synchronization
   const { emit, on } = useEventBus();
 
+  // Read isOpen through a ref so the listener subscription stays stable across
+  // open/close transitions. With isOpen in the deps the listener was being
+  // resubscribed mid-flight during rapid trigger switching, which let the
+  // wrong menu win the race. Mirrors useAnchoredMenu.
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
   // Listen for other menus opening and close this one if needed
   useEffect(() => {
     const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      // If another menu is opening and this menu is open, close this one
-      if (data.menuId !== menuId && isOpen) {
+      if (data.menuId !== menuId && isOpenRef.current) {
         setIsOpen(false);
         setAnchorPosition(null);
       }
     });
 
     return unsubscribe;
-  }, [on, menuId, isOpen]);
+  }, [on, menuId]);
 
-  // Emit event when this menu opens
+  // Emit event only on the false -> true transition. A re-render where isOpen
+  // is still true must not re-emit (otherwise it could trigger the listener
+  // above on a peer that just opened in the same render flush). Mirrors
+  // useAnchoredMenu.
+  const wasOpenForEmitRef = useRef(false);
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !wasOpenForEmitRef.current) {
+      wasOpenForEmitRef.current = true;
       emit('popover:open', { menuId });
+    } else if (!isOpen) {
+      wasOpenForEmitRef.current = false;
     }
   }, [isOpen, emit, menuId]);
 

--- a/src/components/fields/ComboBox/ComboBox.tsx
+++ b/src/components/fields/ComboBox/ComboBox.tsx
@@ -854,7 +854,17 @@ function ComboBoxOverlay({
       isDismissable: true,
       shouldCloseOnInteractOutside: (el) => {
         const menuTriggerEl = el.closest('[data-popover-trigger]');
-        if (!menuTriggerEl) return true;
+        if (!menuTriggerEl) {
+          // Plain interactive controls (Button, ItemButton) opt in via
+          // `data-popover-dismiss` to dismiss us without losing their click
+          // to useOverlay's stopPropagation. Schedule the close after the
+          // click finishes so the button's onPress runs first.
+          if (el.closest('[data-popover-dismiss]')) {
+            setTimeout(onClose, 0);
+            return false;
+          }
+          return true;
+        }
         if (menuTriggerEl === triggerRef?.current) return true;
         return false;
       },

--- a/src/components/fields/ComboBox/ComboBox.tsx
+++ b/src/components/fields/ComboBox/ComboBox.tsx
@@ -42,7 +42,7 @@ import {
   useLayoutEffect,
 } from '../../../utils/react';
 import { useFocus } from '../../../utils/react/interactions';
-import { useEventBus } from '../../../utils/react/useEventBus';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { extractStyles } from '../../../utils/styles';
 import { CollectionItem as Item } from '../../CollectionItem';
 import { useFieldProps, useFormProps, wrapWithField } from '../../form';
@@ -279,9 +279,6 @@ function useComboBoxState({
   defaultInputValue,
   comboBoxId,
 }: UseComboBoxStateProps): UseComboBoxStateReturn {
-  // Get event bus for menu synchronization
-  const { emit, on } = useEventBus();
-
   // Internal state for uncontrolled mode
   const [internalSelectedKey, setInternalSelectedKey] = useState<Key | null>(
     defaultSelectedKey ?? null,
@@ -303,23 +300,11 @@ function useComboBoxState({
   // Popover state
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  // Listen for other menus opening and close this one if needed
-  useEffect(() => {
-    const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      if (data.menuId !== comboBoxId && isPopoverOpen) {
-        setIsPopoverOpen(false);
-      }
-    });
-
-    return unsubscribe;
-  }, [on, comboBoxId, isPopoverOpen]);
-
-  // Emit event when this combobox opens
-  useEffect(() => {
-    if (isPopoverOpen) {
-      emit('popover:open', { menuId: comboBoxId });
-    }
-  }, [isPopoverOpen, emit, comboBoxId]);
+  usePopoverSync({
+    menuId: comboBoxId,
+    isOpen: isPopoverOpen,
+    onClose: () => setIsPopoverOpen(false),
+  });
 
   return {
     effectiveSelectedKey,

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -754,7 +754,17 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
         shouldFlip={shouldFlip}
         shouldCloseOnInteractOutside={(el) => {
           const menuTriggerEl = el.closest('[data-popover-trigger]');
-          if (!menuTriggerEl) return true;
+          if (!menuTriggerEl) {
+            // Plain interactive controls (Button, ItemButton) opt in via
+            // `data-popover-dismiss` to dismiss us without losing their click
+            // to useOverlay's stopPropagation. Schedule the close after the
+            // click finishes so the button's onPress runs first.
+            if (el.closest('[data-popover-dismiss]')) {
+              setTimeout(() => handleOpenChange(false), 0);
+              return false;
+            }
+            return true;
+          }
           if (menuTriggerEl === triggerRef?.current?.UNSAFE_getDOMNode())
             return true;
           return false;

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -30,7 +30,7 @@ import { useWarn } from '../../../_internal/hooks/use-warn';
 import { CloseIcon, DirectionIcon, LoadingIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
 import { generateRandomId } from '../../../utils/random';
-import { useEventBus } from '../../../utils/react/useEventBus';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { processSelectionArray } from '../../../utils/selection';
 import { extractStyles } from '../../../utils/styles';
 import { CubeItemButtonProps, ItemAction, ItemButton } from '../../actions';
@@ -280,8 +280,6 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
 
   const filterPickerId = useMemo(() => generateRandomId(), []);
 
-  const { emit, on } = useEventBus();
-
   useWarn(isCheckable === false && selectionMode === 'single', {
     key: ['filterpicker-checkable-single-mode'],
     args: [
@@ -454,21 +452,11 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
     onOpenChange?.(isOpen);
   });
 
-  // Close this picker when another menu opens (event bus)
-  useEffect(() => {
-    return on('popover:open', (data: { menuId: string }) => {
-      if (data.menuId !== filterPickerId && isPopoverOpen) {
-        handleOpenChange(false);
-      }
-    });
-  }, [on, filterPickerId, isPopoverOpen, handleOpenChange]);
-
-  // Emit event when this picker opens
-  useEffect(() => {
-    if (isPopoverOpen) {
-      emit('popover:open', { menuId: filterPickerId });
-    }
-  }, [isPopoverOpen, emit, filterPickerId]);
+  usePopoverSync({
+    menuId: filterPickerId,
+    isOpen: isPopoverOpen,
+    onClose: () => handleOpenChange(false),
+  });
 
   // Keyboard handler for arrow keys to open popover
   const { keyboardProps } = useKeyboard({

--- a/src/components/fields/ListBox/ListBox.tsx
+++ b/src/components/fields/ListBox/ListBox.tsx
@@ -1317,21 +1317,26 @@ function Option({
     filteredItemProps.icon,
   ]);
 
-  // Custom click handler for the entire option
-  const handleOptionClick = (e: MouseEvent) => {
-    // Mark focus changes from mouse clicks
+  // Side-effects layered on top of React Aria's own onClick. The underlying
+  // React Aria onClick is already chained via mergeProps below, so this handler
+  // must NOT call optionProps.onClick again — re-invoking it would trigger
+  // usePress's virtual-click branch and double-fire onPress (and toggle
+  // selection twice in multiple mode).
+  const handleOptionExtras = (e: MouseEvent) => {
     if (lastFocusSourceRef) {
       lastFocusSourceRef.current = 'mouse';
     }
 
-    // If there's an onOptionClick callback and this is checkable in multiple mode,
-    // we need to distinguish between checkbox and content clicks
-    if (
-      onOptionClick &&
-      isCheckable &&
-      state.selectionManager.selectionMode === 'multiple'
-    ) {
-      // Check if the click target is within the checkbox area
+    state.selectionManager.setFocusedKey(item.key);
+
+    if (!onOptionClick) {
+      return;
+    }
+
+    // In checkable multiple mode, suppress the callback when the click landed
+    // inside the checkbox wrapper — that area is reserved for toggle-only
+    // behaviour (React Aria still handles the toggle via the chained onClick).
+    if (isCheckable && state.selectionManager.selectionMode === 'multiple') {
       const clickTarget = e.target as HTMLElement;
       const checkboxElement = localRef.current?.querySelector(
         '[data-element="CheckboxWrapper"]',
@@ -1342,32 +1347,11 @@ function Option({
         (checkboxElement === clickTarget ||
           checkboxElement.contains(clickTarget))
       ) {
-        // Checkbox area clicked - only toggle, don't call onOptionClick
-        // Let React Aria handle the selection
-        optionProps.onClick?.(e);
-        // Set focus to the clicked item
-        state.selectionManager.setFocusedKey(item.key);
-      } else {
-        // Content area clicked - toggle and trigger callback
-        // Let React Aria handle the selection first
-        optionProps.onClick?.(e);
-        // Set focus to the clicked item
-        state.selectionManager.setFocusedKey(item.key);
-        // Then call the callback (which will close the popover in FilterPicker)
-        if (onOptionClick) {
-          onOptionClick(item.key);
-        }
-      }
-    } else {
-      // Normal behavior - let React Aria handle it
-      optionProps.onClick?.(e);
-      // Set focus to the clicked item
-      state.selectionManager.setFocusedKey(item.key);
-      // Call onOptionClick if provided
-      if (onOptionClick) {
-        onOptionClick(item.key);
+        return;
       }
     }
+
+    onOptionClick(item.key);
   };
 
   // Filter out React Aria props that shouldn't reach the DOM
@@ -1394,7 +1378,7 @@ function Option({
         hoverProps,
         filteredItemProps,
         {
-          onClick: handleOptionClick,
+          onClick: handleOptionExtras,
           onKeyDown,
           onKeyUp,
           tabIndex,

--- a/src/components/fields/Picker/Picker.tsx
+++ b/src/components/fields/Picker/Picker.tsx
@@ -680,7 +680,17 @@ export const Picker = forwardRef(function Picker<T extends object>(
         shouldFlip={shouldFlip}
         shouldCloseOnInteractOutside={(el) => {
           const menuTriggerEl = el.closest('[data-popover-trigger]');
-          if (!menuTriggerEl) return true;
+          if (!menuTriggerEl) {
+            // Plain interactive controls (Button, ItemButton) opt in via
+            // `data-popover-dismiss` to dismiss us without losing their click
+            // to useOverlay's stopPropagation. Schedule the close after the
+            // click finishes so the button's onPress runs first.
+            if (el.closest('[data-popover-dismiss]')) {
+              setTimeout(() => handleOpenChange(false), 0);
+              return false;
+            }
+            return true;
+          }
           if (menuTriggerEl === triggerRef?.current?.UNSAFE_getDOMNode())
             return true;
           return false;

--- a/src/components/fields/Picker/Picker.tsx
+++ b/src/components/fields/Picker/Picker.tsx
@@ -30,7 +30,7 @@ import { useWarn } from '../../../_internal/hooks/use-warn';
 import { CloseIcon, DirectionIcon, LoadingIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
 import { generateRandomId } from '../../../utils/random';
-import { useEventBus } from '../../../utils/react/useEventBus';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { processSelectionArray } from '../../../utils/selection';
 import { extractStyles } from '../../../utils/styles';
 import { CubeItemButtonProps, ItemAction, ItemButton } from '../../actions';
@@ -248,9 +248,6 @@ export const Picker = forwardRef(function Picker<T extends object>(
   // Generate a unique ID for this Picker instance
   const pickerId = useMemo(() => generateRandomId(), []);
 
-  // Get event bus for menu synchronization
-  const { emit, on } = useEventBus();
-
   // Warn if isCheckable is false in single selection mode
   useWarn(isCheckable === false && selectionMode === 'single', {
     key: ['picker-checkable-single-mode'],
@@ -464,21 +461,11 @@ export const Picker = forwardRef(function Picker<T extends object>(
     onOpenChange?.(isOpen);
   });
 
-  // Close this picker when another menu opens (event bus)
-  useEffect(() => {
-    return on('popover:open', (data: { menuId: string }) => {
-      if (data.menuId !== pickerId && isPopoverOpen) {
-        handleOpenChange(false);
-      }
-    });
-  }, [on, pickerId, isPopoverOpen, handleOpenChange]);
-
-  // Emit event when this picker opens
-  useEffect(() => {
-    if (isPopoverOpen) {
-      emit('popover:open', { menuId: pickerId });
-    }
-  }, [isPopoverOpen, emit, pickerId]);
+  usePopoverSync({
+    menuId: pickerId,
+    isOpen: isPopoverOpen,
+    onClose: () => handleOpenChange(false),
+  });
 
   // Keyboard handler for arrow keys to open popover
   const { keyboardProps } = useKeyboard({

--- a/src/components/fields/Select/Select.tsx
+++ b/src/components/fields/Select/Select.tsx
@@ -555,8 +555,17 @@ export function ListBoxPopup({
       isDismissable: true,
       shouldCloseOnInteractOutside: (el) => {
         const menuTriggerEl = el.closest('[data-popover-trigger]');
-        // If no menu trigger was clicked, allow closing
-        if (!menuTriggerEl) return true;
+        if (!menuTriggerEl) {
+          // Plain interactive controls (Button, ItemButton) opt in via
+          // `data-popover-dismiss` to dismiss us without losing their click
+          // to useOverlay's stopPropagation. Schedule the close after the
+          // click finishes so the button's onPress runs first.
+          if (el.closest('[data-popover-dismiss]')) {
+            setTimeout(() => state.close(), 0);
+            return false;
+          }
+          return true;
+        }
         // If the same trigger that opened this select was clicked, allow closing
         if (menuTriggerEl === triggerRef?.current) return true;
         // Otherwise, don't close (let event mechanism handle it)

--- a/src/components/fields/Select/Select.tsx
+++ b/src/components/fields/Select/Select.tsx
@@ -53,7 +53,7 @@ import {
   useCombinedRefs,
 } from '../../../utils/react/index';
 import { useFocus } from '../../../utils/react/interactions';
-import { useEventBus } from '../../../utils/react/useEventBus';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { extractStyles } from '../../../utils/styles';
 import { ItemAction } from '../../actions';
 import {
@@ -317,27 +317,11 @@ function Select<T extends object>(
   // Generate a unique ID for this select instance
   const selectId = useMemo(() => generateRandomId(), []);
 
-  // Get event bus for menu synchronization
-  const { emit, on } = useEventBus();
-
-  // Listen for other menus opening and close this one if needed
-  useEffect(() => {
-    const unsubscribe = on('popover:open', (data: { menuId: string }) => {
-      // If another menu is opening and this select is open, close this one
-      if (data.menuId !== selectId && state.isOpen) {
-        state.close();
-      }
-    });
-
-    return unsubscribe;
-  }, [on, selectId, state]);
-
-  // Emit event when this select opens
-  useEffect(() => {
-    if (state.isOpen) {
-      emit('popover:open', { menuId: selectId });
-    }
-  }, [state.isOpen, emit, selectId]);
+  usePopoverSync({
+    menuId: selectId,
+    isOpen: state.isOpen,
+    onClose: () => state.close(),
+  });
 
   // Call onOpenChange when open state changes
   useEffect(() => {

--- a/src/components/overlays/Modal/Tray.tsx
+++ b/src/components/overlays/Modal/Tray.tsx
@@ -57,6 +57,13 @@ export interface CubeTrayProps extends OverlayProps, WithCloseBehavior {
   isOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   defaultOpen?: boolean;
+  /**
+   * Predicate that decides whether the overlay should close in response to an
+   * interaction outside of it. When the function returns `false`, react-aria's
+   * `useOverlay` no longer calls `stopPropagation`/`preventDefault` on the
+   * outside event, which lets sibling triggers receive the click.
+   */
+  shouldCloseOnInteractOutside?: (element: Element) => boolean;
 }
 
 interface CubeTrayWrapperProps extends CubeTrayProps, TransitionState {
@@ -72,12 +79,13 @@ function Tray(props: CubeTrayProps, ref) {
     isFixedHeight,
     isNonModal,
     styles,
+    shouldCloseOnInteractOutside,
     ...otherProps
   } = props;
   let domRef = useDOMRef(ref);
 
   let { overlayProps, underlayProps } = useOverlay(
-    { ...props, isDismissable: true },
+    { ...props, isDismissable: true, shouldCloseOnInteractOutside },
     domRef,
   );
 

--- a/src/utils/react/usePopoverSync.test.tsx
+++ b/src/utils/react/usePopoverSync.test.tsx
@@ -1,0 +1,133 @@
+import { ReactNode, useEffect } from 'react';
+
+import { act, renderHook } from '../../test';
+
+import { EventBusProvider, useEventBus } from './useEventBus';
+import { usePopoverSync } from './usePopoverSync';
+
+const HookWrapper = ({ children }: { children: ReactNode }) => (
+  <EventBusProvider>{children}</EventBusProvider>
+);
+
+// `emit` from useEventBus is `setTimeout(0)`-deferred, so flush to drain it.
+const flushBus = () =>
+  act(() => new Promise((resolve) => setTimeout(resolve, 0)));
+
+describe('usePopoverSync', () => {
+  it('emits popover:open once on the false -> true transition and not on idle re-renders', async () => {
+    const observer = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) => {
+        const { on } = useEventBus();
+        // Subscribe a stable observer once on mount.
+        useEffect(() => on('popover:open', observer), [on]);
+        usePopoverSync({ menuId: 'a', isOpen, onClose: () => {} });
+      },
+      { wrapper: HookWrapper, initialProps: { isOpen: false } },
+    );
+
+    rerender({ isOpen: true });
+    await flushBus();
+    expect(observer).toHaveBeenCalledTimes(1);
+
+    // Idle re-render while still open must NOT re-emit.
+    rerender({ isOpen: true });
+    await flushBus();
+    expect(observer).toHaveBeenCalledTimes(1);
+
+    // Close, then re-open: should emit again.
+    rerender({ isOpen: false });
+    await flushBus();
+    rerender({ isOpen: true });
+    await flushBus();
+    expect(observer).toHaveBeenCalledTimes(2);
+  });
+
+  it('two peers: opening B closes A; B ignores its own emit', async () => {
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ a, b }: { a: boolean; b: boolean }) => {
+        usePopoverSync({ menuId: 'a', isOpen: a, onClose: closeA });
+        usePopoverSync({ menuId: 'b', isOpen: b, onClose: closeB });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { a: false, b: false },
+      },
+    );
+
+    rerender({ a: true, b: false });
+    await flushBus();
+    expect(closeA).not.toHaveBeenCalled();
+    expect(closeB).not.toHaveBeenCalled();
+
+    // Open B: A's listener fires. B's listener ignores its own emit.
+    rerender({ a: true, b: true });
+    await flushBus();
+    expect(closeA).toHaveBeenCalledTimes(1);
+    expect(closeB).not.toHaveBeenCalled();
+  });
+
+  it('always reads the latest onClose without resubscribing', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ a, b, onClose }: { a: boolean; b: boolean; onClose: () => void }) => {
+        usePopoverSync({ menuId: 'a', isOpen: a, onClose });
+        usePopoverSync({ menuId: 'b', isOpen: b, onClose: () => {} });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { a: false, b: false, onClose: first },
+      },
+    );
+
+    rerender({ a: true, b: false, onClose: first });
+    await flushBus();
+    // Swap onClose identity while A is still open; subscription must NOT churn.
+    rerender({ a: true, b: false, onClose: second });
+    await flushBus();
+    // Trigger a peer open so A's listener fires.
+    rerender({ a: true, b: true, onClose: second });
+    await flushBus();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('enabled=false: no emit and no peer-close', async () => {
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ a, b }: { a: boolean; b: boolean }) => {
+        usePopoverSync({
+          menuId: 'a',
+          isOpen: a,
+          onClose: closeA,
+          enabled: false,
+        });
+        usePopoverSync({ menuId: 'b', isOpen: b, onClose: closeB });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { a: false, b: false },
+      },
+    );
+
+    // Open A while disabled — must not emit, so B (which is closed anyway)
+    // observes nothing.
+    rerender({ a: true, b: false });
+    await flushBus();
+    expect(closeB).not.toHaveBeenCalled();
+
+    // Open B — A is disabled so it does not listen and stays open silently.
+    rerender({ a: true, b: true });
+    await flushBus();
+    expect(closeA).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/react/usePopoverSync.ts
+++ b/src/utils/react/usePopoverSync.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+
+import { useEventBus } from './useEventBus';
+
+export interface UsePopoverSyncOptions {
+  /** Stable identifier for this popover instance (typically a generateRandomId() memo). */
+  menuId: string;
+  /** Current open state of this popover. */
+  isOpen: boolean;
+  /** Called when another popover opens while this one is open. */
+  onClose: () => void;
+  /**
+   * When `false`, this popover does not participate in the sync (no listening,
+   * no emitting). Useful for "dummy" triggers that proxy a real one (see
+   * `MenuTrigger`'s `isDummy`). Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Coordinates the "only one popover open at a time" invariant via the EventBus.
+ *
+ * - When `isOpen` flips `false -> true`, emits `popover:open` once.
+ * - While open, listens for peers' `popover:open` events and calls `onClose`.
+ *
+ * Implementation notes (ALL of these matter — losing any one re-introduces a
+ * race that surfaces only under rapid trigger switching, which is hard to
+ * reproduce in tests):
+ *
+ * 1. `isOpen` and `onClose` are read through refs inside the listener, so the
+ *    subscription effect's dep array does NOT include `isOpen`/`onClose`. This
+ *    keeps the listener identity stable across open/close transitions and
+ *    avoids the unsubscribe-emit-resubscribe window where an emit can be
+ *    delivered to a stale listener (or no listener).
+ * 2. The emit fires only on the `false -> true` transition, gated by
+ *    `wasOpenRef`. A re-render where `isOpen` is still `true` must NOT
+ *    re-emit, otherwise it could re-trigger listeners on peers that just
+ *    opened in the same render flush.
+ * 3. The `enabled` flag short-circuits both effects symmetrically. When it
+ *    flips off, `wasOpenRef` is reset so re-enabling later still emits if
+ *    `isOpen` is true at that moment.
+ */
+export function usePopoverSync({
+  menuId,
+  isOpen,
+  onClose,
+  enabled = true,
+}: UsePopoverSyncOptions): void {
+  const { emit, on } = useEventBus();
+
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    return on('popover:open', (data: { menuId: string }) => {
+      if (data.menuId !== menuId && isOpenRef.current) {
+        onCloseRef.current();
+      }
+    });
+  }, [on, menuId, enabled]);
+
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (!enabled) {
+      wasOpenRef.current = false;
+      return;
+    }
+    if (isOpen && !wasOpenRef.current) {
+      wasOpenRef.current = true;
+      emit('popover:open', { menuId });
+    } else if (!isOpen) {
+      wasOpenRef.current = false;
+    }
+  }, [isOpen, emit, menuId, enabled]);
+}


### PR DESCRIPTION
## Summary

- **`Tray` accepts `shouldCloseOnInteractOutside`** and forwards it to react-aria's `useOverlay` (mirrors `Popover`). Without this, `useOverlay` unconditionally `stopPropagation` / `preventDefault`s outside pointer events whenever the tray is the topmost overlay, swallowing clicks on sibling triggers.
- **`MenuTrigger` no longer auto-swaps to a `Tray` on mobile.** The previous behaviour relied on `useIsMobileDevice()`, which returns `true` in jsdom-style environments where `window.screen.width === 0`, so the mobile branch could activate unintentionally. Opt in explicitly with `mobileType="tray"` (default `'popover'`), mirroring the existing `mobileType` API on `DialogTrigger`.
- **`MenuTrigger` shares one `shouldCloseOnInteractOutside` callback** between its `Popover` and `Tray` branches; the predicate also short-circuits while `state.isOpen` is `false` so sibling clicks aren't swallowed during the `Popover` exit transition (a regression seen with the capture-phase `pointerdown` listener react-aria uses on jsdom 29+).
- **Internal correctness fixes** that surfaced during the investigation:
  - `useContextMenu` tags its `targetRef` container with `data-popover-trigger`, matching the `useAnchoredMenu` pattern, so cross-menu close-on-outside predicates treat clicks inside a context-menu container as legitimate trigger interactions.
  - `useAnchoredMenu` reads `isOpen` through a ref in its event-bus listener and only emits `popover:open` on the `false → true` transition, eliminating resubscribe race conditions during rapid trigger switching.
  - `ListBox <Option>` no longer double-invokes the chained React Aria `onClick` via `mergeProps` (was double-toggling selection in checkable multiple mode).
- **Test fix:** `Menu.test.tsx > should close other menus when a new menu opens` now destructures `targetRef` from `useContextMenu` (canonical/typed name used by `TreeNode` and the dedicated `useContextMenu` test) instead of the non-existent `anchorRef`. Without the ref, the third trigger's container was never tagged with `data-popover-trigger` and the predicate above treated clicks on it as outside interactions.
- **`chore(deps): add jsdom@^29.1.1`** as a direct devDependency. vitest 4 dropped jsdom as a transitive dep, so `pnpm test` (and the pre-push hook) need it pinned explicitly.

## Behavioural change for consumers

Apps that intentionally relied on the implicit mobile tray must now pass `mobileType="tray"` to the relevant `MenuTrigger`s to restore the previous behaviour. Captured in the included changeset (`minor`).

## Test plan

- [x] `pnpm test` — 35 files / 658 passing / 1 skipped under jsdom 29.1.1.
- [x] Targeted suites (`Menu`, `use-context-menu`, `ListBox`) green: 118/118.
- [ ] Manual: verify a `MenuTrigger` with `mobileType="tray"` still renders the bottom-sheet `Tray` on a small viewport.
- [ ] Manual: verify the previously-flaky "rapid menu opening" and "close other menus on open" flows in Storybook.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes overlay dismissal behavior and the default `MenuTrigger` mobile rendering (tray now opt-in), which can affect how menus/popovers close and respond to clicks across the app.
> 
> **Overview**
> **Overlays/menus now behave more predictably across devices and sibling triggers.** `MenuTrigger` no longer auto-switches to a `Tray` on mobile; consumers must opt in via `mobileType="tray"` (default is `popover`). `Tray` gains `shouldCloseOnInteractOutside` and `MenuTrigger` shares a single outside-interaction predicate across `Popover`/`Tray` to prevent react-aria from swallowing sibling-trigger clicks, including during exit animations.
> 
> **Outside-click dismissal is updated to support single-click “press + close”.** `Button` and `ItemButton` add `data-popover-dismiss`, and `MenuTrigger`, `Select`, `ComboBox`, `FilterPicker`, and `Picker` treat those targets as special outside interactions by scheduling close via `setTimeout(0)` while allowing the click to propagate.
> 
> **Popover synchronization is refactored and hardened.** Introduces `usePopoverSync` (with tests) and replaces ad-hoc `useEventBus` open/close wiring in menus, submenus, and picker-like components; `useContextMenu` now tags its `targetRef` as a popover trigger. Also fixes a `ListBox` option click handler to avoid double-invoking react-aria’s chained `onClick`, and updates a menu test ref destructure.
> 
> **Dev tooling:** adds `jsdom@^29.1.1` as an explicit devDependency and updates the lockfile accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d516d07a8d6c895226702d553c1b6f1a1a4f20e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->