### PR TITLE
fix(Menu): close entire submenu hierarchy on outside click

### DIFF
--- a/.changeset/submenu-outside-click-cascade.md
+++ b/.changeset/submenu-outside-click-cascade.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+**Menu sub-menus**: a single outside click now closes the entire menu hierarchy. Previously, with one or more nested `Menu.SubMenuTrigger`s open, only the deepest sub-menu closed on the first outside click — the parent menu and intermediate sub-menus stayed open until additional clicks. React Aria's `useOverlay` invokes `onClose` only for the topmost overlay in its `visibleOverlays` stack, so the fix lives in `SubMenuTrigger`: the nested `Popover` now receives a `shouldCloseOnInteractOutside` predicate (mirroring `MenuTrigger`'s) that schedules the parent's `onClose` via `setTimeout(0)`. The existing `parentContext.isClosing` cascade then collapses every level. `usePopoverSync`'s peer-coordination semantics (closing siblings when one popover opens) are unchanged. Existing close paths — Escape, `DismissButton`, item selection — are untouched and continue to behave as before.

--- a/src/components/actions/Menu/SubMenuTrigger.test.tsx
+++ b/src/components/actions/Menu/SubMenuTrigger.test.tsx
@@ -904,5 +904,87 @@ describe('<SubMenuTrigger />', () => {
         { timeout: 1500 },
       );
     });
+
+    it('should close every nested submenu and the root on a single outside click', async () => {
+      const deeplyNestedExample = (
+        <EventBusProvider>
+          <div>
+            <button data-qa="OutsideTarget">Outside</button>
+            <MenuTrigger>
+              <Button>Open Menu</Button>
+              <Menu width="220px">
+                <Menu.SubMenuTrigger>
+                  <Menu.Item key="file">File</Menu.Item>
+                  <Menu>
+                    <Menu.SubMenuTrigger>
+                      <Menu.Item key="export">Export</Menu.Item>
+                      <Menu>
+                        <Menu.SubMenuTrigger>
+                          <Menu.Item key="advanced">Advanced</Menu.Item>
+                          <Menu>
+                            <Menu.Item key="custom">Custom Format</Menu.Item>
+                          </Menu>
+                        </Menu.SubMenuTrigger>
+                      </Menu>
+                    </Menu.SubMenuTrigger>
+                  </Menu>
+                </Menu.SubMenuTrigger>
+              </Menu>
+            </MenuTrigger>
+          </div>
+        </EventBusProvider>
+      );
+
+      const { getByText, queryByText, getByTestId } =
+        renderWithRoot(deeplyNestedExample);
+
+      // Open root menu
+      await userEvent.click(getByText('Open Menu'));
+
+      await waitFor(() => {
+        expect(getByText('File')).toBeInTheDocument();
+      });
+
+      // Open first-level submenu
+      await userEvent.hover(getByText('File'));
+      await waitFor(
+        () => {
+          expect(getByText('Export')).toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+
+      // Open second-level submenu
+      await userEvent.hover(getByText('Export'));
+      await waitFor(
+        () => {
+          expect(getByText('Advanced')).toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+
+      // Open third-level submenu
+      await userEvent.hover(getByText('Advanced'));
+      await waitFor(
+        () => {
+          expect(getByText('Custom Format')).toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+
+      // Single outside click should collapse the entire chain
+      await userEvent.click(getByTestId('OutsideTarget'));
+
+      await waitFor(
+        () => {
+          // Every level — root + 3 nested submenus — must be gone
+          expect(queryByText('File')).not.toBeInTheDocument();
+          expect(queryByText('Export')).not.toBeInTheDocument();
+          expect(queryByText('Advanced')).not.toBeInTheDocument();
+          expect(queryByText('Custom Format')).not.toBeInTheDocument();
+        },
+        { timeout: 2000 },
+      );
+    });
   });
 });

--- a/src/components/actions/Menu/SubMenuTrigger.tsx
+++ b/src/components/actions/Menu/SubMenuTrigger.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-aria';
 import { useMenuTriggerState } from 'react-stately';
 
+import { useEvent } from '../../../_internal';
 import { generateRandomId } from '../../../utils/random';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { Popover } from '../../overlays/Modal';
@@ -313,6 +314,43 @@ function InternalSubMenuTrigger(props: InternalSubMenuTriggerProps) {
     };
   };
 
+  // Outside-click handling for the nested submenu Popover.
+  //
+  // React Aria's `useOverlay` keeps a module-level `visibleOverlays` stack and
+  // only invokes `onClose` for the topmost overlay (`onHide` gates on the
+  // stack tail). With root + N nested submenus open, a single outside click
+  // would otherwise only close the deepest submenu. Scheduling
+  // `parentContext.onClose()` here propagates the close upward; the existing
+  // `parentContext.isClosing` cascade (see `nestedMenuContext.isClosing` and
+  // the Popover's `isOpen={!parentContext.isClosing}`) collapses every
+  // intermediate submenu visually.
+  //
+  // Mirrors `MenuTrigger`'s predicate so clicks on `[data-popover-trigger]`
+  // and `[data-popover-dismiss]` elements behave consistently across nesting
+  // levels.
+  const shouldCloseOnInteractOutside = useEvent((el: Element) => {
+    if (!state.isOpen) return false;
+
+    const menuTriggerEl = el.closest('[data-popover-trigger]');
+    if (!menuTriggerEl) {
+      if (el.closest('[data-popover-dismiss]')) {
+        // Let the button's onPress fire first, then collapse the chain.
+        setTimeout(() => parentContext.onClose?.(), 0);
+        return false;
+      }
+      // True outside click: schedule parent close so the entire hierarchy
+      // cascades. `useOverlay`'s own `onHide` will close this submenu via the
+      // topmost-overlay rule.
+      setTimeout(() => parentContext.onClose?.(), 0);
+      return true;
+    }
+    // Click landed on a popover trigger (parent menu item, sibling submenu
+    // trigger, or a different menu's button). Don't close ourselves here —
+    // either the trigger handles it or `usePopoverSync` closes us via
+    // `popover:open`.
+    return false;
+  });
+
   // Provide context to the trigger element (already rendered MenuItem)
   const triggerContextValue = useMemo(
     () => ({
@@ -358,6 +396,7 @@ function InternalSubMenuTrigger(props: InternalSubMenuTriggerProps) {
           isOpen={!parentContext.isClosing}
           style={positionProps.style}
           placement={placement as Placement}
+          shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
           onClose={state.close}
           // Spread any additional overlay props
           {...overlayProps}


### PR DESCRIPTION
A single outside click previously closed only the deepest open submenu because React Aria's `useOverlay` invokes `onClose` for the topmost overlay only. Add `shouldCloseOnInteractOutside` to the nested `SubMenuTrigger` Popover that schedules `parentContext.onClose()` so the existing `parentContext.isClosing` cascade collapses every level. `usePopoverSync` peer-coordination semantics are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nested overlay dismissal behavior by scheduling parent `onClose` calls on outside interactions; risk is mainly around timing/propagation differences that could affect other click targets or close behavior in complex nesting.
> 
> **Overview**
> Fixes nested `Menu.SubMenuTrigger` behavior so a *single* outside click collapses the entire open menu/submenu chain instead of only closing the deepest submenu.
> 
> This adds a `shouldCloseOnInteractOutside` predicate to the nested submenu `Popover` (mirroring `MenuTrigger` semantics) that schedules the parent menu’s `onClose` via `setTimeout(0)` to trigger the existing close cascade, and introduces a regression test covering a deeply nested hierarchy. Includes a changeset bump for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a202271a8e4d09a0c9cd1ba9ac9935358634b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->