### PR TITLE
feat(ListBox, TabPicker): drag handle on hover for custom-icon items; neutral close action

### DIFF
--- a/.changeset/listbox-drag-icon-hover.md
+++ b/.changeset/listbox-drag-icon-hover.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+ListBox: show drag handle on hover when item has a custom icon; remove danger theme from TabPicker close action

--- a/src/components/fields/ListBox/ListBox.stories.tsx
+++ b/src/components/fields/ListBox/ListBox.stories.tsx
@@ -1584,10 +1584,10 @@ export const DifferentShapes: Story = {
 export const Reorderable: StoryObj = {
   render: function ReorderableRender() {
     const INITIAL_ITEMS = [
-      { key: 'revenue', label: 'Revenue' },
-      { key: 'orders', label: 'Orders' },
-      { key: 'customers', label: 'Customers' },
-      { key: 'avg-order', label: 'Avg Order Value' },
+      { key: 'revenue', label: 'Revenue', icon: <DatabaseIcon /> },
+      { key: 'orders', label: 'Orders', icon: <FilterIcon /> },
+      { key: 'customers', label: 'Customers', icon: <UserIcon /> },
+      { key: 'avg-order', label: 'Avg Order Value', icon: <SettingsIcon /> },
       { key: 'conversion', label: 'Conversion Rate' },
       { key: 'sessions', label: 'Sessions' },
       { key: 'bounce-rate', label: 'Bounce Rate' },
@@ -1617,7 +1617,12 @@ export const Reorderable: StoryObj = {
           onReorder={(newOrder) => setKeyOrder(newOrder)}
         >
           {orderedItems.map((item) => (
-            <ListBox.Item key={item.key}>{item.label}</ListBox.Item>
+            <ListBox.Item
+              key={item.key}
+              icon={'icon' in item ? item.icon : undefined}
+            >
+              {item.label}
+            </ListBox.Item>
           ))}
         </ListBox>
         <Text preset="t4" color="#dark.60">

--- a/src/components/fields/ListBox/ListBox.tsx
+++ b/src/components/fields/ListBox/ListBox.tsx
@@ -146,8 +146,8 @@ const ListBoxItem = tasty(Item, {
         draggable: 'grab',
       },
       opacity: {
-        draggable: '.4',
-        'draggable & :hover': '1',
+        gripIcon: '.4',
+        'gripIcon & hovered': '1',
       },
       transition: {
         draggable: 'opacity',
@@ -1283,8 +1283,10 @@ function Option({
 
   // Determine icon: drag handle > checkbox > user icon > default
   const effectiveIcon = useMemo(() => {
-    if (isDraggable && !filteredItemProps.icon) {
-      return <GripVerticalIcon size={14} />;
+    if (isDraggable) {
+      if (!filteredItemProps.icon || isHovered) {
+        return <GripVerticalIcon size={14} />;
+      }
     }
 
     if (
@@ -1407,6 +1409,7 @@ function Option({
         pressed: isPressed,
         dragging: isDragging,
         draggable: isDraggable,
+        gripIcon: isDraggable && (!filteredItemProps.icon || isHovered),
         valid: isSelected && validationState === 'valid',
         invalid: isSelected && validationState === 'invalid',
         checkable: isCheckable,

--- a/src/components/navigation/Tabs/TabPicker.tsx
+++ b/src/components/navigation/Tabs/TabPicker.tsx
@@ -97,7 +97,6 @@ export function TabPicker({
             isDeletable ? (
               <ItemAction
                 icon={<CloseIcon />}
-                theme="danger"
                 aria-label="Close"
                 onPress={() => {
                   onDelete(tab.key);

--- a/src/components/navigation/Tabs/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/Tabs.stories.tsx
@@ -2,7 +2,13 @@ import { IconCalendar } from '@tabler/icons-react';
 import { Key, RefObject, useRef, useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 
-import { PlusIcon } from '../../../icons';
+import {
+  DatabaseIcon,
+  FilterIcon,
+  PlusIcon,
+  SettingsIcon,
+  UserIcon,
+} from '../../../icons';
 import { Button } from '../../actions/Button';
 import { Menu } from '../../actions/Menu';
 import { Layout } from '../../content/Layout';
@@ -1741,10 +1747,10 @@ export const HiddenScrollbar: Story = {
 export const ReorderableTabPicker: Story = {
   render: function ReorderableTabPickerRender(args) {
     const INITIAL_TABS = [
-      { key: 'overview', title: 'Overview' },
-      { key: 'analytics', title: 'Analytics' },
-      { key: 'reports', title: 'Reports' },
-      { key: 'settings', title: 'Settings' },
+      { key: 'overview', title: 'Overview', icon: <DatabaseIcon /> },
+      { key: 'analytics', title: 'Analytics', icon: <FilterIcon /> },
+      { key: 'reports', title: 'Reports', icon: <UserIcon /> },
+      { key: 'settings', title: 'Settings', icon: <SettingsIcon /> },
       { key: 'users', title: 'Users' },
       { key: 'billing', title: 'Billing' },
       { key: 'security', title: 'Security' },
@@ -1793,7 +1799,11 @@ export const ReorderableTabPicker: Story = {
           onReorder={(newOrder) => setKeyOrder(newOrder)}
         >
           {tabs.map((tab) => (
-            <Tab key={tab.key} title={tab.title}>
+            <Tab
+              key={tab.key}
+              title={tab.title}
+              icon={'icon' in tab ? tab.icon : undefined}
+            >
               <Paragraph>{tab.title} content</Paragraph>
             </Tab>
           ))}


### PR DESCRIPTION


### Describe changes

TabPicker: removed `theme="danger"` from close action — close icon is now neutral (gray) instead of red.

ListBox (draggable items with custom icons):

- Show custom icon in default state, replace with grip handle on row hover
- Icon transition is handled by the built-in `IconSwitch` cross-fade
- Grip icon opacity: dimmed (.4) by default, full (1) on hover — controlled via new `gripIcon` mod instead of CSS `:hover`

Stories: added items with custom icons to Reorderable (ListBox) and ReorderableTabPicker (Tabs) to demonstrate the behavior

https://www.loom.com/share/818dd5c7cd0f4aa1acee5aff428e1d6b

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only behavior/styling changes in `ListBox` and `TabPicker` with no data, auth, or API impact.
> 
> **Overview**
> **ListBox:** Updates reorderable items so a custom leading icon is shown by default, but cross-fades to the drag grip when the row is hovered; styling now uses a dedicated `gripIcon` modifier to control grip opacity instead of relying on a CSS `:hover` selector.
> 
> **TabPicker:** Removes the `danger` theme from the delete/close `ItemAction`, making the close icon non-destructive in appearance.
> 
> Updates Storybook examples (`ListBox` reorderable story and `ReorderableTabPicker`) to include custom icons and demonstrate the new hover-to-grip behavior, and adds a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287788490bc51aef897ad54b2208b28b663951fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->