### PR TITLE
fix(fields): inherit clear-button theme on FilterPicker, Picker, and …

### DIFF
--- a/.changeset/clear-button-theme-inherit.md
+++ b/.changeset/clear-button-theme-inherit.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix clear button styling on `FilterPicker`, `Picker`, and `Select` so it inherits the trigger `type` and `theme` (including `special` and validation error state) instead of defaulting to neutral action colors.

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -540,6 +540,104 @@ export const Clearable: Story = {
   ),
 };
 
+export const ClearableThemes: Story = {
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        story:
+          'Verifies that the clear button inherits the trigger\u2019s `type` and `theme` via `ItemActionProvider`, so its text color always matches the trigger label across every trigger variant — including `type="primary"`, `theme="special"`, and `validationState="invalid"`.',
+      },
+    },
+  },
+  render: () => {
+    const triggerVariants = [
+      {
+        type: 'outline' as const,
+        theme: 'default' as const,
+        label: 'outline / default',
+      },
+      {
+        type: 'outline-2' as const,
+        theme: 'default' as const,
+        label: 'outline-2 / default',
+      },
+      {
+        type: 'clear' as const,
+        theme: 'default' as const,
+        label: 'clear / default',
+      },
+      {
+        type: 'primary' as const,
+        theme: 'default' as const,
+        label: 'primary / default',
+      },
+      {
+        type: 'outline' as const,
+        theme: 'special' as const,
+        label: 'outline / special',
+      },
+      {
+        type: 'outline-2' as const,
+        theme: 'special' as const,
+        label: 'outline-2 / special',
+      },
+      {
+        type: 'clear' as const,
+        theme: 'special' as const,
+        label: 'clear / special',
+      },
+      {
+        type: 'primary' as const,
+        theme: 'special' as const,
+        label: 'primary / special',
+      },
+    ];
+
+    return (
+      <Flow gap="2x">
+        {triggerVariants.map(({ type, theme, label }) => (
+          <FilterPicker<(typeof fruits)[number]>
+            key={`${type}-${theme}`}
+            isClearable
+            items={fruits}
+            label={label}
+            type={type}
+            theme={theme}
+            placeholder="Choose items..."
+            searchPlaceholder="Search fruits..."
+            width="max 30x"
+            defaultSelectedKey="apple"
+          >
+            {(fruit) => (
+              <FilterPicker.Item key={fruit.key} textValue={fruit.label}>
+                {fruit.label}
+              </FilterPicker.Item>
+            )}
+          </FilterPicker>
+        ))}
+        <FilterPicker<(typeof fruits)[number]>
+          isClearable
+          items={fruits}
+          label="outline / default + invalid"
+          placeholder="Choose items..."
+          searchPlaceholder="Search fruits..."
+          width="max 30x"
+          defaultSelectedKey="apple"
+          validationState="invalid"
+          message="This selection is invalid"
+        >
+          {(fruit) => (
+            <FilterPicker.Item key={fruit.key} textValue={fruit.label}>
+              {fruit.label}
+            </FilterPicker.Item>
+          )}
+        </FilterPicker>
+      </Flow>
+    );
+  },
+};
+
 export const MultipleSelection: Story = {
   args: {
     label: 'Select Multiple Options',

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -33,7 +33,12 @@ import { generateRandomId } from '../../../utils/random';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { processSelectionArray } from '../../../utils/selection';
 import { extractStyles } from '../../../utils/styles';
-import { CubeItemButtonProps, ItemAction, ItemButton } from '../../actions';
+import {
+  CubeItemButtonProps,
+  ItemAction,
+  ItemActionProvider,
+  ItemButton,
+} from '../../actions';
 import { CubeItemProps } from '../../content/Item';
 import { Text } from '../../content/Text';
 import { useFieldProps, useFormProps, wrapWithField } from '../../form';
@@ -637,14 +642,18 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
         ) : rightIcon !== undefined ? (
           rightIcon
         ) : showClearButton ? (
-          <ItemAction
-            icon={<CloseIcon />}
-            size={size}
-            theme={validationState === 'invalid' ? 'danger' : undefined}
-            qa="FilterPickerClearButton"
-            mods={{ pressed: false }}
-            onPress={clearValue}
-          />
+          <ItemActionProvider
+            type={type}
+            theme={validationState === 'invalid' ? 'danger' : theme}
+          >
+            <ItemAction
+              icon={<CloseIcon />}
+              size={size}
+              qa="FilterPickerClearButton"
+              mods={{ pressed: false }}
+              onPress={clearValue}
+            />
+          </ItemActionProvider>
         ) : (
           <DirectionIcon to={isPopoverOpen ? 'top' : 'bottom'} />
         )

--- a/src/components/fields/Picker/Picker.stories.tsx
+++ b/src/components/fields/Picker/Picker.stories.tsx
@@ -80,6 +80,94 @@ export const IsClearable: Story = {
   ),
 };
 
+export const ClearableThemes: Story = {
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        story:
+          'Verifies that the clear button inherits the trigger\u2019s `type` and `theme` via `ItemActionProvider`, so its text color always matches the trigger label across every trigger variant \u2014 including `type="primary"`, `theme="special"`, and `validationState="invalid"`.',
+      },
+    },
+  },
+  render: () => {
+    const triggerVariants = [
+      {
+        type: 'outline' as const,
+        theme: 'default' as const,
+        label: 'outline / default',
+      },
+      {
+        type: 'outline-2' as const,
+        theme: 'default' as const,
+        label: 'outline-2 / default',
+      },
+      {
+        type: 'clear' as const,
+        theme: 'default' as const,
+        label: 'clear / default',
+      },
+      {
+        type: 'primary' as const,
+        theme: 'default' as const,
+        label: 'primary / default',
+      },
+      {
+        type: 'outline' as const,
+        theme: 'special' as const,
+        label: 'outline / special',
+      },
+      {
+        type: 'outline-2' as const,
+        theme: 'special' as const,
+        label: 'outline-2 / special',
+      },
+      {
+        type: 'clear' as const,
+        theme: 'special' as const,
+        label: 'clear / special',
+      },
+      {
+        type: 'primary' as const,
+        theme: 'special' as const,
+        label: 'primary / special',
+      },
+    ];
+
+    return (
+      <Flex flow="column" gap="2x">
+        {triggerVariants.map(({ type, theme, label }) => (
+          <Picker
+            key={`${type}-${theme}`}
+            isClearable
+            placeholder="Select a fruit"
+            label={label}
+            type={type}
+            theme={theme}
+            defaultSelectedKey="apple"
+          >
+            {fruits.map((fruit) => (
+              <Picker.Item key={fruit.key}>{fruit.label}</Picker.Item>
+            ))}
+          </Picker>
+        ))}
+        <Picker
+          isClearable
+          placeholder="Select a fruit"
+          label="outline / default + invalid"
+          defaultSelectedKey="apple"
+          validationState="invalid"
+          message="This selection is invalid"
+        >
+          {fruits.map((fruit) => (
+            <Picker.Item key={fruit.key}>{fruit.label}</Picker.Item>
+          ))}
+        </Picker>
+      </Flex>
+    );
+  },
+};
+
 export const WithSelectAll: Story = {
   args: {
     placeholder: 'Select fruits',

--- a/src/components/fields/Picker/Picker.tsx
+++ b/src/components/fields/Picker/Picker.tsx
@@ -33,7 +33,12 @@ import { generateRandomId } from '../../../utils/random';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { processSelectionArray } from '../../../utils/selection';
 import { extractStyles } from '../../../utils/styles';
-import { CubeItemButtonProps, ItemAction, ItemButton } from '../../actions';
+import {
+  CubeItemButtonProps,
+  ItemAction,
+  ItemActionProvider,
+  ItemButton,
+} from '../../actions';
 import { CubeItemProps } from '../../content/Item';
 import { Text } from '../../content/Text';
 import { useFieldProps, useFormProps, wrapWithField } from '../../form';
@@ -570,14 +575,18 @@ export const Picker = forwardRef(function Picker<T extends object>(
         ) : rightIcon !== undefined ? (
           rightIcon
         ) : showClearButton ? (
-          <ItemAction
-            icon={<CloseIcon />}
-            size={size}
-            theme={validationState === 'invalid' ? 'danger' : undefined}
-            qa="PickerClearButton"
-            mods={{ pressed: false }}
-            onPress={clearValue}
-          />
+          <ItemActionProvider
+            type={type}
+            theme={validationState === 'invalid' ? 'danger' : theme}
+          >
+            <ItemAction
+              icon={<CloseIcon />}
+              size={size}
+              qa="PickerClearButton"
+              mods={{ pressed: false }}
+              onPress={clearValue}
+            />
+          </ItemActionProvider>
         ) : (
           <DirectionIcon to={isPopoverOpen ? 'top' : 'bottom'} />
         )

--- a/src/components/fields/Select/Select.stories.tsx
+++ b/src/components/fields/Select/Select.stories.tsx
@@ -477,6 +477,99 @@ Clearable.args = {
   placeholder: 'Choose a color...',
 };
 
+export const ClearableThemes: StoryObj<CubeSelectProps<any>>['render'] = () => {
+  const triggerVariants = [
+    {
+      type: 'outline' as const,
+      theme: 'default' as const,
+      label: 'outline / default',
+    },
+    {
+      type: 'outline-2' as const,
+      theme: 'default' as const,
+      label: 'outline-2 / default',
+    },
+    {
+      type: 'clear' as const,
+      theme: 'default' as const,
+      label: 'clear / default',
+    },
+    {
+      type: 'primary' as const,
+      theme: 'default' as const,
+      label: 'primary / default',
+    },
+    {
+      type: 'outline' as const,
+      theme: 'special' as const,
+      label: 'outline / special',
+    },
+    {
+      type: 'outline-2' as const,
+      theme: 'special' as const,
+      label: 'outline-2 / special',
+    },
+    {
+      type: 'clear' as const,
+      theme: 'special' as const,
+      label: 'clear / special',
+    },
+    {
+      type: 'primary' as const,
+      theme: 'special' as const,
+      label: 'primary / special',
+    },
+  ];
+
+  return (
+    <Space flow="column" gap="2x">
+      {triggerVariants.map(({ type, theme, label }) => (
+        <Space
+          key={`${type}-${theme}`}
+          radius="1x"
+          padding={theme === 'special' ? '2x' : undefined}
+          fill={theme === 'special' ? '#dark' : undefined}
+        >
+          <Select
+            isClearable
+            label={label}
+            type={type}
+            theme={theme}
+            defaultSelectedKey="blue"
+            placeholder="Choose a color..."
+            width="200px"
+          >
+            {options.map((option) => (
+              <Select.Item key={option}>{option}</Select.Item>
+            ))}
+          </Select>
+        </Space>
+      ))}
+      <Select
+        isClearable
+        label="outline / default + invalid"
+        defaultSelectedKey="blue"
+        validationState="invalid"
+        placeholder="Choose a color..."
+        width="200px"
+      >
+        {options.map((option) => (
+          <Select.Item key={option}>{option}</Select.Item>
+        ))}
+      </Select>
+    </Space>
+  );
+};
+ClearableThemes.parameters = {
+  layout: 'padded',
+  docs: {
+    description: {
+      story:
+        'Verifies that the clear button inherits the trigger\u2019s `type` and `theme` via `ItemActionProvider`, so its text color always matches the trigger label across every trigger variant \u2014 including `type="primary"`, `theme="special"`, and `validationState="invalid"`.',
+    },
+  },
+};
+
 export const WithIcon = Template.bind({});
 WithIcon.args = { icon: <IconCoin /> };
 

--- a/src/components/fields/Select/Select.tsx
+++ b/src/components/fields/Select/Select.tsx
@@ -55,7 +55,7 @@ import {
 import { useFocus } from '../../../utils/react/interactions';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { extractStyles } from '../../../utils/styles';
-import { ItemAction } from '../../actions';
+import { ItemAction, ItemActionProvider } from '../../actions';
 import {
   StyledDivider as ListDivider,
   StyledSectionHeading as ListSectionHeading,
@@ -466,13 +466,17 @@ function Select<T extends object>(
           rightIcon !== undefined ? (
             rightIcon
           ) : showClearButton ? (
-            <ItemAction
-              icon={<CloseIcon />}
-              theme={validationState === 'invalid' ? 'danger' : undefined}
-              qa="SelectClearButton"
-              mods={{ pressed: false }}
-              onPress={clearValue}
-            />
+            <ItemActionProvider
+              type={type}
+              theme={validationState === 'invalid' ? 'danger' : theme}
+            >
+              <ItemAction
+                icon={<CloseIcon />}
+                qa="SelectClearButton"
+                mods={{ pressed: false }}
+                onPress={clearValue}
+              />
+            </ItemActionProvider>
           ) : isLoading ? (
             <LoadingIcon />
           ) : (


### PR DESCRIPTION
…Select

Wrap clear ItemActions in ItemActionProvider so icons follow the trigger type and theme. Add ClearableThemes stories for regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts styling context for clear buttons and adds Storybook coverage; behavior is unchanged aside from visual theming.
> 
> **Overview**
> Fixes `FilterPicker`, `Picker`, and `Select` clear-button styling by wrapping the clear `ItemAction` in `ItemActionProvider`, ensuring it inherits the trigger’s `type`/`theme` and correctly reflects `special` theme and invalid (`danger`) state instead of default neutral action colors.
> 
> Adds `ClearableThemes` Storybook stories for all three components to regression-test the clear button across trigger variants, and includes a patch changeset documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2aff7371f82bab873ad8dbfb14738dfcc30a1c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->