### PR TITLE
fix(stories): use Space for vertical stacks of inline-level items

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -27,6 +27,6 @@ module.exports = [
     path: './dist/index.js',
     webpack: true,
     import: '{ Button }',
-    limit: '115kB',
+    limit: '116kB',
   },
 ];

--- a/src/components/actions/ItemAction/ItemAction.stories.tsx
+++ b/src/components/actions/ItemAction/ItemAction.stories.tsx
@@ -280,7 +280,7 @@ export const InsideItemButton: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Icon Only Actions</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             type="outline"
             icon={<IconFile />}
@@ -306,12 +306,12 @@ export const InsideItemButton: Story = {
           >
             Report.xlsx
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Labels</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             type="outline"
             icon={<IconFile />}
@@ -324,7 +324,7 @@ export const InsideItemButton: Story = {
           >
             Document.pdf
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
@@ -332,7 +332,7 @@ export const InsideItemButton: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Actions automatically inherit type and theme from parent ItemButton
         </Paragraph>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             type="primary"
             theme="default"
@@ -359,7 +359,7 @@ export const InsideItemButton: Story = {
           >
             Danger Button
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
@@ -367,7 +367,7 @@ export const InsideItemButton: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Actions can override inherited type/theme
         </Paragraph>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             type="outline"
             icon={<IconFile />}
@@ -401,12 +401,12 @@ export const InsideItemButton: Story = {
           >
             Item with Mixed Actions
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Different Sizes</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             type="outline"
             size="small"
@@ -446,7 +446,7 @@ export const InsideItemButton: Story = {
           >
             Large Button
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
@@ -454,7 +454,7 @@ export const InsideItemButton: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Actions can appear only on hover
         </Paragraph>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             autoHideActions
             type="outline"
@@ -483,7 +483,7 @@ export const InsideItemButton: Story = {
           >
             Long Item Name with Hover Actions
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -511,7 +511,7 @@ export const InsideItem: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Basic Usage</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="item"
             icon={<IconFile />}
@@ -537,12 +537,12 @@ export const InsideItem: Story = {
           >
             Report.xlsx
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Different Item Types</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="primary"
             icon={<IconFile />}
@@ -579,12 +579,12 @@ export const InsideItem: Story = {
           >
             Neutral Item
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Description</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="item"
             icon={<IconFile />}
@@ -613,12 +613,12 @@ export const InsideItem: Story = {
           >
             Report.xlsx
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Theme Inheritance</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="item"
             theme="danger"
@@ -645,12 +645,12 @@ export const InsideItem: Story = {
           >
             Success Theme Item
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Mixed Action Types</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="item"
             icon={<IconFile />}
@@ -669,12 +669,12 @@ export const InsideItem: Story = {
           >
             Item with Multiple Actions
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Loading States</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="item"
             icon={<IconFile />}
@@ -687,7 +687,7 @@ export const InsideItem: Story = {
           >
             Item with Loading Action
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
@@ -696,7 +696,7 @@ export const InsideItem: Story = {
           Actions inherit disabled state from parent Item. Use isDisabled=false
           to keep action enabled.
         </Paragraph>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             isDisabled
             type="item"
@@ -727,12 +727,12 @@ export const InsideItem: Story = {
           >
             Disabled Item (delete action enabled)
           </Item>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Truncated Content</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <Item
             type="item"
             icon={<IconFile />}
@@ -747,7 +747,7 @@ export const InsideItem: Story = {
           >
             Very Long Item Name That Should Truncate With Actions
           </Item>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -768,7 +768,7 @@ export const InteractiveExample: Story = {
       <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
         Click on the action buttons to see the interactions
       </Paragraph>
-      <Flow gap="1x" placeItems="start">
+      <Space flow="column" gap="1x" placeItems="start">
         <ItemButton
           type="outline"
           icon={<IconFile />}
@@ -850,7 +850,7 @@ export const InteractiveExample: Story = {
         >
           Presentation.pptx (hover to see actions)
         </ItemButton>
-      </Flow>
+      </Space>
     </Flow>
   ),
   parameters: {

--- a/src/components/actions/ItemButton/ItemButton.stories.tsx
+++ b/src/components/actions/ItemButton/ItemButton.stories.tsx
@@ -11,6 +11,7 @@ import { Paragraph } from '../../content/Paragraph';
 import { Title } from '../../content/Title';
 import { Flow } from '../../layout/Flow';
 import { Grid } from '../../layout/Grid';
+import { Space } from '../../layout/Space';
 import { ItemAction } from '../ItemAction';
 
 import { ItemButton } from './ItemButton';
@@ -152,7 +153,7 @@ export const AsLink: Story = {
 
 export const Variants: Story = {
   render: (args) => (
-    <Flow gap="1x">
+    <Space flow="column" gap="1x" placeItems="start">
       <ItemButton {...args} type="primary">
         Primary
       </ItemButton>
@@ -171,7 +172,7 @@ export const Variants: Story = {
       <ItemButton {...args} type="link">
         Link
       </ItemButton>
-    </Flow>
+    </Space>
   ),
 };
 
@@ -183,7 +184,7 @@ export const WithHotkeys: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Try pressing the keyboard shortcuts to trigger the buttons:
         </Paragraph>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             hotkeys="cmd+s"
@@ -217,7 +218,7 @@ export const WithHotkeys: Story = {
           >
             Cancel
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
@@ -226,7 +227,7 @@ export const WithHotkeys: Story = {
           When a custom suffix is provided, hotkeys are still functional but the
           shortcut hint is not shown:
         </Paragraph>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             hotkeys="cmd+d"
@@ -235,12 +236,12 @@ export const WithHotkeys: Story = {
           >
             Download
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Different Hotkey Formats</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             hotkeys="ctrl+alt+d"
@@ -264,7 +265,7 @@ export const WithHotkeys: Story = {
           >
             Submit
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -283,7 +284,7 @@ export const WithCheckbox: Story = {
     <Flow gap="2x">
       <Flow gap="1x">
         <Title level={4}>Selected Items (Checkbox Visible)</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} isSelected={true}>
             Selected item with checkbox
           </ItemButton>
@@ -293,12 +294,12 @@ export const WithCheckbox: Story = {
           <ItemButton {...args} isSelected={true} type="outline">
             Outline selected button
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Non-Selected Items (Checkbox Hidden)</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} isSelected={false}>
             Non-selected item with hidden checkbox
           </ItemButton>
@@ -308,12 +309,12 @@ export const WithCheckbox: Story = {
           <ItemButton {...args} isSelected={false} type="outline">
             Outline non-selected button
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Mixed Selection States</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} isSelected={true} type="primary">
             Selected Item 1
           </ItemButton>
@@ -323,12 +324,12 @@ export const WithCheckbox: Story = {
           <ItemButton {...args} isSelected={true} type="primary">
             Selected Item 3
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Comparison: Checkbox vs Regular Icon</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} isSelected={true}>
             With checkbox (selected)
           </ItemButton>
@@ -338,7 +339,7 @@ export const WithCheckbox: Story = {
           <ItemButton {...args} icon={<IconFile />}>
             With regular icon
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -361,7 +362,7 @@ export const WithLoading: Story = {
       <Flow gap="2x">
         <Flow gap="1x">
           <Title level={4}>Loading States with Auto Slot Selection</Title>
-          <Flow gap="1x" placeItems="start">
+          <Space flow="column" gap="1x" placeItems="start">
             <ItemButton {...cleanArgs} isLoading={false} icon={<IconFile />}>
               Normal state
             </ItemButton>
@@ -378,12 +379,12 @@ export const WithLoading: Story = {
             <ItemButton {...cleanArgs} isLoading={true} prefix="$" suffix=".00">
               Loading (auto - no icons, fallback to icon)
             </ItemButton>
-          </Flow>
+          </Space>
         </Flow>
 
         <Flow gap="1x">
           <Title level={4}>Loading with Different Types</Title>
-          <Flow gap="1x" placeItems="start">
+          <Space flow="column" gap="1x" placeItems="start">
             <ItemButton
               {...cleanArgs}
               type="primary"
@@ -408,12 +409,12 @@ export const WithLoading: Story = {
             >
               Outline Loading
             </ItemButton>
-          </Flow>
+          </Space>
         </Flow>
 
         <Flow gap="1x">
           <Title level={4}>Explicit Loading Slots</Title>
-          <Flow gap="1x" placeItems="start">
+          <Space flow="column" gap="1x" placeItems="start">
             <ItemButton
               {...cleanArgs}
               isLoading={true}
@@ -441,7 +442,7 @@ export const WithLoading: Story = {
             >
               Loading in suffix slot
             </ItemButton>
-          </Flow>
+          </Space>
         </Flow>
 
         <Flow gap="1x">
@@ -450,7 +451,7 @@ export const WithLoading: Story = {
             Loading buttons are automatically disabled and cannot be interacted
             with:
           </Paragraph>
-          <Flow gap="1x" placeItems="start">
+          <Space flow="column" gap="1x" placeItems="start">
             <ItemButton
               {...cleanArgs}
               isLoading={true}
@@ -467,7 +468,7 @@ export const WithLoading: Story = {
             >
               Normal button (clickable)
             </ItemButton>
-          </Flow>
+          </Space>
         </Flow>
       </Flow>
     );
@@ -487,7 +488,7 @@ export const AutoTooltipOnOverflow: Story = {
     <Flow gap="2x">
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with tooltip=true</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             tooltip={true}
@@ -504,12 +505,12 @@ export const AutoTooltipOnOverflow: Story = {
           >
             Short text
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with Configuration Object</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             tooltip={{ auto: true, placement: 'top' }}
@@ -526,12 +527,12 @@ export const AutoTooltipOnOverflow: Story = {
           >
             Text with custom delay and bottom placement
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Auto vs Explicit Tooltip</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             tooltip={{ title: 'Custom tooltip text', auto: true }}
@@ -548,12 +549,12 @@ export const AutoTooltipOnOverflow: Story = {
           >
             Auto tooltip shows this text when overflowed
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>No Tooltip When Not Overflowed</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             tooltip={true}
@@ -570,12 +571,12 @@ export const AutoTooltipOnOverflow: Story = {
           >
             Normal length text (no tooltip)
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with Different Button Types</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             tooltip={true}
@@ -603,12 +604,12 @@ export const AutoTooltipOnOverflow: Story = {
           >
             Clear button with overflow
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with Hotkeys</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             tooltip={{ auto: true, placement: 'top' }}
@@ -630,7 +631,7 @@ export const AutoTooltipOnOverflow: Story = {
           >
             Open document with long name
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -649,7 +650,7 @@ export const WithActionsLayouts: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Different Sizes</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -720,12 +721,12 @@ export const WithActionsLayouts: Story = {
           >
             XLarge Size
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Only Actions</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -751,12 +752,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name that should truncate properly with actions
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Left Icon</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -784,12 +785,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with icon that should truncate properly
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Prefix</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -817,12 +818,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with prefix that should truncate properly
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Left Icon and Prefix</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -852,12 +853,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with icon and prefix that should truncate
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Inline Description</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -887,12 +888,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with inline description that should truncate
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Inline Description and Left Icon</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -924,12 +925,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with icon and inline description
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Block Description</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -959,12 +960,12 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with block description that should truncate
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Block Description and Left Icon</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -996,7 +997,7 @@ export const WithActionsLayouts: Story = {
           >
             Very long item name with icon and block description
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -1015,7 +1016,7 @@ export const WithHighlight: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Basic Highlight</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} icon={<IconFile />} highlight="file">
             File management options
           </ItemButton>
@@ -1027,12 +1028,12 @@ export const WithHighlight: Story = {
           >
             Edit document settings
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Case Sensitivity</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1050,12 +1051,12 @@ export const WithHighlight: Story = {
           >
             Case-sensitive: FILE matches, file does not
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Multiple Matches</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1064,12 +1065,12 @@ export const WithHighlight: Story = {
           >
             The quick brown fox jumps over the lazy dog
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>With Custom Highlight Styles</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1079,12 +1080,12 @@ export const WithHighlight: Story = {
           >
             Item with custom highlight style
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Combined with Other Features</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1110,7 +1111,7 @@ export const WithHighlight: Story = {
           >
             Item with actions and highlight
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),
@@ -1306,19 +1307,19 @@ export const Disabled: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Basic Disabled Buttons</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} isDisabled={true}>
             Disabled button
           </ItemButton>
           <ItemButton {...args} isDisabled={false}>
             Enabled button
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Icons</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton {...args} isDisabled={true} icon={<IconFile />}>
             Disabled with icon
           </ItemButton>
@@ -1330,12 +1331,12 @@ export const Disabled: Story = {
           >
             Disabled with both icons
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Disabled Across Different Types</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="primary"
@@ -1376,12 +1377,12 @@ export const Disabled: Story = {
           >
             Disabled clear
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Disabled Across Different Sizes</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             size="xsmall"
@@ -1422,12 +1423,12 @@ export const Disabled: Story = {
           >
             Disabled xlarge
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Description</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1448,12 +1449,12 @@ export const Disabled: Story = {
           >
             Disabled with block description
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Actions</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1468,12 +1469,12 @@ export const Disabled: Story = {
           >
             Disabled with actions
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Hotkeys</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             isDisabled={true}
@@ -1483,12 +1484,12 @@ export const Disabled: Story = {
           >
             Disabled with hotkeys (won't work)
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
 
       <Flow gap="1x">
         <Title level={4}>Comparison: Enabled vs Disabled</Title>
-        <Flow gap="1x" placeItems="start">
+        <Space flow="column" gap="1x" placeItems="start">
           <ItemButton
             {...args}
             type="primary"
@@ -1521,7 +1522,7 @@ export const Disabled: Story = {
           >
             Disabled outline button
           </ItemButton>
-        </Flow>
+        </Space>
       </Flow>
     </Flow>
   ),

--- a/src/components/actions/Menu/Menu.stories.tsx
+++ b/src/components/actions/Menu/Menu.stories.tsx
@@ -1421,7 +1421,7 @@ export const MenuSynchronization = () => {
         closes any other open menu.
       </Paragraph>
 
-      <Flow gap="3x" flexDirection="row">
+      <Space flow="row" gap="3x">
         <Card border padding="3x" margin="0 0 3x 0">
           <Paragraph preset="t3m" color="#dark" margin="0 0 2x 0">
             Regular MenuTrigger
@@ -1474,10 +1474,10 @@ export const MenuSynchronization = () => {
             Right-click to open context menu
           </Paragraph>
         </Card>
-      </Flow>
+      </Space>
 
       <Alert type="info" title="Try it out">
-        <Flow gap="1x">
+        <Space flow="column" gap="1x">
           <Text>1. Open any menu by clicking a button</Text>
           <Text>
             2. Try opening another menu - the first one will automatically close
@@ -1486,7 +1486,7 @@ export const MenuSynchronization = () => {
             3. Right-click on the context menu card for a context menu
           </Text>
           <Text>4. Notice how only one menu can be open at any time</Text>
-        </Flow>
+        </Space>
       </Alert>
     </Flow>
   );
@@ -1690,7 +1690,7 @@ export const SubMenuCustomization = () => {
         placement, offset, and autoFocus behavior.
       </Paragraph>
 
-      <Flow gap="3x" flexDirection="row" flexWrap="wrap">
+      <Space flow="row wrap" gap="3x">
         {/* Default placement */}
         <Card border padding="3x" minWidth="250px">
           <Paragraph preset="t3m" color="#dark" margin="0 0 2x 0">
@@ -1789,10 +1789,10 @@ export const SubMenuCustomization = () => {
             </Menu>
           </MenuTrigger>
         </Card>
-      </Flow>
+      </Space>
 
       <Alert type="info" title="SubMenu Features">
-        <Flow gap="1x">
+        <Space flow="column" gap="1x">
           <Text>
             • <Text.Strong>Keyboard Navigation:</Text.Strong> Use arrow keys to
             navigate between menus
@@ -1817,7 +1817,7 @@ export const SubMenuCustomization = () => {
             • <Text.Strong>Custom Positioning:</Text.Strong> Control placement,
             offset, and flip behavior
           </Text>
-        </Flow>
+        </Space>
       </Alert>
     </Flow>
   );

--- a/src/components/content/Item/Item.stories.tsx
+++ b/src/components/content/Item/Item.stories.tsx
@@ -1269,7 +1269,7 @@ DescriptionWithTypes.parameters = {
 export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
   <Flow gap="2x">
     <Title level={5}>Inline Description with All Elements</Title>
-    <Flow gap="1x">
+    <Space flow="column" gap="1x" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1313,10 +1313,10 @@ export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
       >
         All Elements
       </Item>
-    </Flow>
+    </Space>
 
     <Title level={5}>Block Description with All Elements</Title>
-    <Flow gap="1x">
+    <Space flow="column" gap="1x" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1360,10 +1360,10 @@ export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
       >
         All Elements
       </Item>
-    </Flow>
+    </Space>
 
     <Title level={5}>Description with Actions</Title>
-    <Flow gap="1x">
+    <Space flow="column" gap="1x" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1394,7 +1394,7 @@ export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
       >
         User Record
       </Item>
-    </Flow>
+    </Space>
   </Flow>
 );
 

--- a/src/components/fields/ComboBox/ComboBox.stories.tsx
+++ b/src/components/fields/ComboBox/ComboBox.stories.tsx
@@ -6,6 +6,7 @@ import { Paragraph } from '../../content/Paragraph';
 import { Text } from '../../content/Text';
 import { Flex } from '../../layout/Flex';
 import { Flow } from '../../layout/Flow';
+import { Space } from '../../layout/Space';
 
 import { ComboBox, CubeComboBoxProps } from './ComboBox';
 
@@ -416,7 +417,7 @@ export const AllowsCustomValue = () => {
         <ComboBox.Item key="angular">Angular</ComboBox.Item>
         <ComboBox.Item key="svelte">Svelte</ComboBox.Item>
       </ComboBox>
-      <Flow gap="1x">
+      <Space flow="column" gap="1x">
         <Text>
           Input value: <Text.Strong>{inputValue || 'none'}</Text.Strong>
         </Text>
@@ -428,7 +429,7 @@ export const AllowsCustomValue = () => {
           Type text and press Enter or blur to commit. Select from list to
           commit immediately.
         </Paragraph>
-      </Flow>
+      </Space>
     </Flow>
   );
 };
@@ -492,7 +493,7 @@ export const ClearOnBlur = () => {
         <ComboBox.Item key="cherry">Cherry</ComboBox.Item>
         <ComboBox.Item key="date">Date</ComboBox.Item>
       </ComboBox>
-      <Flow gap="1x">
+      <Space flow="column" gap="1x">
         <Text>
           Selected: <Text.Strong>{selectedKey || 'none'}</Text.Strong>
         </Text>
@@ -501,7 +502,7 @@ export const ClearOnBlur = () => {
           focus. This is useful for search-like scenarios where you want to
           reset after each interaction.
         </Paragraph>
-      </Flow>
+      </Space>
     </Flow>
   );
 };
@@ -837,7 +838,7 @@ export const IndependentControls = () => {
         <ComboBox.Item key="date">Date</ComboBox.Item>
         <ComboBox.Item key="elderberry">Elderberry</ComboBox.Item>
       </ComboBox>
-      <Flow gap="1x">
+      <Space flow="column" gap="1x">
         <Text>
           Input value: <Text.Strong>{inputValue || 'empty'}</Text.Strong>
         </Text>
@@ -848,7 +849,7 @@ export const IndependentControls = () => {
           inputValue and selectedKey are independent. Typing updates input and
           clears selection. Selecting from list updates both.
         </Paragraph>
-      </Flow>
+      </Space>
     </Flow>
   );
 };
@@ -877,7 +878,7 @@ export const AllowsCustomValueNoCommitOnBlur = () => {
         <ComboBox.Item key="angular">Angular</ComboBox.Item>
         <ComboBox.Item key="svelte">Svelte</ComboBox.Item>
       </ComboBox>
-      <Flow gap="1x">
+      <Space flow="column" gap="1x">
         <Text>
           Input value: <Text.Strong>{inputValue || 'none'}</Text.Strong>
         </Text>
@@ -889,7 +890,7 @@ export const AllowsCustomValueNoCommitOnBlur = () => {
           With shouldCommitOnBlur=false, custom values only commit on Enter key,
           not on blur.
         </Paragraph>
-      </Flow>
+      </Space>
     </Flow>
   );
 };

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -827,7 +827,7 @@ export const RenderSummaryBehavior: Story = {
           1. renderSummary={'{false}'} (Icon-only triggers)
         </Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -845,9 +845,9 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
 
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -866,7 +866,7 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
         </Space>
         <Text preset="t4" color="#dark.60">
           ✓ Both triggers show only the icon, no text regardless of selection
@@ -876,7 +876,7 @@ export const RenderSummaryBehavior: Story = {
       <Space gap="2x" flow="column" placeItems="start">
         <Title preset="h6">2. Custom renderSummary returning null</Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -892,9 +892,9 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
 
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -911,7 +911,7 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
         </Space>
         <Text preset="t4" color="#dark.60">
           ✓ Both triggers show the placeholder when custom renderer returns null
@@ -921,7 +921,7 @@ export const RenderSummaryBehavior: Story = {
       <Space gap="2x" flow="column" placeItems="start">
         <Title preset="h6">3. Custom renderSummary with custom text</Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -940,9 +940,9 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
 
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -962,7 +962,7 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
         </Space>
         <Text preset="t4" color="#dark.60">
           ✓ Custom text is shown in both cases based on selection state
@@ -972,7 +972,7 @@ export const RenderSummaryBehavior: Story = {
       <Space gap="2x" flow="column" placeItems="start">
         <Title preset="h6">4. Custom renderSummary with JSX</Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -997,9 +997,9 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
 
-          <Flow gap="1x">
+          <Space flow="column" gap="1x">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -1025,7 +1025,7 @@ export const RenderSummaryBehavior: Story = {
                 </FilterPicker.Item>
               ))}
             </FilterPicker>
-          </Flow>
+          </Space>
         </Space>
         <Text preset="t4" color="#dark.60">
           ✓ Complex JSX renders correctly in both cases

--- a/src/components/fields/ListBox/ListBox.stories.tsx
+++ b/src/components/fields/ListBox/ListBox.stories.tsx
@@ -18,7 +18,6 @@ import { Badge } from '../../content/Badge/Badge';
 import { Text } from '../../content/Text';
 import { Title } from '../../content/Title';
 import { Form } from '../../form/Form';
-import { Flow } from '../../layout/Flow';
 import { Space } from '../../layout/Space';
 import { Dialog } from '../../overlays/Dialog/Dialog';
 import { DialogTrigger } from '../../overlays/Dialog/DialogTrigger';
@@ -1090,7 +1089,7 @@ export const WithIcons: Story = {
 export const FocusBehavior: Story = {
   render: (args) => (
     <Space gap="3x" flow="column">
-      <Flow gap="1x">
+      <Space flow="column" gap="1x">
         <Text preset="t3" weight="600">
           Standard Focus (focusOnHover=true)
         </Text>
@@ -1103,9 +1102,9 @@ export const FocusBehavior: Story = {
             <ListBox.Item key={fruit.key}>{fruit.label}</ListBox.Item>
           ))}
         </ListBox>
-      </Flow>
+      </Space>
 
-      <Flow gap="1x">
+      <Space flow="column" gap="1x">
         <Text preset="t3" weight="600">
           No Focus on Hover (focusOnHover=false)
         </Text>
@@ -1118,7 +1117,7 @@ export const FocusBehavior: Story = {
             <ListBox.Item key={fruit.key}>{fruit.label}</ListBox.Item>
           ))}
         </ListBox>
-      </Flow>
+      </Space>
     </Space>
   ),
   args: {

--- a/src/components/fields/TextArea/TextArea.stories.tsx
+++ b/src/components/fields/TextArea/TextArea.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { baseProps } from '../../../stories/lists/baseProps';
 import { Button } from '../../actions/Button/Button';
+import { Space } from '../../layout/Space';
 
 import { CubeTextAreaProps, TextArea } from './TextArea';
 
@@ -277,7 +278,7 @@ export const ControlledAutoSize = () => {
   const [value, setValue] = useState('Line 1');
 
   return (
-    <>
+    <Space flow="column" gap="1x" placeItems="start">
       <TextArea
         autoSize
         label="Controlled AutoSize TextArea"
@@ -287,15 +288,10 @@ export const ControlledAutoSize = () => {
         description="Height adjusts when value changes programmatically"
         onChange={setValue}
       />
-      <Button
-        margin="1x 0 0 0"
-        onPress={() => setValue('Line 1\nLine 2\nLine 3\nLine 4')}
-      >
+      <Button onPress={() => setValue('Line 1\nLine 2\nLine 3\nLine 4')}>
         Add lines programmatically
       </Button>
-      <Button margin="1x 0 0 0" onPress={() => setValue('Line 1')}>
-        Reset to single line
-      </Button>
-    </>
+      <Button onPress={() => setValue('Line 1')}>Reset to single line</Button>
+    </Space>
   );
 };

--- a/src/components/navigation/Tabs/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/Tabs.stories.tsx
@@ -14,7 +14,6 @@ import { Menu } from '../../actions/Menu';
 import { Layout } from '../../content/Layout';
 import { Paragraph } from '../../content/Paragraph';
 import { Text } from '../../content/Text';
-import { Flow } from '../../layout/Flow';
 import { Space } from '../../layout/Space';
 
 import { Tab, Tabs } from './Tabs';
@@ -1212,7 +1211,7 @@ function RenderCountPanel({
   const count = countsRef.current[tabKey];
 
   return (
-    <Flow qa={`panel-${tabKey}`} gap="1x">
+    <Space qa={`panel-${tabKey}`} flow="column" gap="1x">
       <Text.Strong>
         {tabKey.charAt(0).toUpperCase() + tabKey.slice(1)} Content
       </Text.Strong>
@@ -1228,7 +1227,7 @@ function RenderCountPanel({
         {tabKey === 'tab3' &&
           'Switch between tabs to see the caching in action.'}
       </Paragraph>
-    </Flow>
+    </Space>
   );
 }
 
@@ -1357,32 +1356,32 @@ export const LazyRenderingWithKeepMounted: Story = {
           switch (key) {
             case 'tab1':
               return (
-                <Flow gap="1x">
+                <Space flow="column" gap="1x">
                   <Text.Strong>Dashboard</Text.Strong>
                   <Paragraph>
                     Your main dashboard with charts and statistics.
                   </Paragraph>
-                </Flow>
+                </Space>
               );
             case 'tab2':
               return (
-                <Flow gap="1x">
+                <Space flow="column" gap="1x">
                   <Text.Strong>Settings</Text.Strong>
                   <Paragraph>
                     Configure your preferences here. State is preserved when
                     switching tabs.
                   </Paragraph>
-                </Flow>
+                </Space>
               );
             case 'tab3':
               return (
-                <Flow gap="1x">
+                <Space flow="column" gap="1x">
                   <Text.Strong>Reports</Text.Strong>
                   <Paragraph>
                     Generate and view reports. Complex data tables would load
                     lazily.
                   </Paragraph>
-                </Flow>
+                </Space>
               );
             default:
               return null;


### PR DESCRIPTION
Replace Flow with Space flow="column" in stories where children are inline-level (ItemButton/Item/Button/Text), so vertical stacking and gap actually apply. Flow stays block-flow as designed.

### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to Storybook layout markup and imports, with no production component logic modified.
> 
> **Overview**
> Storybook examples for `ItemAction`, `ItemButton`, `Menu`, `Item`, `ComboBox`, `FilterPicker`, `ListBox`, `TextArea`, and `Tabs` replace `Flow` wrappers with `Space flow="column"` (or `Space flow="row"/"row wrap"`) where children are inline-level, ensuring vertical stacking and `gap` spacing apply as intended.
> 
> Also adjusts related story layout details (imports, a few wrapper props, and removing manual `margin` spacing in `TextArea` stories in favor of `Space` gaps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653dc73d84d853a8d341986845ddd858b9b5129c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->