### PR TITLE
feat(tokens): add surface-4 radio tab backgrounds

### DIFF
--- a/.changeset/surface-4-radio-tabs.md
+++ b/.changeset/surface-4-radio-tabs.md
@@ -1,0 +1,7 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Add a new `#surface-4` neutral token and use it as the container background for radio-style tabs.
+
+This updates both `Tabs` and `RadioGroup` tabs mode to the new surface depth and registers the token in type and editor token metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,18 @@ ComponentName/
 | `pnpm audit-docs`               | Audit component API ↔ docs ↔ argTypes sync. Uses TS Compiler API for full type resolution. Options: `--component=Name` (single component), `--fix-stories` (auto-add/remove argTypes in `.stories.tsx`), `--fix-docs` (auto-update `### Style Properties` sections in `.docs.mdx`), `--json`, `--verbose`, `--all-props`. **Run after changing a component's API or adding a new component.** |
 
 
+## Environment & Local Development
+
+- **Required runtimes:** Node.js `>=22.14.0` and pnpm `^10` (`packageManager` is pinned to `pnpm@10.32.0` in `package.json`).
+- **Install step for Storybook/Vite:** after `pnpm install`, run `pnpm rebuild esbuild` because `pnpm-workspace.yaml` blocks `esbuild` postinstall by default.
+- **Storybook (dev):** `pnpm storybook` (port `6060`).
+- **Storybook (static fallback):** if Vite dev mode overloads constrained environments, run `pnpm build-storybook`, then serve `storybook-static` (for example `npx serve storybook-static -l 6060`) when visual verification is needed.
+- **Tests:** `pnpm test` (single run) or `pnpm test-watch`.
+- **Linting:** `pnpm lint` (check) and `pnpm fix` (auto-fix).
+- **Build:** `pnpm build` (tsdown, unbundled ESM output in `dist/`).
+- **Git hooks:** Husky installs via `prepare`; `pre-commit` runs `pnpm lint-staged`, and `pre-push` runs `pnpm test`. Skip hooks only when explicitly intended (`--no-verify` or `HUSKY=0`).
+- **External dependencies:** no databases, Docker services, or external APIs are required for normal local development.
+
 ## Stack
 
 - **Styling:** `@tenphi/tasty` — declarative token-aware CSS-in-JS

--- a/src/components/fields/RadioGroup/RadioGroup.tsx
+++ b/src/components/fields/RadioGroup/RadioGroup.tsx
@@ -66,7 +66,7 @@ const RadioGroupElement = tasty({
     radius: '1cr',
     fill: {
       '': '#clear',
-      'tabs | disabled': '#surface-3',
+      'tabs | disabled': '#surface-4',
     },
     width: 'max-content max-content initial',
     flexShrink: 0,

--- a/src/components/navigation/Tabs/styled.ts
+++ b/src/components/navigation/Tabs/styled.ts
@@ -33,7 +33,7 @@ export const TabsElement = tasty({
     },
     fill: {
       '': '#clear',
-      'type=radio': '#surface-3',
+      'type=radio': '#surface-4',
     },
     flexShrink: 0,
     flexGrow: 0,

--- a/src/stories/Usage.docs.mdx
+++ b/src/stories/Usage.docs.mdx
@@ -124,6 +124,7 @@ The neutral palette uses a `surface` / `surface-text` model. Each surface depth 
 | `#surface` | Primary background |
 | `#surface-2` | Slightly recessed background (cards, inputs) |
 | `#surface-3` | Deepest background (panels, code blocks) |
+| `#surface-4` | Subtle recessed background for radio-tab containers |
 | `#surface-text` | AAA text on `#surface` |
 | `#surface-text-soft` | AA text on `#surface` (secondary copy, body text) |
 | `#surface-text-soft-2` | AA-large text on `#surface` (placeholders, captions) |

--- a/src/tasty-augment.d.ts
+++ b/src/tasty-augment.d.ts
@@ -12,6 +12,7 @@ declare module '@tenphi/tasty' {
     surface: true;
     'surface-2': true;
     'surface-3': true;
+    'surface-4': true;
     'surface-text': true;
     'surface-text-soft': true;
     'surface-text-soft-2': true;

--- a/src/tokens/palette.ts
+++ b/src/tokens/palette.ts
@@ -64,6 +64,12 @@ defaultTheme.colors({
     saturation: 0.19,
     inherit: false,
   },
+  'surface-4': {
+    base: 'surface',
+    lightness: 94,
+    saturation: 0.23,
+    inherit: false,
+  },
 
   // ---- Text on surfaces ----
   // The darkest text token uses an *absolute* lightness anchored at the very

--- a/src/tokens/palette.ts
+++ b/src/tokens/palette.ts
@@ -66,7 +66,7 @@ defaultTheme.colors({
   },
   'surface-4': {
     base: 'surface',
-    lightness: 94,
+    lightness: '-6',
     saturation: 0.23,
     inherit: false,
   },

--- a/tasty.config.ts
+++ b/tasty.config.ts
@@ -23,6 +23,7 @@ export default {
     '#surface',
     '#surface-2',
     '#surface-3',
+    '#surface-4',
     '#surface-inverse',
     '#surface-text',
     '#surface-text-soft',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk visual-only change: introduces a new neutral surface token and swaps radio-style tab container backgrounds to use it, with minimal chance of regressions beyond theming/contrast differences.
> 
> **Overview**
> Introduces a new neutral color token `#surface-4` (added to the Glaze palette, tasty TS color typings, and VSCode extension token metadata).
> 
> Updates radio-style tab containers to use the new depth: `Tabs` (`type=radio`) and `RadioGroup` in `tabs` mode switch their container background from `#surface-3` to `#surface-4`, and Storybook usage docs are updated to document the new surface level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746e6a2918fe28d4f799b914864214da0f33223a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->