### PR TITLE
fix(item-themes): use surface-2 for outline button fills

### DIFF
--- a/.changeset/outline-button-surface-2.md
+++ b/.changeset/outline-button-surface-2.md
@@ -1,0 +1,7 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Use `#surface-2` instead of `#surface` as the base fill for outline item actions and buttons across default, danger, success, warning, and note themes.
+
+This gives outline controls a slightly elevated background on surface-level containers.

--- a/src/components/fields/TextInput/TextInputBase.tsx
+++ b/src/components/fields/TextInput/TextInputBase.tsx
@@ -63,7 +63,7 @@ export const INPUT_WRAPPER_STYLES: Styles = {
   gridRows: '1sf',
   placeItems: 'stretch',
   fill: {
-    '': '#surface',
+    '': '#surface-2',
     disabled: '#disabled-surface',
   },
   border: {

--- a/src/components/fields/TextInput/TextInputBase.tsx
+++ b/src/components/fields/TextInput/TextInputBase.tsx
@@ -63,7 +63,7 @@ export const INPUT_WRAPPER_STYLES: Styles = {
   gridRows: '1sf',
   placeItems: 'stretch',
   fill: {
-    '': '#surface-2',
+    '': '#surface',
     disabled: '#disabled-surface',
   },
   border: {

--- a/src/data/item-themes.ts
+++ b/src/data/item-themes.ts
@@ -132,11 +132,11 @@ export const DEFAULT_OUTLINE_STYLES: Styles = {
     ...(VALIDATION_STYLES.border as Record<string, string>),
   },
   fill: {
-    '': '#surface #dark.0',
-    hovered: '#surface #dark.03',
-    selected: '#surface #dark.09',
-    'selected & hovered': '#surface #dark.12',
-    pressed: '#surface #dark.09',
+    '': '#surface-2 #dark.0',
+    hovered: '#surface-2 #dark.03',
+    selected: '#surface-2 #dark.09',
+    'selected & hovered': '#surface-2 #dark.12',
+    pressed: '#surface-2 #dark.09',
     disabled: '#disabled-surface',
   },
   color: {
@@ -289,9 +289,9 @@ export const DANGER_OUTLINE_STYLES: Styles = {
     disabled: '#border',
   },
   fill: {
-    '': '#surface #danger.0',
-    hovered: '#surface #danger.1',
-    'pressed | (selected & !hovered)': '#surface #danger.05',
+    '': '#surface-2 #danger.0',
+    hovered: '#surface-2 #danger.1',
+    'pressed | (selected & !hovered)': '#surface-2 #danger.05',
     disabled: '#disabled-surface',
   },
   color: {
@@ -428,9 +428,9 @@ export const SUCCESS_OUTLINE_STYLES: Styles = {
     disabled: '#border',
   },
   fill: {
-    '': '#surface #success.0',
-    hovered: '#surface #success.1',
-    'pressed | (selected & !hovered)': '#surface #success.05',
+    '': '#surface-2 #success.0',
+    hovered: '#surface-2 #success.1',
+    'pressed | (selected & !hovered)': '#surface-2 #success.05',
     disabled: '#disabled-surface',
   },
   color: {
@@ -566,9 +566,9 @@ export const WARNING_OUTLINE_STYLES: Styles = {
     disabled: '#border',
   },
   fill: {
-    '': '#surface #warning.0',
-    hovered: '#surface #warning.1',
-    'pressed | (selected & !hovered)': '#surface #warning.05',
+    '': '#surface-2 #warning.0',
+    hovered: '#surface-2 #warning.1',
+    'pressed | (selected & !hovered)': '#surface-2 #warning.05',
     disabled: '#disabled-surface',
   },
   color: {
@@ -704,9 +704,9 @@ export const NOTE_OUTLINE_STYLES: Styles = {
     disabled: '#border',
   },
   fill: {
-    '': '#surface #note.0',
-    hovered: '#surface #note.1',
-    'pressed | (selected & !hovered)': '#surface #note.05',
+    '': '#surface-2 #note.0',
+    hovered: '#surface-2 #note.1',
+    'pressed | (selected & !hovered)': '#surface-2 #note.05',
     disabled: '#disabled-surface',
   },
   color: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk visual-only change limited to outline theme fill tokens; main risk is minor UI color/contrast shifts across themes.
> 
> **Overview**
> **Outline variants now render on `#surface-2` instead of `#surface`.** This updates the base/hover/selected/pressed fill tokens for default, danger, success, warning, and note outline styles in `src/data/item-themes.ts`, giving outline buttons/item actions a slightly more elevated background.
> 
> Adds a patch changeset documenting the token shift for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de557fd96691281f0cb6b36d0d7a1626ac5be79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->