### PR TITLE
fix: text-input recipe

### DIFF
--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -59,8 +59,7 @@ configure({
       fill: '#clear',
     },
     'input-autofill': {
-      '@autofill':
-        ':is(:-webkit-autofill, :autofill, :-internal-autofill-selected, :-internal-autofill-previewed)',
+      '@autofill': ':-webkit-autofill | :autofill',
       appearance: {
         '@autofill | (@autofill & :hover) | (@autofill & :focus)': 'none',
       },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small CSS selector change limited to input autofill styling; may slightly affect autofill behavior in less common browsers but no logic/data changes.
> 
> **Overview**
> Updates the `input-autofill` tasty recipe in `Root.tsx` by replacing the previous complex `:is(...)` autofill selector (including internal pseudo-classes) with a simpler `:-webkit-autofill | :autofill` alias, keeping the existing autofill appearance/text/caret styling rules intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d2a3b520985092637db6ade15c86989b73464d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->