### PR TITLE
fix(Tabs): optional title prop

### DIFF
--- a/.changeset/tabs-optional-title.md
+++ b/.changeset/tabs-optional-title.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+**Tabs**: `Tab`'s `title` prop is now optional, enabling icon-only tabs via the `icon` / `rightIcon` slots. When `title` is omitted, supply an `aria-label` (and typically a `tooltip`) so the tab retains an accessible name. Added a `VerticalIconOnly` story demonstrating this with `placement="left"` and `tabListPadding="1x"`.

--- a/src/components/navigation/Tabs/TabButton.tsx
+++ b/src/components/navigation/Tabs/TabButton.tsx
@@ -249,8 +249,10 @@ export function TabButton({ item, tabData, isLastTab }: TabButtonProps) {
   const isDeletable = !!onDelete;
   const isEditing = editingKey === item.key;
 
-  // Compute effective values - Tab-level overrides Tabs-level
-  const effectiveIsEditable = tabData.isEditable ?? parentIsEditable ?? false;
+  // Compute effective values - Tab-level overrides Tabs-level.
+  // Icon-only tabs (no `title`) have nothing to rename, so editing is disabled.
+  const effectiveIsEditable =
+    (tabData.isEditable ?? parentIsEditable ?? false) && tabData.title != null;
   const effectiveMenu =
     tabData.menu === null ? null : tabData.menu ?? parentMenu;
   const effectiveMenuTriggerProps: Partial<CubeItemActionProps> = {

--- a/src/components/navigation/Tabs/Tabs.docs.mdx
+++ b/src/components/navigation/Tabs/Tabs.docs.mdx
@@ -193,6 +193,29 @@ Each `Tab` renders an [Item](/docs/content-item--docs) internally, so it inherit
 </Tabs>
 ```
 
+#### Icon-only tabs
+
+Omit `title` to render an icon-only tab. Always provide an `aria-label` (and typically a `tooltip`) so the tab remains accessible. Pairs well with `placement="left" | "right"` and `tabListPadding` for a compact vertical strip.
+
+<Story of={TabsStories.VerticalIconOnly} />
+
+```jsx
+<Tabs placement="left" tabListPadding="1x" defaultActiveKey="overview">
+  <Tab
+    key="overview"
+    icon={<DatabaseIcon />}
+    aria-label="Overview"
+    tooltip={{ title: 'Overview', placement: 'right' }}
+  />
+  <Tab
+    key="settings"
+    icon={<SettingsIcon />}
+    aria-label="Settings"
+    tooltip={{ title: 'Settings', placement: 'right' }}
+  />
+</Tabs>
+```
+
 #### Tab with constrained width
 
 The `width` style prop (inherited from Item) is useful for file-style tabs where titles may be long.
@@ -258,7 +281,7 @@ Inherits all props from `ItemButton` except `shape` (always sharp).
 
 In addition, Tab accepts these tab-specific props:
 
-- **`title`** `ReactNode` — Content displayed in the tab button (required)
+- **`title`** `ReactNode` — Content displayed in the tab button. Optional for icon-only tabs (`icon` / `rightIcon`); when omitted, supply an `aria-label` (and typically a `tooltip`) so the tab has an accessible name.
 - **`isDisabled`** `boolean` — Disables the tab
 - **`size`** `TabSize` — Override tab size for this tab
 - **`type`** `TabType` — Override tab type for this tab

--- a/src/components/navigation/Tabs/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/Tabs.stories.tsx
@@ -1654,6 +1654,49 @@ export const VerticalFile: Story = {
 };
 
 /**
+ * Vertical icon-only tabs. `title` is omitted; each tab uses `icon` plus an
+ * `aria-label` and `tooltip` for accessibility. `tabListPadding="1x"` gives
+ * the strip a compact inset.
+ */
+export const VerticalIconOnly: Story = {
+  args: { placement: 'left', tabListPadding: '1x' },
+  render: (args) => (
+    <Layout height="40x">
+      <Tabs {...args} defaultActiveKey="overview">
+        <Tab
+          key="overview"
+          qa="Tab-overview"
+          icon={<DatabaseIcon />}
+          aria-label="Overview"
+          tooltip={{ title: 'Overview', placement: 'right' }}
+        />
+        <Tab
+          key="analytics"
+          qa="Tab-analytics"
+          icon={<FilterIcon />}
+          aria-label="Analytics"
+          tooltip={{ title: 'Analytics', placement: 'right' }}
+        />
+        <Tab
+          key="users"
+          qa="Tab-users"
+          icon={<UserIcon />}
+          aria-label="Users"
+          tooltip={{ title: 'Users', placement: 'right' }}
+        />
+        <Tab
+          key="settings"
+          qa="Tab-settings"
+          icon={<SettingsIcon />}
+          aria-label="Settings"
+          tooltip={{ title: 'Settings', placement: 'right' }}
+        />
+      </Tabs>
+    </Layout>
+  ),
+};
+
+/**
  * `radio` type in a vertical layout — the pill container wraps its tabs in a
  * column and each tab fills the width of the strip.
  */

--- a/src/components/navigation/Tabs/types.ts
+++ b/src/components/navigation/Tabs/types.ts
@@ -286,8 +286,12 @@ export interface CubeTabProps extends TabStyleProps, PanelBehaviorProps {
    * Auto-injected from the React `key` prop (converted to string).
    */
   id?: string;
-  /** Content displayed in the tab button. */
-  title: ReactNode;
+  /**
+   * Content displayed in the tab button. Optional for icon-only tabs
+   * (`icon` / `rightIcon`). When omitted, provide an `aria-label` (and
+   * typically a `tooltip`) so the tab has an accessible name.
+   */
+  title?: ReactNode;
   /** Panel content rendered when tab is active. */
   children?: ReactNode;
   /** Disables the tab (cannot be selected). */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small public API relaxation on a UI component with clear accessibility guidance; editing behavior is tightened for titleless tabs only.
> 
> **Overview**
> **`Tab`'s `title` is now optional**, so tabs can be icon-only using `icon` / `rightIcon` without a text label. Docs and a new **`VerticalIconOnly`** story show the expected pattern: **`aria-label`** plus **`tooltip`**, often with **`placement="left"`** and **`tabListPadding`**.
> 
> **`TabButton`** turns off inline rename when there is no title (`effectiveIsEditable` requires `title != null`), since icon-only tabs have nothing to edit. Types and docs describe the optional prop and accessibility expectations. Published as a **minor** changeset on `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e020c371a915799fb85a5f2ccdcec6c3630bab94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->