### PR TITLE
fix(ListBox): adapt checkable mode checkbox to dark mode

### DIFF
--- a/.changeset/listbox-checkbox-dark-mode.md
+++ b/.changeset/listbox-checkbox-dark-mode.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`ListBox`: fix checkbox colors in `isCheckable` mode so the unchecked background adapts to dark mode and the selected state uses the proper accent surface color, matching `Checkbox`.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "0.11.0",
-    "@tenphi/tasty": "2.6.0",
+    "@tenphi/tasty": "2.6.1",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.11.0
         version: 0.11.0
       '@tenphi/tasty':
-        specifier: 2.6.0
-        version: 2.6.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.6.1
+        version: 2.6.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2730,8 +2730,8 @@ packages:
     resolution: {integrity: sha512-rEzQoCUkoXczbrmcYCkr3Vwv3HvomSwC4gspN0m/cKNhfMiQF/CDEWNrTTLoD+XesUwtrdnB2wE2Wrm17mVT9g==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@2.6.0':
-    resolution: {integrity: sha512-+1hkCr49NFRaqx+JYvXSafjpMq5px8wWsA99jKYKVaOd0G7BMy1oAvtqKSIVbfyFiVgPLp1Okyd8reUHRgKTDA==}
+  '@tenphi/tasty@2.6.1':
+    resolution: {integrity: sha512-kqgjYBU+kvrn9pLVRy0Mg3N35l19KiHQryBWCtO2He+Gal5Ujo81+Xn46Z8HzAduvahzq8VIShCGTxboz5XeEg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10089,7 +10089,7 @@ snapshots:
 
   '@tenphi/glaze@0.11.0': {}
 
-  '@tenphi/tasty@2.6.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.6.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/src/components/fields/ListBox/ListBox.tsx
+++ b/src/components/fields/ListBox/ListBox.tsx
@@ -222,15 +222,15 @@ const ListBoxCheckbox = tasty({
       'selected | indeterminate | hovered | focused': 1,
     },
     fill: {
-      '': '#white',
-      'selected | indeterminate': '#primary-text',
-      'invalid & !(selected | indeterminate)': '#white',
+      '': '#surface',
+      'selected | indeterminate': '#primary',
+      'invalid & !(selected | indeterminate)': '#surface',
       'invalid & (selected | indeterminate)': '#danger',
       disabled: '#dark.12',
     },
     color: {
-      '': '#white',
-      'disabled & !selected': '#clear',
+      '': '#clear',
+      'selected | indeterminate': '#white',
     },
     border: {
       '': '#dark.30',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk visual-only change: updates ListBox checkable-mode checkbox theme tokens and bumps a styling dependency; no behavior or data-flow changes.
> 
> **Overview**
> Fixes `ListBox` checkbox styling in `isCheckable` mode so the unchecked state uses `#surface` (adapts to dark mode) and the selected/indeterminate state uses the correct accent surface + white checkmark, aligning with `Checkbox`.
> 
> Includes a patch changeset entry and bumps `@tenphi/tasty` from `2.6.0` to `2.6.1` (lockfile updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a3a58247634b93ca816ed2f6a093f73cb09324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->