### PR TITLE
fix(Layout.Header): tighten breadcrumbs and title line-height

### DIFF
--- a/.changeset/layout-header-tight-typography.md
+++ b/.changeset/layout-header-tight-typography.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': patch
 ---
 
-**Fix:** `Layout.Header` now sets `line-height: 1em` on both the breadcrumbs and the title. The headings' default leading no longer overlaps the adjacent grid rows, so long titles fit cleanly under breadcrumbs and the header collapses to its actual ink height.
+**Fix:** `Layout.Header` now sets `line-height: 1em` on the breadcrumbs row, and on the title only when breadcrumbs are present. The headings' default leading no longer overlaps the breadcrumbs row, so long titles fit cleanly beneath breadcrumbs while keeping the natural line-height when breadcrumbs are absent.

--- a/.changeset/layout-header-tight-typography.md
+++ b/.changeset/layout-header-tight-typography.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+**Fix:** `Layout.Header` now sets `line-height: 1em` on both the breadcrumbs and the title. The headings' default leading no longer overlaps the adjacent grid rows, so long titles fit cleanly under breadcrumbs and the header collapses to its actual ink height.

--- a/src/components/content/Layout/LayoutHeader.tsx
+++ b/src/components/content/Layout/LayoutHeader.tsx
@@ -73,7 +73,9 @@ const HeaderElement = tasty(LayoutContent, {
         'level=5': 'h5',
         'level=6': 'h6',
       },
-      lineHeight: '1em',
+      lineHeight: {
+        hasBreadcrumbs: '1em',
+      },
       color: '#dark',
       margin: 0,
       overflow: 'hidden',
@@ -192,7 +194,7 @@ function LayoutHeader(
     <HeaderElement
       {...otherProps}
       ref={ref}
-      mods={{ ...mods, level }}
+      mods={{ ...mods, level, hasBreadcrumbs }}
       scrollbar={scrollbar}
     >
       {renderBreadcrumbs()}

--- a/src/components/content/Layout/LayoutHeader.tsx
+++ b/src/components/content/Layout/LayoutHeader.tsx
@@ -57,6 +57,7 @@ const HeaderElement = tasty(LayoutContent, {
       placeItems: 'center start',
       gap: '1bw',
       preset: 't3 / strong',
+      lineHeight: '1em',
       color: '#dark-02',
     },
 
@@ -72,6 +73,7 @@ const HeaderElement = tasty(LayoutContent, {
         'level=5': 'h5',
         'level=6': 'h6',
       },
+      lineHeight: '1em',
       color: '#dark',
       margin: 0,
       overflow: 'hidden',


### PR DESCRIPTION
## Summary

- Set `line-height: 1em` on both the `Breadcrumbs` and `Title` sub-elements of `Layout.Header`.
- The header presets (`t3 / strong` for breadcrumbs and `h1`–`h6` for the title) ship with leading larger than the font size. In the header's compact grid, that extra leading made ascenders/descenders of the title overlap the adjacent breadcrumbs row, visually shrinking the title's share of vertical space.
- With tight line-heights the rows now collapse to the actual text height, so long titles sit cleanly under breadcrumbs and the overall header is more compact.

## Test plan

- [x] `pnpm test -- Layout` — 35 files, 658 passing (1 skipped); no behavioral regressions.
- [ ] Storybook visual check: `Content/Layout` → `WithBreadcrumbs`, `CompleteApplicationShell` to confirm the breadcrumbs no longer collide with the title.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that adjusts `line-height` and `mods` for `Layout.Header`; potential impact is limited to header layout/typography in screens that use breadcrumbs.
> 
> **Overview**
> **Fixes `Layout.Header` typography collisions when breadcrumbs are present.**
> 
> Sets `line-height: 1em` for the breadcrumbs row and conditionally applies the same to the title via a new `hasBreadcrumbs` style mod, preventing heading leading from overlapping the breadcrumbs area while preserving the default title line-height when breadcrumbs are absent.
> 
> Adds a changeset for a patch release of `@cube-dev/ui-kit` documenting the layout fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26deb92414ad68e31885380a556e8d6058a0877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->