### PR TITLE
feat(InlineInput): always show focus outline while editing; add `isStyled` prop

### DIFF
--- a/src/components/content/InlineInput/InlineInput.docs.mdx
+++ b/src/components/content/InlineInput/InlineInput.docs.mdx
@@ -98,7 +98,7 @@ The `mods` property is automatically populated. Consumers can target these in th
 | ---------- | --------- | --------------------------------------------------------------------------------- |
 | editing    | `boolean` | Currently in edit mode                                                            |
 | editable   | `boolean` | `editTrigger` is `dblclick` or `click` and not disabled/read-only                 |
-| focused    | `boolean` | The component is focused — keyboard-focused on the display, **or** while editing |
+| focused    | `boolean` | The component is focused — keyboard-focused on the display, **or** while editing. Always `false` when `keyboardActivation={false}` (the host owns the focus indication). |
 | disabled   | `boolean` | `isDisabled` is `true`                                                            |
 | read-only  | `boolean` | `isReadOnly` is `true`                                                            |
 | styled     | `boolean` | `isStyled` is `true`                                                              |
@@ -261,7 +261,7 @@ By default the display element is keyboard-focusable (`tabIndex=0`, `role="butto
 
 <Story of={InlineInputStories.KeyboardActivation} />
 
-When `InlineInput` is embedded in a host that already owns keyboard activation (e.g. `Tabs` — each tab is a `<button>` that listens for `F2` itself), pass `keyboardActivation={false}` to avoid creating a nested tab stop inside the host. The imperative `ref.startEditing()` always works regardless of this setting, and the focus ring is suppressed in this mode (the host's focus ring is the one users see).
+When `InlineInput` is embedded in a host that already owns keyboard activation (e.g. `Tabs` — each tab is a `<button>` that listens for `F2` itself), pass `keyboardActivation={false}` to avoid creating a nested tab stop inside the host. The imperative `ref.startEditing()` always works regardless of this setting, and the focus ring is fully suppressed in this mode — **both in display and edit mode** — so the host's focus ring is the only one users see.
 
 ```jsx
 <InlineInput defaultValue="Press Enter to edit" />

--- a/src/components/content/InlineInput/InlineInput.docs.mdx
+++ b/src/components/content/InlineInput/InlineInput.docs.mdx
@@ -44,6 +44,7 @@ Unlike `TextInput`, `InlineInput` is intentionally **not** a form field. It mana
 - **`allowEmpty`** `boolean` (default: `false`) — When `false`, submitting an empty/whitespace value cancels instead.
 - **`isDisabled`** `boolean` (default: `false`) — When `true`, edit mode cannot be entered (programmatically or otherwise).
 - **`isReadOnly`** `boolean` (default: `false`) — When `true`, edit mode cannot be entered, but the display reads as enabled.
+- **`isStyled`** `boolean` (default: `false`) — When `true`, applies a styled wrapper (border, surface fill, padding, fixed height) so the component visually matches a `TextInput`. Useful when swapping a field component (e.g. `Select`) for an `InlineInput` to rename / edit the current value without a visual jump.
 - **`placeholder`** `string` — Placeholder text shown in the input when the draft is empty.
 - **`renderDisplay`** `(value: string) => ReactNode` — Custom render for display (non-editing) mode.
 - **`tooltip`** `boolean | string | AutoTooltipValue` (default: `true`) — Tooltip behaviour for the display value. `true` enables auto-tooltip on overflow (showing the full text when truncated). A string always shows that text. `false` disables the tooltip. Suppressed automatically while editing and when `renderDisplay` is used.
@@ -93,14 +94,15 @@ These properties allow direct style application without using the `styles` prop:
 
 The `mods` property is automatically populated. Consumers can target these in their own `styles`:
 
-| Modifier   | Type      | Description                                                                |
-| ---------- | --------- | -------------------------------------------------------------------------- |
-| editing    | `boolean` | Currently in edit mode                                                     |
-| editable   | `boolean` | `editTrigger` is `dblclick` or `click` and not disabled/read-only          |
-| focused    | `boolean` | Display element is keyboard-focused (`isFocusVisible`) and editable        |
-| disabled   | `boolean` | `isDisabled` is `true`                                                     |
-| read-only  | `boolean` | `isReadOnly` is `true`                                                     |
-| empty      | `boolean` | The committed value is empty                                               |
+| Modifier   | Type      | Description                                                                       |
+| ---------- | --------- | --------------------------------------------------------------------------------- |
+| editing    | `boolean` | Currently in edit mode                                                            |
+| editable   | `boolean` | `editTrigger` is `dblclick` or `click` and not disabled/read-only                 |
+| focused    | `boolean` | The component is focused — keyboard-focused on the display, **or** while editing |
+| disabled   | `boolean` | `isDisabled` is `true`                                                            |
+| read-only  | `boolean` | `isReadOnly` is `true`                                                            |
+| styled     | `boolean` | `isStyled` is `true`                                                              |
+| empty      | `boolean` | The committed value is empty                                                      |
 
 ## Examples
 
@@ -215,6 +217,22 @@ By default, submitting an empty value cancels. Set `allowEmpty` to keep the empt
 <InlineInput defaultValue="You can't edit me" isDisabled />
 <InlineInput defaultValue="Read-only value" isReadOnly />
 ```
+
+### Styled (TextInput Look)
+
+Set `isStyled` to apply a styled wrapper (border, surface fill, padding, fixed height) that visually matches a `TextInput`. Use this when you need to swap a field component (e.g. `Select`) for an `InlineInput` to rename / edit the current value without a visual jump:
+
+<Story of={InlineInputStories.Styled} />
+
+```jsx
+<InlineInput isStyled width="200px" defaultValue="Click to rename" />
+```
+
+### Swap Select with Rename
+
+A common pattern: a `Select` is replaced by a styled `InlineInput` when the user triggers a "Rename" action. The styled wrapper preserves the visual dimensions of the `Select` so the swap is seamless.
+
+<Story of={InlineInputStories.SwapSelectWithRename} />
 
 ### Overflow & Tooltip
 

--- a/src/components/content/InlineInput/InlineInput.stories.tsx
+++ b/src/components/content/InlineInput/InlineInput.stories.tsx
@@ -335,17 +335,16 @@ export const SwapSelectWithRename: Story = {
     isStyled: true,
   },
   render: function SwapSelectWithRenameStory(args) {
-    const OPTIONS = [
+    const [options, setOptions] = useState([
       { key: 'draft', label: 'Draft' },
       { key: 'published', label: 'Published' },
       { key: 'archived', label: 'Archived' },
-    ];
-
+    ]);
     const [selectedKey, setSelectedKey] = useState<string>('draft');
     const [isRenaming, setIsRenaming] = useState(false);
     const inputRef = useRef<CubeInlineInputRef>(null);
 
-    const selected = OPTIONS.find((o) => o.key === selectedKey);
+    const selected = options.find((o) => o.key === selectedKey);
 
     const handleRename = () => {
       setIsRenaming(true);
@@ -358,11 +357,14 @@ export const SwapSelectWithRename: Story = {
     const handleSubmit = (next: string) => {
       const trimmed = next.trim();
 
-      if (!trimmed) return;
+      if (trimmed) {
+        setOptions((prev) =>
+          prev.map((o) =>
+            o.key === selectedKey ? { ...o, label: trimmed } : o,
+          ),
+        );
+      }
 
-      const idx = OPTIONS.findIndex((o) => o.key === selectedKey);
-
-      if (idx !== -1) OPTIONS[idx].label = trimmed;
       setIsRenaming(false);
     };
 
@@ -388,7 +390,7 @@ export const SwapSelectWithRename: Story = {
             selectedKey={selectedKey}
             onSelectionChange={(key) => setSelectedKey(String(key))}
           >
-            {OPTIONS.map((o) => (
+            {options.map((o) => (
               <Select.Item key={o.key}>{o.label}</Select.Item>
             ))}
           </Select>

--- a/src/components/content/InlineInput/InlineInput.stories.tsx
+++ b/src/components/content/InlineInput/InlineInput.stories.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState } from 'react';
 
 import { Button } from '../../actions/Button/Button';
+import { Select } from '../../fields/Select/Select';
+import { Flex } from '../../layout/Flex';
 import { Title } from '../Title';
 
 import { CubeInlineInputRef, InlineInput } from './InlineInput';
@@ -114,6 +116,15 @@ const meta = {
     isReadOnly: {
       control: 'boolean',
       description: 'When true, edit mode cannot be entered.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    isStyled: {
+      control: 'boolean',
+      description:
+        'When true, applies a styled wrapper (border, fill, padding, fixed height) so the component visually matches a TextInput.',
       table: {
         defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
@@ -308,6 +319,88 @@ export const KeyboardActivation: Story = {
       <InlineInput {...args} />
     </p>
   ),
+};
+
+export const Styled: Story = {
+  args: {
+    isStyled: true,
+    defaultValue: 'Click to rename',
+    width: '200px',
+  },
+  render: (args) => <InlineInput {...args} />,
+};
+
+export const SwapSelectWithRename: Story = {
+  args: {
+    isStyled: true,
+  },
+  render: function SwapSelectWithRenameStory(args) {
+    const OPTIONS = [
+      { key: 'draft', label: 'Draft' },
+      { key: 'published', label: 'Published' },
+      { key: 'archived', label: 'Archived' },
+    ];
+
+    const [selectedKey, setSelectedKey] = useState<string>('draft');
+    const [isRenaming, setIsRenaming] = useState(false);
+    const inputRef = useRef<CubeInlineInputRef>(null);
+
+    const selected = OPTIONS.find((o) => o.key === selectedKey);
+
+    const handleRename = () => {
+      setIsRenaming(true);
+      // Focus the input once it mounts.
+      requestAnimationFrame(() => {
+        inputRef.current?.startEditing();
+      });
+    };
+
+    const handleSubmit = (next: string) => {
+      const trimmed = next.trim();
+
+      if (!trimmed) return;
+
+      const idx = OPTIONS.findIndex((o) => o.key === selectedKey);
+
+      if (idx !== -1) OPTIONS[idx].label = trimmed;
+      setIsRenaming(false);
+    };
+
+    return (
+      <Flex gap="1x" placeItems="center">
+        {isRenaming ? (
+          <InlineInput
+            {...args}
+            ref={inputRef}
+            isStyled
+            width="200px"
+            defaultValue={selected?.label ?? ''}
+            editTrigger="none"
+            placeholder="New name"
+            aria-label="Rename option"
+            onSubmit={handleSubmit}
+            onCancel={() => setIsRenaming(false)}
+          />
+        ) : (
+          <Select
+            width="200px"
+            aria-label="Status"
+            selectedKey={selectedKey}
+            onSelectionChange={(key) => setSelectedKey(String(key))}
+          >
+            {OPTIONS.map((o) => (
+              <Select.Item key={o.key}>{o.label}</Select.Item>
+            ))}
+          </Select>
+        )}
+        <Button
+          onPress={isRenaming ? () => setIsRenaming(false) : handleRename}
+        >
+          {isRenaming ? 'Cancel' : 'Rename'}
+        </Button>
+      </Flex>
+    );
+  },
 };
 
 export const Overflow: Story = {

--- a/src/components/content/InlineInput/InlineInput.stories.tsx
+++ b/src/components/content/InlineInput/InlineInput.stories.tsx
@@ -335,17 +335,17 @@ export const SwapSelectWithRename: Story = {
     isStyled: true,
   },
   render: function SwapSelectWithRenameStory(args) {
-    const OPTIONS = [
+    const [options, setOptions] = useState([
       { key: 'draft', label: 'Draft' },
       { key: 'published', label: 'Published' },
       { key: 'archived', label: 'Archived' },
-    ];
+    ]);
 
     const [selectedKey, setSelectedKey] = useState<string>('draft');
     const [isRenaming, setIsRenaming] = useState(false);
     const inputRef = useRef<CubeInlineInputRef>(null);
 
-    const selected = OPTIONS.find((o) => o.key === selectedKey);
+    const selected = options.find((o) => o.key === selectedKey);
 
     const handleRename = () => {
       setIsRenaming(true);
@@ -360,9 +360,9 @@ export const SwapSelectWithRename: Story = {
 
       if (!trimmed) return;
 
-      const idx = OPTIONS.findIndex((o) => o.key === selectedKey);
-
-      if (idx !== -1) OPTIONS[idx].label = trimmed;
+      setOptions((prev) =>
+        prev.map((o) => (o.key === selectedKey ? { ...o, label: trimmed } : o)),
+      );
       setIsRenaming(false);
     };
 
@@ -388,7 +388,7 @@ export const SwapSelectWithRename: Story = {
             selectedKey={selectedKey}
             onSelectionChange={(key) => setSelectedKey(String(key))}
           >
-            {OPTIONS.map((o) => (
+            {options.map((o) => (
               <Select.Item key={o.key}>{o.label}</Select.Item>
             ))}
           </Select>

--- a/src/components/content/InlineInput/InlineInput.test.tsx
+++ b/src/components/content/InlineInput/InlineInput.test.tsx
@@ -534,6 +534,38 @@ describe('<InlineInput />', () => {
     });
   });
 
+  describe('isStyled', () => {
+    it('exposes the styled modifier on the root when isStyled is true', () => {
+      const { getByTestId, rerender } = renderWithRoot(
+        <InlineInput defaultValue="Hello" qa="II" />,
+      );
+
+      const root = getByTestId('II');
+      expect(root).not.toHaveAttribute('data-styled');
+
+      rerender(<InlineInput isStyled defaultValue="Hello" qa="II" />);
+      expect(getByTestId('II')).toHaveAttribute('data-styled');
+    });
+
+    it('still enters edit mode and submits when styled', async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn();
+      const { getByText, getByRole } = renderWithRoot(
+        <InlineInput isStyled defaultValue="Hello" onSubmit={handleSubmit} />,
+      );
+
+      await user.dblClick(getByText('Hello'));
+
+      const input = getByRole('textbox') as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'World' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+
+      expect(handleSubmit).toHaveBeenCalledWith('World');
+    });
+  });
+
   describe('Modifiers / styling', () => {
     it('exposes editing modifier in edit mode', () => {
       const { getByTestId, rerender } = renderWithRoot(
@@ -786,6 +818,22 @@ describe('<InlineInput />', () => {
       // global focus-visible state true, then assert the span stays clean.
       await user.tab();
       expect(getByTestId('II')).not.toHaveAttribute('data-focused');
+    });
+
+    it('marks the root as focused while editing, regardless of activation', async () => {
+      const user = userEvent.setup();
+      const { getByText, getByTestId } = renderWithRoot(
+        <InlineInput defaultValue="Hello" qa="II" />,
+      );
+
+      const root = getByTestId('II');
+      expect(root).not.toHaveAttribute('data-focused');
+
+      // Mouse-driven activation should still mark the root as focused while
+      // editing — the input is focused inside.
+      await user.dblClick(getByText('Hello'));
+      expect(root).toHaveAttribute('data-editing');
+      expect(root).toHaveAttribute('data-focused');
     });
 
     it('clears the focus ring when keyboard-initiated edit mode ends', async () => {

--- a/src/components/content/InlineInput/InlineInput.test.tsx
+++ b/src/components/content/InlineInput/InlineInput.test.tsx
@@ -836,6 +836,23 @@ describe('<InlineInput />', () => {
       expect(root).toHaveAttribute('data-focused');
     });
 
+    it('suppresses the focus ring entirely when keyboardActivation is false (host owns focus)', async () => {
+      // Hosts like `Tabs` already render their own focus ring around the
+      // surrounding control. We must not draw a second ring on top while the
+      // user is editing the inline value.
+      const user = userEvent.setup();
+      const { getByText, getByTestId } = renderWithRoot(
+        <InlineInput defaultValue="Hello" qa="II" keyboardActivation={false} />,
+      );
+
+      const root = getByTestId('II');
+      expect(root).not.toHaveAttribute('data-focused');
+
+      await user.dblClick(getByText('Hello'));
+      expect(root).toHaveAttribute('data-editing');
+      expect(root).not.toHaveAttribute('data-focused');
+    });
+
     it('clears the focus ring when keyboard-initiated edit mode ends', async () => {
       // Regression test: when entering edit mode via the keyboard, the
       // display span loses focus to the inner input. If `useFocusRing`'s

--- a/src/components/content/InlineInput/InlineInput.tsx
+++ b/src/components/content/InlineInput/InlineInput.tsx
@@ -559,13 +559,19 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
     // `focused` controls the visible focus indicator on the root.
     //
     // While editing, the inner `<input>` always has focus (FocusScope
-    // `autoFocus`), so we always show the focus indicator on the root —
-    // regardless of how the user activated edit mode (click vs keyboard).
+    // `autoFocus`), so we show the focus indicator on the root regardless
+    // of how the user activated edit mode (click vs keyboard).
     //
     // In display mode, we keep the original behaviour: only show the
     // indicator on keyboard focus (focus-visible), and only when the display
     // element is actually focusable (i.e. `isEditable`).
-    const showFocusRing = isEditing || (isFocusVisible && isEditable);
+    //
+    // When `keyboardActivation` is `false` the host (e.g. `Tabs`) owns the
+    // entire focus story for this control, so we suppress the focus ring
+    // entirely — including while editing — to avoid drawing a redundant
+    // indicator on top of the host's own focus ring.
+    const showFocusRing =
+      keyboardActivation && (isEditing || (isFocusVisible && isEditable));
 
     const mods = useMemo(
       () => ({

--- a/src/components/content/InlineInput/InlineInput.tsx
+++ b/src/components/content/InlineInput/InlineInput.tsx
@@ -106,6 +106,16 @@ export interface CubeInlineInputProps
   /** When true, edit mode cannot be entered, but the display reads as enabled. */
   isReadOnly?: boolean;
 
+  /**
+   * When true, applies a styled wrapper to the component (border, fill, padding,
+   * fixed height) so it visually matches a `TextInput`. Useful when swapping a
+   * field component (e.g. `Select`) for an `InlineInput` to rename / edit the
+   * current value without a visual jump.
+   *
+   * @default false
+   */
+  isStyled?: boolean;
+
   /** Placeholder text shown in the input when the draft is empty. */
   placeholder?: string;
   /** Custom render for display (non-editing) mode. Receives the currently-displayed value (including optimistic). */
@@ -157,28 +167,66 @@ const InlineInputRoot = tasty({
     // margin edge, which visibly shifts the text upward inside surrounding
     // line boxes (notably inside Tabs' centered `Item.Label`).
     display: 'inline-flex',
-    alignItems: 'baseline',
-    verticalAlign: 'baseline',
+    alignItems: {
+      '': 'baseline',
+      styled: 'center',
+    },
+    verticalAlign: {
+      '': 'baseline',
+      styled: 'middle',
+    },
     position: 'relative',
     maxWidth: '100%',
-    color: 'inherit',
-    preset: 'inherit',
+    boxSizing: 'border-box',
+    color: {
+      '': 'inherit',
+      styled: '#dark-02',
+      'styled & disabled': '#dark.30',
+    },
+    preset: {
+      '': 'inherit',
+      styled: 't3',
+    },
     cursor: {
       '': 'inherit',
       'editable & !editing': 'text',
     },
-    // Keyboard focus ring (only when the display element is keyboard-focusable,
-    // which is gated by `keyboardActivation` on the React side via the
-    // `focused` mod). Outline doesn't take layout space and respects rounded
-    // corners via `outlineOffset`.
+    fill: {
+      '': 'transparent',
+      styled: '#surface',
+      'styled & disabled': '#disabled-surface',
+    },
+    border: {
+      '': false,
+      styled: true,
+      'styled & focused': '#primary-text',
+      'styled & disabled': true,
+    },
+    // Focus ring. Shown when the display element is keyboard-focused
+    // (driven on the React side by `isFocusVisible`) and *always* while
+    // editing — so swapping into the input always presents a clear focus
+    // indicator regardless of how the user activated it (click vs keyboard).
+    // In `styled` mode the border colour transition is enough to indicate
+    // focus (matching `TextInput`'s visual), so the outline is suppressed.
+    // Outline doesn't take layout space and respects rounded corners via
+    // `outlineOffset`.
     outline: {
       '': '1bw #primary.0',
-      focused: '1bw #primary',
+      'focused & !styled': '1bw #primary',
     },
     outlineOffset: 1,
     radius: {
       '': 0,
       focused: true,
+      styled: true,
+    },
+    padding: {
+      '': 0,
+      styled: '(.75x - 1bw) (1x - 1bw)',
+    },
+    height: {
+      '': 'auto',
+      styled: '$size-md',
     },
     transition: 'theme',
 
@@ -200,8 +248,18 @@ const InlineInputRoot = tasty({
       preset: 'inherit',
       color: 'inherit',
       fill: 'transparent',
-      width: 'initial $input-width 100%',
-      minWidth: '1em',
+      textAlign: 'left',
+      // In `styled` mode the wrapper has a fixed size and we want the input
+      // to fill it (matches `TextInput`). In the default inline mode the
+      // input auto-sizes to its content via `$input-width`.
+      width: {
+        '': 'initial $input-width 100%',
+        styled: '100%',
+      },
+      minWidth: {
+        '': '1em',
+        styled: 0,
+      },
       '&::placeholder': { recipe: 'input-placeholder' },
     },
 
@@ -258,6 +316,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
       allowEmpty = false,
       isDisabled = false,
       isReadOnly = false,
+      isStyled = false,
       placeholder,
       renderDisplay,
       tooltip = true,
@@ -497,12 +556,16 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
 
     const isEditable = editTrigger !== 'none' && !isDisabled && !isReadOnly;
 
-    // `focused` is the keyboard-focus ring state. We gate it on `isEditable`
-    // and `!isEditing` so the ring never shows on a non-editable display
-    // (e.g. inside Tabs with `keyboardActivation={false}` — the span isn't
-    // focusable there, but we belt-and-braces it anyway) or while editing
-    // (focus is on the inner input).
-    const showFocusRing = isFocusVisible && isEditable && !isEditing;
+    // `focused` controls the visible focus indicator on the root.
+    //
+    // While editing, the inner `<input>` always has focus (FocusScope
+    // `autoFocus`), so we always show the focus indicator on the root —
+    // regardless of how the user activated edit mode (click vs keyboard).
+    //
+    // In display mode, we keep the original behaviour: only show the
+    // indicator on keyboard focus (focus-visible), and only when the display
+    // element is actually focusable (i.e. `isEditable`).
+    const showFocusRing = isEditing || (isFocusVisible && isEditable);
 
     const mods = useMemo(
       () => ({
@@ -511,6 +574,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
         focused: showFocusRing,
         disabled: isDisabled,
         'read-only': isReadOnly,
+        styled: isStyled,
         empty: !displayedValue,
         ...customMods,
       }),
@@ -520,6 +584,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
         showFocusRing,
         isDisabled,
         isReadOnly,
+        isStyled,
         displayedValue,
         customMods,
       ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves [CUB-2588](https://linear.app).

## Summary

- **Focus outline always visible while editing.** The focus indicator on the root used to be shown only when the display element was keyboard-focused (`isFocusVisible`) and *not* while editing. It's now also shown while editing, regardless of how edit mode was activated (mouse click, keyboard, or `ref.startEditing()`). The inner `<input>` always has focus during editing, so the outline now consistently signals "this control is focused".
- **`keyboardActivation={false}` fully suppresses the focus ring** — including while editing. Hosts like `Tabs` already draw their own focus ring around the surrounding control; we must not draw a second one on top. Passing `keyboardActivation={false}` already means "the host owns keyboard activation"; we extend that to "the host owns focus indication".
- **New `isStyled` prop.** When `true`, the component takes on a `TextInput`-like look (surface fill, border, fixed `$size-md` height, padding, rounded corners, `t3` preset). Useful for swap patterns where a `Select` is replaced by an `InlineInput` to rename / edit the current value without a visual jump. The border colour transitions to `#primary-text` on focus (matching `TextInput`); the outline is suppressed in `styled` mode to avoid a double indicator. The inner input fills the wrapper width in styled mode rather than auto-sizing.

## Walkthrough

The new `Swap Select With Rename` story demonstrates the headline use case: a `Select` is replaced by a styled `InlineInput` when the user triggers a "Rename" action. The swap is visually seamless — same height, same border style, same padding.

[Select with Draft value and Rename button](https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswap_select_initial.png)
[Select swapped to styled InlineInput in edit mode](https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswap_select_renaming.png)
[Select returned with the renamed label](https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswap_select_after_rename.png)

Styled InlineInput on its own (display + edit mode):

[Styled InlineInput in display mode](https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline_input_styled.png)
[Styled InlineInput in edit mode with focused border](https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline_input_styled_editing.png)

Default InlineInput now shows the focus outline while editing, even when activated by mouse:

[Default InlineInput editing — focus outline visible after mouse activation](https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline_input_default_editing.png)

## Files Changed

- `src/components/content/InlineInput/InlineInput.tsx` — new `isStyled` prop, `styled` modifier, updated focus-ring logic (`showFocusRing = keyboardActivation && (isEditing || (isFocusVisible && isEditable))`), `styled`-aware tasty styles.
- `src/components/content/InlineInput/InlineInput.stories.tsx` — `isStyled` argType + two new stories (`Styled`, `SwapSelectWithRename`).
- `src/components/content/InlineInput/InlineInput.test.tsx` — new tests for the always-on focus indicator while editing, full suppression with `keyboardActivation={false}`, and the `isStyled` modifier / edit lifecycle.
- `src/components/content/InlineInput/InlineInput.docs.mdx` — documented `isStyled`, new `styled` modifier, updated `focused` modifier description (now notes the `keyboardActivation={false}` suppression), added two new doc sections.

## Testing

- ✅ `pnpm vitest run src/components/content/InlineInput src/components/navigation/Tabs` — 100 passing (56 InlineInput + 44 Tabs).
- ✅ `pnpm test` (pre-push hook) — full suite, 722 passing, 1 skipped.
- ✅ `pnpm build` — library builds clean.
- ✅ `pnpm fix` — lint + format clean.
- ⚠️ `pnpm audit-docs --component=InlineInput` — pre-existing false positive about `scrollMargin` (already listed under `Position:` in the `Style Properties` section, unrelated to this PR; reproduces on `main`).
- ✅ Manually verified all three new visual states in Storybook (screenshots above).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cdae3a9-4808-4637-9439-76c48f37c955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cdae3a9-4808-4637-9439-76c48f37c955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

