### PR TITLE
fix(Tabs): layout switch

### DIFF
--- a/.changeset/tabs-no-panels-flex-sizing.md
+++ b/.changeset/tabs-no-panels-flex-sizing.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`Tabs`: when there are no panels (no `Tab` content, no `Tabs.Panel` children, no `renderPanel`), the outer wrapper no longer grows or shrinks within its parent flex container — it now locks to the tab bar's intrinsic size, matching the pre-wrapper behavior of a panel-less `<Tabs>`. With panels, the wrapper still participates in parent flex layouts as before.

--- a/src/components/navigation/Tabs/styled.ts
+++ b/src/components/navigation/Tabs/styled.ts
@@ -20,9 +20,11 @@ export const TabsElement = tasty({
     // Participate in parent flex layouts; allow shrinking on both axes so we
     // never force the parent into overflow. The Bar keeps `flex-shrink: 0`,
     // which makes the practical minimum of the wrapper along the main axis
-    // equal to the tablist's intrinsic size.
-    flexShrink: 1,
-    flexGrow: 1,
+    // equal to the tablist's intrinsic size. When there are no panels the
+    // wrapper has only the Bar inside it, so we lock its sizing to the Bar's
+    // intrinsic size — matching the pre-wrapper behavior of a panel-less Tabs.
+    flexShrink: { '': 0, 'has-panels': 1 },
+    flexGrow: { '': 0, 'has-panels': 1 },
     width: 'min 0',
     height: 'min 0',
     overflow: 'visible',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small styling change in Tabs layout rules with no auth, data, or API impact.
> 
> **Overview**
> **`Tabs`** outer wrapper flex behavior now depends on whether panel content exists (`has-panels`).
> 
> When there are **no** panels (no `Tab` body, no `Tabs.Panel`, no `renderPanel`), the wrapper uses **`flex-grow: 0`** and **`flex-shrink: 0`** so it stays at the tab bar’s intrinsic size inside a parent flex layout—restoring behavior from before the bar+panels wrapper. When panels are present, **`flex-grow`** and **`flex-shrink`** stay **1** so the component can still fill and shrink with its parent as before.
> 
> A patch **changeset** documents the `@cube-dev/ui-kit` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f315eafc7d9b8c18ec27df2bc66a77f0a8c892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->