### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,22 @@ Refer to that file for:
 - **Compound components:** `Object.assign(Button, { Group: ButtonGroup, Split: ButtonSplit })`.
 - **Tasty re-exports:** Only types are re-exported from `@tenphi/tasty`. Runtime imports (`tasty`, `extractStyles`, `filterBaseProps`) come directly from `@tenphi/tasty`.
 
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Node.js** >= 22.14.0 and **pnpm** 10.32.0 are pre-installed.
+- After `pnpm install`, run `pnpm rebuild esbuild` — pnpm blocks esbuild's postinstall by default, but Vite (used by Storybook) requires the native esbuild binary.
+
+### Running services
+
+- **Storybook dev server**: `pnpm storybook` (port 6060). Note: Vite's unbundled dev mode generates hundreds of parallel module requests on first load, which may trigger `ERR_INSUFFICIENT_RESOURCES` in Chrome in resource-constrained VMs. If you need to visually verify components via `computerUse`, build a static Storybook (`pnpm build-storybook`) and serve it (`npx serve storybook-static -l 6060`) instead.
+- **Tests**: `pnpm test` (Vitest, single run) or `pnpm test-watch` (watch mode).
+- **Lint**: `pnpm fix` (ESLint + Prettier, auto-fix mode).
+- **Build**: `pnpm build` (tsdown, unbundled ESM output in `dist/`).
+
+### Key gotchas
+
+- Husky hooks are installed via `prepare` script during `pnpm install`. Pre-push hook runs `pnpm test`; pre-commit runs `pnpm lint-staged`. To skip hooks on commits use `git commit --no-verify`.
+- No external services (databases, Docker, APIs) are needed — this is a pure frontend component library.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Describe changes

Add a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting:
- esbuild rebuild requirement after `pnpm install` (pnpm blocks its postinstall by default)
- Storybook dev server note about `ERR_INSUFFICIENT_RESOURCES` in resource-constrained VMs and the static-build workaround
- Commands reference for tests, lint, and build
- Key gotchas (husky hooks, no external services needed)

##### Checklist

- [x] Pipeline is passed
- [x] Tests are passed successfully
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: N/A

#

### Other information

This is a documentation-only change to support Cursor Cloud agent development workflows. No code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b01d49e-14db-451f-b262-784881cd23ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b01d49e-14db-451f-b262-784881cd23ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

