### PR TITLE
fix(Tabs): keep rename input mounted when triggered from tab menu

### DIFF
--- a/.changeset/fix-tabs-rename-focus.md
+++ b/.changeset/fix-tabs-rename-focus.md
@@ -1,0 +1,7 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`Tabs`: keep the inline rename input mounted when triggered from the tab menu. Previously the Menu popover's `<FocusScope restoreFocus>` would yank focus back to the trigger as soon as the menu started closing, fire `InlineInput`'s `submitOnBlur`, and unmount the input the user just opened — so clicking "Rename" appeared to do nothing.
+
+`InlineInput` now ignores blurs that happen within ~500ms of a programmatic `startEditing()` call (cleared on the first user keystroke). `TabButton` also retries focusing the input across the menu's exit transition as a belt-and-suspenders defense.

--- a/src/components/content/InlineInput/InlineInput.test.tsx
+++ b/src/components/content/InlineInput/InlineInput.test.tsx
@@ -532,6 +532,117 @@ describe('<InlineInput />', () => {
 
       expect(ref.current?.getValue()).toBe('hello');
     });
+
+    // Regression: clicking "Rename" inside a closing Menu popover used to
+    // unmount the input because the popover's `<FocusScope restoreFocus>`
+    // synchronously yanked focus back to its trigger, which in turn fired
+    // `submitOnBlur` and committed-out of editing. After a programmatic
+    // `startEditing()`, an immediate blur must NOT commit; instead, the
+    // input is re-focused. Once the user actually types, the guard clears.
+    describe('startEditing() blur-side grace period', () => {
+      it('does not commit when the input blurs immediately after a programmatic startEditing()', async () => {
+        const ref = createRef<CubeInlineInputRef>();
+        const handleSubmit = vi.fn();
+        const { getByRole, queryByRole } = renderWithRoot(
+          <>
+            <button data-qa="OtherButton">Other</button>
+            <InlineInput ref={ref} defaultValue="X" onSubmit={handleSubmit} />
+          </>,
+        );
+
+        act(() => {
+          ref.current?.startEditing();
+        });
+
+        const input = getByRole('textbox') as HTMLInputElement;
+        expect(document.activeElement).toBe(input);
+
+        // Simulate the closing-overlay focus theft: move focus elsewhere
+        // immediately after `startEditing()`. With the guard, `submitOnBlur`
+        // should NOT commit and the input should remain mounted.
+        const otherButton = document.querySelector(
+          '[data-qa="OtherButton"]',
+        ) as HTMLButtonElement;
+        act(() => {
+          otherButton.focus();
+        });
+
+        await act(async () => {
+          // Let the deferred re-focus rAF run.
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        });
+
+        expect(handleSubmit).not.toHaveBeenCalled();
+        expect(queryByRole('textbox')).toBeInTheDocument();
+      });
+
+      it('commits a blur that fires after the user has typed', () => {
+        const ref = createRef<CubeInlineInputRef>();
+        const handleSubmit = vi.fn();
+        const { getByRole } = renderWithRoot(
+          <>
+            <button data-qa="OtherButton">Other</button>
+            <InlineInput ref={ref} defaultValue="X" onSubmit={handleSubmit} />
+          </>,
+        );
+
+        act(() => {
+          ref.current?.startEditing();
+        });
+
+        const input = getByRole('textbox') as HTMLInputElement;
+        // User interacts → guard is cleared.
+        act(() => {
+          fireEvent.change(input, { target: { value: 'Y' } });
+        });
+
+        const otherButton = document.querySelector(
+          '[data-qa="OtherButton"]',
+        ) as HTMLButtonElement;
+        act(() => {
+          otherButton.focus();
+        });
+
+        expect(handleSubmit).toHaveBeenCalledWith('Y');
+      });
+
+      it('commits a blur once the grace window has passed', () => {
+        vi.useFakeTimers();
+        try {
+          const ref = createRef<CubeInlineInputRef>();
+          const handleSubmit = vi.fn();
+          const { getByRole } = renderWithRoot(
+            <>
+              <button data-qa="OtherButton">Other</button>
+              <InlineInput ref={ref} defaultValue="X" onSubmit={handleSubmit} />
+            </>,
+          );
+
+          act(() => {
+            ref.current?.startEditing();
+          });
+
+          // Advance past the 500ms grace window so a blur commits normally.
+          act(() => {
+            vi.advanceTimersByTime(600);
+          });
+
+          const input = getByRole('textbox') as HTMLInputElement;
+          expect(document.activeElement).toBe(input);
+
+          const otherButton = document.querySelector(
+            '[data-qa="OtherButton"]',
+          ) as HTMLButtonElement;
+          act(() => {
+            otherButton.focus();
+          });
+
+          expect(handleSubmit).toHaveBeenCalledWith('X');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+    });
   });
 
   describe('isStyled', () => {

--- a/src/components/content/InlineInput/InlineInput.tsx
+++ b/src/components/content/InlineInput/InlineInput.tsx
@@ -282,6 +282,12 @@ const InlineInputRoot = tasty({
 
 const STYLE_PROPS = [...BLOCK_STYLES, ...OUTER_STYLES, ...COLOR_STYLES];
 
+// Grace window after a programmatic `startEditing()` during which a blur
+// (typically a closing overlay's focus restoration) re-focuses the input
+// rather than committing. ~500ms covers the Menu/Popover EXIT_DURATION
+// (350ms in `Overlay.tsx`) with margin.
+const PROGRAMMATIC_EDIT_BLUR_GRACE_MS = 500;
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -363,6 +369,19 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
     // re-entry happens before they settle.
     const submitTokenRef = useRef(0);
 
+    // Timestamp of the most recent programmatic `startEditing()` call (via
+    // the imperative ref). Used to defeat a focus-theft race where a closing
+    // overlay's `<FocusScope restoreFocus>` yanks focus back to its trigger
+    // immediately after a consumer called `startEditing()` from inside the
+    // overlay's `onAction` (e.g. a Tabs menu "Rename" item). Without this
+    // guard the resulting blur would fire `submitOnBlur` and unmount the
+    // input the user just opened.
+    //
+    // Cleared on first user interaction inside the input (`handleInputChange`
+    // / `handleKeyDown`) and on leaving editing mode, so any later blur
+    // commits normally.
+    const programmaticEditStartRef = useRef<number | null>(null);
+
     // Synchronous mirror of `isEditing`. We need this because cancel/commit
     // call user callbacks (`onCancel`/`onSubmit`) that may synchronously
     // re-focus another element — that causes a synchronous blur on the
@@ -405,6 +424,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
 
       if (!next && !allowEmpty) {
         isEditingRef.current = false;
+        programmaticEditStartRef.current = null;
         setIsEditing(false);
         onCancel?.();
 
@@ -418,6 +438,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
         setOptimisticValue(next);
       }
       isEditingRef.current = false;
+      programmaticEditStartRef.current = null;
       setValue(next);
       setIsEditing(false);
 
@@ -444,6 +465,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
     const cancel = useEvent(() => {
       if (!isEditingRef.current) return;
       isEditingRef.current = false;
+      programmaticEditStartRef.current = null;
       setIsEditing(false);
       onCancel?.();
     });
@@ -469,6 +491,10 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
     }, [isEditing, draft, placeholder]);
 
     const handleKeyDown = useEvent((e: KeyboardEvent<HTMLInputElement>) => {
+      // User is interacting with the input — drop the post-`startEditing()`
+      // blur guard so a subsequent click-away commits normally.
+      programmaticEditStartRef.current = null;
+
       if (e.key === 'Enter') {
         e.preventDefault();
         commit(draft);
@@ -496,6 +522,7 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
     });
 
     const handleInputChange = useEvent((e: ChangeEvent<HTMLInputElement>) => {
+      programmaticEditStartRef.current = null;
       setDraft(e.target.value);
     });
 
@@ -509,6 +536,31 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
       isDisabled: !isEditing,
       onBlurWithin: () => {
         if (!submitOnBlur) return;
+
+        // Grace-period guard against focus theft right after a programmatic
+        // `startEditing()` — e.g. a `<FocusScope restoreFocus>` inside a
+        // closing Menu popover yanking focus back to its trigger after the
+        // consumer activated rename from `onAction`. Re-focus the input on
+        // the next frame so the focus-stealing element finishes its own
+        // handler first, then we steal focus back. The guard is cleared on
+        // the first real user interaction with the input (keydown / input
+        // change) so subsequent click-aways commit normally.
+        const startedAt = programmaticEditStartRef.current;
+        if (
+          startedAt != null &&
+          Date.now() - startedAt < PROGRAMMATIC_EDIT_BLUR_GRACE_MS &&
+          isEditingRef.current
+        ) {
+          requestAnimationFrame(() => {
+            if (isEditingRef.current) {
+              inputRef.current?.focus();
+              inputRef.current?.select();
+            }
+          });
+
+          return;
+        }
+
         commit(draft);
       },
     });
@@ -539,7 +591,16 @@ export const InlineInput = forwardRef<CubeInlineInputRef, CubeInlineInputProps>(
     useImperativeHandle(
       ref,
       () => ({
-        startEditing: () => enterEditing(),
+        startEditing: () => {
+          // Arm the grace-period blur guard for the imperative path only.
+          // Pointer-triggered entries (dblclick / click) don't suffer from
+          // the closing-overlay focus-theft race that motivates this guard.
+          const wasEditing = isEditingRef.current;
+          enterEditing();
+          if (!wasEditing && isEditingRef.current) {
+            programmaticEditStartRef.current = Date.now();
+          }
+        },
         stopEditing: (submit = true) => {
           if (!isEditingRef.current) return;
           if (submit) commit(draft);

--- a/src/components/navigation/Tabs/TabButton.tsx
+++ b/src/components/navigation/Tabs/TabButton.tsx
@@ -311,6 +311,53 @@ export function TabButton({ item, tabData, isLastTab }: TabButtonProps) {
     }
   });
 
+  // Secondary defense against the Menu/InlineInput focus-theft race when a
+  // consumer triggers rename from a menu item. `InlineInput` itself runs a
+  // blur-side grace period after a programmatic `startEditing()` call (see
+  // `PROGRAMMATIC_EDIT_BLUR_GRACE_MS`); this pass just re-focuses the input
+  // across the Menu popover's exit transition (~350ms) in case another code
+  // path (focus manager, host re-render) stole focus from it.
+  //
+  // The `seenEditingInput` guard ensures we don't reopen rename after the
+  // user has already finished editing (Enter / Escape / blur-to-elsewhere):
+  // once we've observed the editing input in the DOM and it later
+  // disappears, the user committed/cancelled and we stop retrying.
+  const renameInputSelector = 'input[aria-label="Edit tab title"]';
+  const scheduleRenameRefocus = useEvent(() => {
+    let seenEditingInput = false;
+    let cancelled = false;
+    const timers: number[] = [];
+
+    const findEditingInput = (): HTMLInputElement | null =>
+      (containerRef.current?.querySelector(renameInputSelector) ??
+        actionsRef.current?.parentElement?.querySelector(renameInputSelector) ??
+        null) as HTMLInputElement | null;
+
+    const tick = () => {
+      if (cancelled) return;
+
+      const editingInput = findEditingInput();
+      if (editingInput) {
+        seenEditingInput = true;
+        if (document.activeElement !== editingInput) {
+          inlineInputRef.current?.focus();
+        }
+
+        return;
+      }
+
+      if (seenEditingInput) {
+        cancelled = true;
+        for (const t of timers) clearTimeout(t);
+      }
+    };
+
+    requestAnimationFrame(tick);
+    timers.push(window.setTimeout(tick, 50));
+    timers.push(window.setTimeout(tick, 200));
+    timers.push(window.setTimeout(tick, 400));
+  });
+
   // Handle menu actions - predefined actions first, then callbacks
   const handleMenuAction = useEvent((action: Key) => {
     // Strip the ".$" prefix that React adds via Children.toArray/map
@@ -322,6 +369,8 @@ export function TabButton({ item, tabData, isLastTab }: TabButtonProps) {
     // Handle predefined actions first (only if requirements are met)
     if (normalizedAction === 'rename' && effectiveIsEditable) {
       inlineInputRef.current?.startEditing();
+      // Belt-and-suspenders: see `scheduleRenameRefocus` for the rationale.
+      scheduleRenameRefocus();
     }
     if (normalizedAction === 'delete' && isDeletable) {
       onDelete?.(itemKeyStr);

--- a/src/components/navigation/Tabs/TabButton.tsx
+++ b/src/components/navigation/Tabs/TabButton.tsx
@@ -328,9 +328,13 @@ export function TabButton({ item, tabData, isLastTab }: TabButtonProps) {
     let cancelled = false;
     const timers: number[] = [];
 
+    // Query the editing input via the tab button `ref` — that's always
+    // wired up regardless of context-menu mode. `containerRef` is shadowed
+    // by `contextMenu.targetRef` when context menu is enabled, and
+    // `actionsRef` may never attach (e.g. `contextMenu="context-only"` with
+    // no delete button and no custom actions).
     const findEditingInput = (): HTMLInputElement | null =>
-      (containerRef.current?.querySelector(renameInputSelector) ??
-        actionsRef.current?.parentElement?.querySelector(renameInputSelector) ??
+      (ref.current?.querySelector(renameInputSelector) ??
         null) as HTMLInputElement | null;
 
     const tick = () => {

--- a/src/components/navigation/Tabs/Tabs.test.tsx
+++ b/src/components/navigation/Tabs/Tabs.test.tsx
@@ -966,6 +966,54 @@ describe('<Tabs />', () => {
       expect(queryByRole('textbox')).toBeInTheDocument();
       expect(handleTitleChange).not.toHaveBeenCalled();
     });
+
+    // Regression: with `contextMenu="context-only"` and no delete handler
+    // / custom actions, the `TabContainer` ref is replaced by the context
+    // menu's target ref and the `Actions` element is never rendered — so
+    // both `containerRef` and `actionsRef` are null. The TabButton refocus
+    // pass must still be able to locate the editing input (via the tab
+    // button ref, which is always wired up).
+    it('also mounts the rename input in context-only mode with no actions', async () => {
+      const handleTitleChange = vi.fn();
+      const { findByRole, getByRole, queryByRole } = renderWithRoot(
+        <Tabs
+          isEditable
+          contextMenu="context-only"
+          defaultActiveKey="tab1"
+          menu={<Menu.Item key="rename">Rename</Menu.Item>}
+          onTitleChange={handleTitleChange}
+        >
+          <Tab key="tab1" title="Tab 1">
+            Content 1
+          </Tab>
+        </Tabs>,
+      );
+
+      const tab = getByRole('tab', { name: 'Tab 1' });
+
+      // Open the context menu via right-click and select Rename.
+      await act(async () => {
+        fireEvent.contextMenu(tab);
+      });
+      const renameItem = await findByRole('menuitem', { name: 'Rename' });
+      await act(async () => {
+        fireEvent.click(renameItem);
+      });
+
+      await waitFor(() => {
+        expect(queryByRole('textbox')).toBeInTheDocument();
+      });
+
+      // Let the TabButton refocus pass run (rAF). With the fix, this finds
+      // the editing input via the tab button ref even though both
+      // `containerRef` and `actionsRef` are null in this configuration.
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+
+      expect(queryByRole('textbox')).toBeInTheDocument();
+      expect(handleTitleChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('Context menu modes', () => {

--- a/src/components/navigation/Tabs/Tabs.test.tsx
+++ b/src/components/navigation/Tabs/Tabs.test.tsx
@@ -908,6 +908,64 @@ describe('<Tabs />', () => {
       // No regression in the editing flow: dblclick still enters edit mode.
       expect(inlineInput).toHaveAttribute('data-qa', 'InlineInput');
     });
+
+    // Regression: a "Rename" item inside the tab menu used to mount the
+    // inline-edit input only to have it stolen-focus + committed-out by the
+    // closing Menu popover's `<FocusScope restoreFocus>`. The user clicked
+    // Rename and nothing visibly happened. InlineInput's grace period plus
+    // TabButton's refocus pass keep the input mounted and focused across the
+    // overlay's exit.
+    it('keeps the rename input mounted and focused when triggered from the tab menu', async () => {
+      const user = userEvent.setup();
+      const handleTitleChange = vi.fn();
+      const { findByRole, getByRole, queryByRole } = renderWithRoot(
+        <Tabs
+          isEditable
+          defaultActiveKey="tab1"
+          menu={<Menu.Item key="rename">Rename</Menu.Item>}
+          onTitleChange={handleTitleChange}
+        >
+          <Tab key="tab1" title="Tab 1">
+            Content 1
+          </Tab>
+        </Tabs>,
+      );
+
+      const tab = getByRole('tab', { name: 'Tab 1' });
+      const menuTrigger = tab.parentElement?.querySelector(
+        'button[aria-haspopup="true"]',
+      ) as HTMLButtonElement;
+
+      expect(menuTrigger).toBeTruthy();
+      await user.click(menuTrigger);
+
+      const renameItem = await findByRole('menuitem', { name: 'Rename' });
+      await user.click(renameItem);
+
+      // The InlineInput should still be in edit mode after the menu closes
+      // and its FocusScope tries to restore focus to the trigger.
+      const input = await waitFor(() => {
+        const el = queryByRole('textbox');
+        expect(el).toBeInTheDocument();
+
+        return el as HTMLInputElement;
+      });
+
+      // Simulate the focus-theft race directly: explicitly steal focus to
+      // the menu trigger right after the input mounts. With the InlineInput
+      // grace period + TabButton refocus pass, the rename session should
+      // survive and not commit-on-blur.
+      act(() => {
+        menuTrigger.focus();
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+
+      expect(queryByRole('textbox')).toBeInTheDocument();
+      expect(handleTitleChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('Context menu modes', () => {

--- a/src/components/overlays/Dialog/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/Dialog.stories.tsx
@@ -471,7 +471,7 @@ PopoverWithMenuAndSelect.args = {};
 PopoverWithMenuAndSelect.play = async ({ canvasElement, viewMode }) => {
   if (viewMode === 'docs') return;
 
-  const { findByRole, getByRole } = within(canvasElement);
+  const { findByRole, getByRole, queryByRole } = within(canvasElement);
 
   // Open the popover
   await userEvent.click(await findByRole('button', { name: 'Open Popover' }));
@@ -490,6 +490,8 @@ PopoverWithMenuAndSelect.play = async ({ canvasElement, viewMode }) => {
 
   // Click somewhere else to close menu, then test Select
   await userEvent.click(dialog);
+  await waitFor(() => expect(queryByRole('menu')).not.toBeInTheDocument());
+  await timeout(500);
 
   // Test Select trigger
   const selectButton = getByRole('button', { name: 'Choose option' });
@@ -498,4 +500,8 @@ PopoverWithMenuAndSelect.play = async ({ canvasElement, viewMode }) => {
   // Check if select listbox opens
   const listbox = await findByRole('listbox');
   await expect(listbox).toBeInTheDocument();
+
+  // Leave the select open, but wait for positioning and transition styles to settle
+  // before Chromatic takes the snapshot.
+  await timeout(500);
 };

--- a/src/tokens/palette.ts
+++ b/src/tokens/palette.ts
@@ -67,7 +67,7 @@ defaultTheme.colors({
   'surface-4': {
     base: 'surface',
     lightness: '-6',
-    saturation: 0.23,
+    saturation: 0.2,
     inherit: false,
   },
 


### PR DESCRIPTION
Previously, clicking "Rename" in a tab's menu mounted the inline-edit input only to have it stolen-focus + committed-out by the closing Menu popover's `<FocusScope restoreFocus>` ~350ms later. The user saw the menu close and nothing else happened.

InlineInput now ignores blurs within ~500ms of a programmatic `startEditing()` call (cleared on the first user keystroke). TabButton also retries focusing the input across the menu's exit transition as a belt-and-suspenders defense.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches focus/blur-driven commit behavior in `InlineInput`, so timing-based guardrails could affect other consumers relying on `submitOnBlur` semantics; changes are well-covered by new regression tests.
> 
> **Overview**
> Fixes a Tabs rename regression where selecting **Rename** from the tab menu could immediately blur, trigger `submitOnBlur`, and unmount the editor.
> 
> `InlineInput` now applies a ~500ms grace period after an imperative `startEditing()` where an immediate blur re-focuses/selects the input instead of committing, and `TabButton` adds a short refocus retry loop during the menu exit transition to keep the rename input focused (including `contextMenu="context-only"` cases).
> 
> Adds targeted regression tests for the focus-theft scenario, tweaks a Dialog story play step to wait for menu close/transition stability, and slightly adjusts the `surface-4` palette saturation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c17349abadadf09ac4c52b8e98a17cd4c7cc203e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->