### PR TITLE
Fix popover sync refactoring

### DIFF
--- a/.changeset/migrate-usedomref-to-useobjectref.md
+++ b/.changeset/migrate-usedomref-to-useobjectref.md
@@ -1,0 +1,7 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+**Breaking:** Refs forwarded to `Modal`, `Tray`, `Dialog`, `Form`, `MenuTrigger`, `Menu`, `CommandMenu`, `RadioGroup`, `CheckboxGroup`, and `Label` now resolve to the underlying DOM element directly. The previous `@react-spectrum/utils` `{ UNSAFE_getDOMNode() }` wrapper (`DOMRefValue`) has been removed. Migrate by reading `ref.current` instead of calling `ref.current?.UNSAFE_getDOMNode()` on these components.
+
+Internally, these components now use `useObjectRef` from `@react-aria/utils` in place of `useDOMRef` from `@react-spectrum/utils`. Refs into focusable wrappers like `Button` (which still use `useFocusableRef`) are unaffected and continue to expose `UNSAFE_getDOMNode()` plus `focus()`.

--- a/.changeset/popover-auto-dismiss.md
+++ b/.changeset/popover-auto-dismiss.md
@@ -1,0 +1,66 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+**New:** Pressing a `Button` or `ItemButton` inside an open popover now
+**dismisses that popover by default**. This covers every overlay that uses
+`usePopoverSync` — `FilterPicker`, `Picker`, `ComboBox`, `Select`,
+`MenuTrigger`, `SubMenuTrigger`, `DialogTrigger type="popover"`,
+`use-anchored-menu`, and `use-context-menu`. Modal/tray/fullscreen Dialogs
+are **not** affected — a Button inside a modal Dialog still does not
+auto-close it.
+
+The dismiss event is dispatched through the EventBus and deferred via
+`setTimeout(0)`, so synchronous `onPress` handlers (and any React state
+updates they trigger) flush BEFORE the popover closes. This makes the
+common "open a hoisted modal from a popover footer" flow work without
+flicker: the modal mounts first, then the popover closes.
+
+### Opt-outs
+
+- **Automatic** — Buttons that act as popover triggers (`MenuTrigger`
+  children, `DialogTrigger type="popover"` children, picker trigger
+  ItemButtons) already carry `data-popover-trigger` and skip the dismiss.
+  Modal-type `DialogTrigger` children stay unmarked so they correctly
+  dismiss the parent popover and let the modal take over.
+- **Manual** — Add `data-popover-keep` to a Button (toggle case) or any
+  ancestor element (subtree case):
+
+  ```jsx
+  <Button data-popover-keep onPress={() => setMode((m) => !m)}>
+    Toggle
+  </Button>
+
+  <div data-popover-keep>{/* every Button inside opts out */}</div>
+  ```
+
+- **Custom non-Cube triggers** — call the newly exported
+  `useDismissParentPopover()` to wire the same behaviour into your own
+  interactive controls.
+
+### Migration
+
+Existing Buttons / ItemButtons inside popovers that were expected to **keep
+the popover open** on press (toggles, inline editors, mode switches, etc.)
+need `data-popover-keep`. Popover triggers wrapped by `MenuTrigger`,
+`DialogTrigger type="popover"`, `FilterPicker`, `Picker`, `ComboBox`, or
+`Select` need no change — they're auto-skipped.
+
+### Internals
+
+- `usePopoverSync` gained a `dismissOnInnerButtonPress` option (default
+  `true`). `DialogTrigger` passes `false` for modal/tray/fullscreen types
+  so buttons inside those dialogs don't subscribe to the new dismiss
+  event. The `popover:dismiss-ancestor` EventBus event carries the
+  originating DOM element so each popover host can do a `container.contains()`
+  check before closing.
+- `DialogTrigger` now applies `data-popover-trigger` to its child press
+  responder **only when `type === 'popover'`**. This is the critical
+  correctness piece for the original bug — when a `DialogTrigger type="modal"`
+  lives inside a `FilterPicker` footer, pressing its trigger now correctly
+  dismisses the FilterPicker, and the modal takes over.
+- `EventBusProvider` is now a no-op when nested inside another
+  `EventBusProvider`. The internal `Provider` from `provider.tsx` wraps
+  overlay content with its own `EventBusProvider`, which used to silently
+  shadow the global `<Root>` bus and prevent cross-overlay events from
+  reaching the host.

--- a/.changeset/popover-auto-dismiss.md
+++ b/.changeset/popover-auto-dismiss.md
@@ -64,3 +64,11 @@ need `data-popover-keep`. Popover triggers wrapped by `MenuTrigger`,
   overlay content with its own `EventBusProvider`, which used to silently
   shadow the global `<Root>` bus and prevent cross-overlay events from
   reaching the host.
+- `usePopoverSync`'s nested-popover guard now walks the **logical**
+  popover chain via a module-level registry of open overlays, rather than
+  relying solely on a direct `container.contains(triggerEl)` DOM check.
+  Popover content is portaled to a shared overlay root, so a grandchild
+  popover's trigger lives in a sibling portal — not inside its
+  grandparent's DOM. Without the chain walk, opening a third+ level
+  `SubMenuTrigger` (or any equivalent nested popover) closed every
+  ancestor.

--- a/.changeset/popover-auto-dismiss.md
+++ b/.changeset/popover-auto-dismiss.md
@@ -54,6 +54,13 @@ need `data-popover-keep`. Popover triggers wrapped by `MenuTrigger`,
   event. The `popover:dismiss-ancestor` EventBus event carries the
   originating DOM element so each popover host can do a `container.contains()`
   check before closing.
+- `usePopoverSync` gained a `closeOnPeerOpen` option (default `true`).
+  `DialogTrigger` passes `false` for modal/tray/fullscreen/panel types so
+  a peer popover opening (e.g. via `useDialogContainer` or
+  `useAnchoredMenu`) cannot bypass the dialog's `isDismissable` /
+  `onClose` handling and call `state.close()` directly. The host still
+  EMITS `popover:open`, so opening a modal correctly dismisses peer
+  popovers — only the listener side is gated.
 - `DialogTrigger` now applies `data-popover-trigger` to its child press
   responder **only when `type === 'popover'`**. This is the critical
   correctness piece for the original bug — when a `DialogTrigger type="modal"`

--- a/src/components/actions/Button/Button.docs.mdx
+++ b/src/components/actions/Button/Button.docs.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
+
 import { Button } from './Button';
 import * as ButtonStories from './Button.stories';
 
@@ -49,6 +50,7 @@ Supports [Base properties](/docs/getting-started-base-properties--docs)
 Customises the root element of the component.
 
 **Sub-elements:**
+
 - `Icon` – wrapper around the leading icon
 - `RightIcon` – wrapper around the trailing icon
 - `Label` – the button text content
@@ -122,27 +124,35 @@ The `mods` prop accepts the following modifiers you can override:
 ```jsx
 import { IconPlus } from '@tabler/icons-react';
 
-{/* Standard icon */}
-<Button icon={<IconPlus />} aria-label="Add item" />
+{
+  /* Standard icon */
+}
+<Button icon={<IconPlus />} aria-label="Add item" />;
 
-{/* Empty slot (reserves space but shows nothing) */}
-<Button icon={true} aria-label="Empty slot" />
+{
+  /* Empty slot (reserves space but shows nothing) */
+}
+<Button icon={true} aria-label="Empty slot" />;
 
-{/* Dynamic icon based on mods */}
-<Button 
-  icon={({ loading }) => loading ? <SpinnerIcon /> : <IconPlus />}
+{
+  /* Dynamic icon based on mods */
+}
+<Button
+  icon={({ loading }) => (loading ? <SpinnerIcon /> : <IconPlus />)}
   aria-label="Dynamic icon"
 >
   Save
-</Button>
+</Button>;
 
-{/* Return true from function for empty slot */}
-<Button 
-  icon={({ selected }) => selected ? <CheckIcon /> : true}
+{
+  /* Return true from function for empty slot */
+}
+<Button
+  icon={({ selected }) => (selected ? <CheckIcon /> : true)}
   aria-label="Conditional icon"
 >
   Option
-</Button>
+</Button>;
 ```
 
 ### Link Button
@@ -167,21 +177,31 @@ import { IconPlus } from '@tabler/icons-react';
 ### With Tooltip
 
 ```jsx
-{/* Simple tooltip text */}
-<Button icon={<IconPlus />} tooltip="Add new item" aria-label="Add" />
+{
+  /* Simple tooltip text */
+}
+<Button icon={<IconPlus />} tooltip="Add new item" aria-label="Add" />;
 
-{/* Auto tooltip on overflow */}
-<Button tooltip={true} width="100px">This text will be truncated</Button>
+{
+  /* Auto tooltip on overflow */
+}
+<Button tooltip={true} width="100px">
+  This text will be truncated
+</Button>;
 ```
 
 ### Custom Size
 
 ```jsx
-{/* Using a number (pixels) */}
-<Button size={64}>Large Custom</Button>
+{
+  /* Using a number (pixels) */
+}
+<Button size={64}>Large Custom</Button>;
 
-{/* Using a string multiplier */}
-<Button size="8x">8x Size</Button>
+{
+  /* Using a string multiplier */
+}
+<Button size="8x">8x Size</Button>;
 ```
 
 ## Accessibility
@@ -202,6 +222,65 @@ import { IconPlus } from '@tabler/icons-react';
 - `aria-label`, `aria-labelledby` – Accessible name.
 - `aria-pressed` – Managed automatically when `isSelected` is used.
 - Additional ARIA attributes supported by React Aria's `useButton`.
+
+## Behaviour Inside Popovers
+
+By default, pressing a `Button` inside an open popover (any overlay that
+uses `usePopoverSync` — including the popovers rendered by `FilterPicker`,
+`Picker`, `ComboBox`, `Select`, `MenuTrigger`, and
+`DialogTrigger type="popover"`) **dismisses that popover** after the user's
+`onPress` runs. This matches the common UX where a popover is a transient
+surface: any action inside it should close it.
+
+Modal / tray / fullscreen Dialogs are **not** affected — a Button inside a
+modal Dialog does not auto-close it.
+
+### Opt-outs
+
+There are three ways to keep the popover open when a Button is pressed:
+
+1. **Automatic for popover triggers.** Buttons that act as popover triggers
+   already carry `data-popover-trigger` (applied by `MenuTrigger`,
+   `DialogTrigger type="popover"`, `FilterPicker`, `Picker`, `ComboBox`,
+   `Select`). Modal-type `DialogTrigger` children are **not** marked, so they
+   correctly dismiss the parent popover and let the modal take over.
+2. **Manual via `data-popover-keep`.** Add the attribute to the button
+   (toggle case) or to any ancestor element (subtree case — useful when a
+   custom inline editor inside a popover footer should not collapse on
+   every interaction):
+
+   ```jsx
+   <Button data-popover-keep onPress={() => setMode((m) => !m)}>
+     Toggle
+   </Button>
+
+   <div data-popover-keep>
+     {/* All Buttons inside this wrapper opt out. */}
+   </div>
+   ```
+
+3. **Custom non-Cube triggers.** Call `useDismissParentPopover()` yourself if
+   your control should dismiss the popover but does not extend `Button` /
+   `ItemButton`:
+   ```jsx
+   const dismiss = useDismissParentPopover();
+   <MyCustomPressable
+     onPress={(e) => {
+       doThing();
+       dismiss(e.currentTarget);
+     }}
+   />;
+   ```
+
+### Async `onPress`
+
+The dismiss is dispatched via the EventBus, which defers with `setTimeout(0)`.
+This means synchronous `onPress` handlers (and any React state updates they
+trigger) flush **before** the popover closes — including the common case of
+opening a hoisted modal via `useDialogContainer` from a popover footer (the
+modal mounts first, then the popover closes behind it). If your `onPress` is
+async and `await`s before opening another overlay, the popover will close
+first and the new overlay will appear after — usually fine, but worth noting.
 
 ## Best Practices
 

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { FocusableRef } from '@react-types/shared';
+import { FocusableRef, PressEvent } from '@react-types/shared';
 import {
   CONTAINER_STYLES,
   Mods,
@@ -14,10 +14,12 @@ import {
   ReactNode,
   RefObject,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { OverlayProps } from 'react-aria';
 
+import { useEvent } from '../../../_internal';
 import { useIsFirstRender } from '../../../_internal/hooks/use-is-first-render';
 import { useWarn } from '../../../_internal/hooks/use-warn';
 import {
@@ -52,7 +54,12 @@ import {
   WARNING_PRIMARY_STYLES,
 } from '../../../data/item-themes';
 import { LoadingIcon } from '../../../icons';
-import { DynamicIcon, mergeProps, resolveIcon } from '../../../utils/react';
+import {
+  DynamicIcon,
+  mergeProps,
+  resolveIcon,
+  useDismissParentPopover,
+} from '../../../utils/react';
 import { extractStyles } from '../../../utils/styles';
 import { useAutoTooltip } from '../../content/use-auto-tooltip';
 import { DisplayTransition } from '../../helpers/DisplayTransition';
@@ -370,6 +377,7 @@ export const Button = forwardRef(function Button(
     download,
     tooltip = true,
     defaultTooltipPlacement = 'top',
+    onPress: userOnPress,
     ...props
   } = allProps;
 
@@ -382,8 +390,32 @@ export const Button = forwardRef(function Button(
   const isLoading = props.isLoading;
   const isSelected = props.isSelected;
 
+  // Default: pressing a Button inside an open popover closes that popover.
+  // Opt-outs (handled inline below):
+  //   - `data-popover-trigger` (auto, applied by MenuTrigger/DialogTrigger
+  //     type='popover' so triggers don't dismiss the popover they live in)
+  //   - `data-popover-keep` on self or any ancestor (manual opt-out for
+  //     toggles, custom inline editors, etc.)
+  // Modals/trays don't subscribe at all, so this is a no-op there.
+  const dismissParentPopover = useDismissParentPopover();
+  const buttonElementRef = useRef<HTMLElement | null>(null);
+
+  const wrappedOnPress = useEvent((e: PressEvent) => {
+    userOnPress?.(e);
+    const el = buttonElementRef.current;
+    if (!el) return;
+    if (el.hasAttribute('data-popover-trigger')) return;
+    if (el.closest('[data-popover-keep]')) return;
+    dismissParentPopover(el);
+  });
+
   const { actionProps, isPressed } = useAction(
-    { ...allProps, isDisabled, ...(label ? { label } : {}) },
+    {
+      ...allProps,
+      isDisabled,
+      onPress: wrappedOnPress,
+      ...(label ? { label } : {}),
+    },
     ref,
   );
 
@@ -535,6 +567,9 @@ export const Button = forwardRef(function Button(
       if (tooltipRef) {
         (tooltipRef as any).current = element;
       }
+      // Track the rendered DOM node so the dismiss wrapper around `onPress`
+      // can read it synchronously without coupling to `useAction`'s ref shape.
+      buttonElementRef.current = element;
     };
 
     // Determine if size is custom (number or unrecognized string)

--- a/src/components/actions/CommandMenu/CommandMenu.tsx
+++ b/src/components/actions/CommandMenu/CommandMenu.tsx
@@ -1,6 +1,5 @@
-import { useSyncRef } from '@react-aria/utils';
-import { useDOMRef } from '@react-spectrum/utils';
-import { DOMRef, FocusStrategy } from '@react-types/shared';
+import { useObjectRef, useSyncRef } from '@react-aria/utils';
+import { FocusStrategy } from '@react-types/shared';
 import {
   BaseProps,
   CONTAINER_STYLES,
@@ -12,6 +11,7 @@ import React, {
   Key,
   ReactElement,
   ReactNode,
+  Ref,
   useCallback,
   useMemo,
   useRef,
@@ -94,7 +94,7 @@ export interface CubeCommandMenuProps<T>
 
 function CommandMenu<T extends object>(
   props: CubeCommandMenuProps<T>,
-  ref: DOMRef<HTMLDivElement>,
+  ref: Ref<HTMLDivElement>,
 ) {
   const {
     searchPlaceholder = 'Search commands...',
@@ -119,7 +119,7 @@ function CommandMenu<T extends object>(
     ...restMenuProps
   } = props;
 
-  const domRef = useDOMRef(ref);
+  const domRef = useObjectRef(ref);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const contextProps = useMenuContext();
 

--- a/src/components/actions/ItemButton/ItemButton.docs.mdx
+++ b/src/components/actions/ItemButton/ItemButton.docs.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
+
 import { ItemButton } from './ItemButton';
 import * as ItemButtonStories from './ItemButton.stories';
 
@@ -82,7 +83,7 @@ Inherits all modifiers from [Item](/docs/content-item--docs) plus:
 ### Sizes
 
 - `xsmall` - Extra small size for compact interfaces
-- `small` - Small size for dense layouts  
+- `small` - Small size for dense layouts
 - `medium` - Default size for most use cases
 - `large` - Large size for prominent actions
 - `xlarge` - Extra large size for hero actions
@@ -92,15 +93,13 @@ Inherits all modifiers from [Item](/docs/content-item--docs) plus:
 ### Basic Button
 
 ```jsx
-<ItemButton onPress={() => console.log('Clicked')}>
-  Click me
-</ItemButton>
+<ItemButton onPress={() => console.log('Clicked')}>Click me</ItemButton>
 ```
 
 ### Button with Icons
 
 ```jsx
-<ItemButton 
+<ItemButton
   icon={<IconFile />}
   rightIcon={<IconExternalLink />}
   onPress={handleOpen}
@@ -112,19 +111,13 @@ Inherits all modifiers from [Item](/docs/content-item--docs) plus:
 ### Link Button
 
 ```jsx
-<ItemButton to="/docs">
-  Go to Documentation
-</ItemButton>
+<ItemButton to="/docs">Go to Documentation</ItemButton>
 ```
 
 ### Button with Hotkey
 
 ```jsx
-<ItemButton 
-  hotkeys="cmd+s"
-  onPress={handleSave}
-  type="primary"
->
+<ItemButton hotkeys="cmd+s" onPress={handleSave} type="primary">
   Save Document
 </ItemButton>
 ```
@@ -132,11 +125,7 @@ Inherits all modifiers from [Item](/docs/content-item--docs) plus:
 ### Form Submit Button
 
 ```jsx
-<ItemButton 
-  htmlType="submit"
-  type="primary"
-  icon={<IconCheck />}
->
+<ItemButton htmlType="submit" type="primary" icon={<IconCheck />}>
   Submit Form
 </ItemButton>
 ```
@@ -144,10 +133,7 @@ Inherits all modifiers from [Item](/docs/content-item--docs) plus:
 ### Button with Selection State
 
 ```jsx
-<ItemButton 
-  isSelected={isSelected}
-  onPress={() => setIsSelected(!isSelected)}
->
+<ItemButton isSelected={isSelected} onPress={() => setIsSelected(!isSelected)}>
   Toggle Selection
 </ItemButton>
 ```
@@ -157,12 +143,20 @@ Inherits all modifiers from [Item](/docs/content-item--docs) plus:
 ItemButton supports inline actions that appear on the right side. Use the `ItemButton.Action` compound component for consistent styling:
 
 ```jsx
-<ItemButton 
+<ItemButton
   icon={<IconFile />}
   actions={
     <>
-      <ItemButton.Action icon={<IconEdit />} aria-label="Edit" onPress={handleEdit} />
-      <ItemButton.Action icon={<IconTrash />} aria-label="Delete" onPress={handleDelete} />
+      <ItemButton.Action
+        icon={<IconEdit />}
+        aria-label="Edit"
+        onPress={handleEdit}
+      />
+      <ItemButton.Action
+        icon={<IconTrash />}
+        aria-label="Delete"
+        onPress={handleDelete}
+      />
     </>
   }
   onPress={handleOpen}
@@ -196,9 +190,41 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
 - `aria-pressed` - Indicates toggle state for toggle buttons
 - `role` - Automatically set to "button" or "link" based on props
 
+## Behaviour Inside Popovers
+
+Like `Button`, an `ItemButton` press inside an open popover **dismisses
+that popover** by default — popovers are transient surfaces and any action
+inside them should close them. Modals/trays/fullscreen Dialogs are not
+affected.
+
+### Opt-outs
+
+- **Automatic for popover triggers** — `MenuTrigger`, `DialogTrigger
+type="popover"`, and the picker components (`FilterPicker`, `Picker`,
+  `ComboBox`, `Select`) mark their trigger ItemButtons with
+  `data-popover-trigger` so they don't dismiss the popover they themselves
+  live in.
+- **Manual via `data-popover-keep`** — add to the ItemButton (toggle) or
+  any ancestor (whole subtree):
+  ```jsx
+  <ItemButton data-popover-keep onPress={() => setMode((m) => !m)}>
+    Toggle Mode
+  </ItemButton>
+  ```
+- **Custom non-Cube triggers** — call `useDismissParentPopover()` directly
+  if you build a control on top of something other than `Button` /
+  `ItemButton`.
+
+The dismiss is dispatched via the EventBus, which defers with `setTimeout(0)`
+— so synchronous `onPress` handlers (and the React state updates they
+trigger) flush BEFORE the popover closes. This makes the "open a hoisted
+modal from a popover footer" pattern work without flicker: the modal mounts
+first, then the popover closes behind it.
+
 ## Best Practices
 
 1. **Do**: Use clear, action-oriented text
+
    ```jsx
    <ItemButton onPress={handleSave} type="primary">
      Save Changes
@@ -206,6 +232,7 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
    ```
 
 2. **Do**: Add hotkeys for frequently used actions
+
    ```jsx
    <ItemButton hotkeys="cmd+s" onPress={handleSave}>
      Save Document
@@ -213,6 +240,7 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
    ```
 
 3. **Do**: Use appropriate button types for forms
+
    ```jsx
    <ItemButton htmlType="submit" type="primary">
      Submit Form
@@ -220,8 +248,9 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
    ```
 
 4. **Do**: Use `ItemButton.Action` for inline actions
+
    ```jsx
-   <ItemButton 
+   <ItemButton
      icon={<IconFile />}
      actions={
        <>
@@ -236,15 +265,21 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
    ```
 
 5. **Don't**: Use vague or unclear button text
+
    ```jsx
-   {/* Avoid this - unclear what "OK" does */}
-   <ItemButton onPress={handleAction}>OK</ItemButton>
+   {
+     /* Avoid this - unclear what "OK" does */
+   }
+   <ItemButton onPress={handleAction}>OK</ItemButton>;
    ```
 
 6. **Don't**: Add too many actions (limit to 2-3 for clarity)
+
    ```jsx
-   {/* Avoid this - too many action buttons */}
-   <ItemButton 
+   {
+     /* Avoid this - too many action buttons */
+   }
+   <ItemButton
      actions={
        <>
          <ItemButton.Action icon={<IconEdit />} aria-label="Edit" />
@@ -255,13 +290,16 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
      }
    >
      Button with too many actions
-   </ItemButton>
+   </ItemButton>;
    ```
 
 7. **Don't**: Overcrowd buttons with too many visual elements
+
    ```jsx
-   {/* Avoid this - too many competing elements */}
-   <ItemButton 
+   {
+     /* Avoid this - too many competing elements */
+   }
+   <ItemButton
      icon={<IconA />}
      rightIcon={<IconB />}
      prefix="Pre"
@@ -269,7 +307,7 @@ Actions automatically inherit the parent button's `type` prop and adjust their s
      description="Long description"
    >
      Overcrowded Button
-   </ItemButton>
+   </ItemButton>;
    ```
 
 8. **Accessibility**: Always ensure buttons have clear, descriptive labels, proper keyboard support, and provide `aria-label` for action buttons

--- a/src/components/actions/ItemButton/ItemButton.tsx
+++ b/src/components/actions/ItemButton/ItemButton.tsx
@@ -1,4 +1,4 @@
-import { FocusableRef } from '@react-types/shared';
+import { FocusableRef, PressEvent } from '@react-types/shared';
 import { Styles, tasty } from '@tenphi/tasty';
 import {
   CSSProperties,
@@ -11,7 +11,12 @@ import {
 } from 'react';
 import { useFocusWithin, useHover } from 'react-aria';
 
-import { mergeProps } from '../../../utils/react';
+import { useEvent } from '../../../_internal';
+import {
+  mergeProps,
+  mergeRefs,
+  useDismissParentPopover,
+} from '../../../utils/react';
 import { CubeItemProps, Item } from '../../content/Item';
 import { ItemBadge } from '../../content/ItemBadge';
 import { DisplayTransition } from '../../helpers';
@@ -169,6 +174,22 @@ const ItemButton = forwardRef(function ItemButton(
   const shouldShowActions =
     isHovered || isFocusWithin || hasPressed || !autoHideActions;
 
+  // Default: pressing an ItemButton inside an open popover closes that
+  // popover. Opt-outs: `data-popover-trigger` on self (applied by
+  // FilterPicker / Picker / Select / MenuTrigger for their own triggers) and
+  // `data-popover-keep` on self or any ancestor. Modals don't subscribe.
+  const dismissParentPopover = useDismissParentPopover();
+  const buttonElementRef = useRef<HTMLElement | null>(null);
+
+  const wrappedOnPress = useEvent((e: PressEvent) => {
+    onPress?.(e);
+    const el = buttonElementRef.current;
+    if (!el) return;
+    if (el.hasAttribute('data-popover-trigger')) return;
+    if (el.closest('[data-popover-keep]')) return;
+    dismissParentPopover(el);
+  });
+
   const { actionProps } = useAction(
     {
       ...(allProps as any),
@@ -177,6 +198,7 @@ const ItemButton = forwardRef(function ItemButton(
       as,
       mods,
       isDisabled: finalIsDisabled,
+      onPress: wrappedOnPress,
     },
     ref,
   );
@@ -185,12 +207,20 @@ const ItemButton = forwardRef(function ItemButton(
     return shouldShowActions ? { ...mods, 'actions-shown': true } : mods;
   }, [mods, shouldShowActions]);
 
+  // Merge the useAction-supplied ref with our internal ref so the dismiss
+  // wrapper can read the rendered DOM node at press time.
+  const combinedRef = useMemo(
+    () => mergeRefs(actionProps.ref as any, buttonElementRef),
+    [actionProps.ref],
+  );
+
   const button = (
     <StyledItem
       insideWrapper={!!actions}
       showActions={shouldShowActions}
       actions={actions ? true : undefined}
       {...(mergeProps(rest, actionProps) as any)}
+      ref={combinedRef}
       data-popover-dismiss=""
       htmlType={actionProps.type}
       type={type}

--- a/src/components/actions/Menu/Menu.stories.tsx
+++ b/src/components/actions/Menu/Menu.stories.tsx
@@ -29,6 +29,8 @@ import { baseProps } from '../../../stories/lists/baseProps';
 import { Block } from '../../Block';
 import { Alert } from '../../content/Alert';
 import { Card } from '../../content/Card/Card';
+import { Content } from '../../content/Content';
+import { Header } from '../../content/Header';
 import { Paragraph } from '../../content/Paragraph';
 import { Text } from '../../content/Text';
 import { Title } from '../../content/Title';
@@ -39,7 +41,12 @@ import { Flex } from '../../layout/Flex';
 import { Flow } from '../../layout/Flow';
 import { Space } from '../../layout/Space';
 import { AlertDialog } from '../../overlays/AlertDialog';
-import { DialogContainer } from '../../overlays/Dialog';
+import {
+  Dialog,
+  DialogContainer,
+  DialogTrigger,
+  useDialogContainer,
+} from '../../overlays/Dialog';
 import { Button } from '../Button';
 import { ItemAction } from '../ItemAction';
 import { useAnchoredMenu } from '../use-anchored-menu';
@@ -1914,6 +1921,24 @@ export const ComprehensivePopoverSynchronization = () => {
     { onAction: handleAction },
   );
 
+  const FooterModalDialog = () => (
+    <Dialog>
+      <Header>
+        <Title>Footer Modal Dialog</Title>
+      </Header>
+      <Content>
+        <Paragraph>
+          This modal dialog is opened from the FilterPicker footer via
+          useDialogContainer. Opening it closes the FilterPicker and any other
+          open popover.
+        </Paragraph>
+      </Content>
+    </Dialog>
+  );
+
+  const { open: openFooterModal, rendered: footerModalRendered } =
+    useDialogContainer(FooterModalDialog, { type: 'modal' });
+
   const selectOptions = [
     { value: 'option1', label: 'Option 1' },
     { value: 'option2', label: 'Option 2' },
@@ -1942,7 +1967,12 @@ export const ComprehensivePopoverSynchronization = () => {
       </Title>
       <Paragraph preset="t4" color="#dark-03" margin="0 0 4x 0">
         Only one popover can be open at a time. Opening any trigger
-        automatically closes others.
+        automatically closes others. By default, pressing a Button or ItemButton
+        inside an open popover dismisses the popover (modals and other Dialogs
+        are unaffected). Use <code>data-popover-keep</code> on the button (or
+        any ancestor) to opt out — e.g. for toggles inside the popover footer.
+        Popover triggers wrapped by MenuTrigger or DialogTrigger
+        (type=&quot;popover&quot;) auto-skip the dismiss.
       </Paragraph>
 
       <Flex gap="2x" placeItems="start">
@@ -1996,16 +2026,87 @@ export const ComprehensivePopoverSynchronization = () => {
           {(item) => <ComboBox.Item key={item.id}>{item.name}</ComboBox.Item>}
         </ComboBox>
 
-        {/* FilterPicker */}
+        {/* FilterPicker - demonstrates the three canonical footer button cases */}
+        {footerModalRendered}
         <FilterPicker
           placeholder="FilterPicker"
           items={filterPickerOptions}
           size="small"
+          footer={
+            <Flex gap="1x">
+              {/* Case 1: popover trigger - auto-skips dismiss via
+                  data-popover-trigger (DialogTrigger type="popover" sets it).
+                  Pressing keeps the FilterPicker open as a nested popover. */}
+              <DialogTrigger type="popover" placement="bottom start">
+                <Button size="small">Dialog (popover)</Button>
+                <Dialog>
+                  <Header>
+                    <Title>Footer Popover Dialog</Title>
+                  </Header>
+                  <Content>
+                    <Paragraph>
+                      Nested popover. The parent FilterPicker stays open because
+                      DialogTrigger marks this button as a popover trigger.
+                    </Paragraph>
+                  </Content>
+                </Dialog>
+              </DialogTrigger>
+
+              {/* Case 2: plain action - closes the FilterPicker by default
+                  while the hoisted modal mounts (EventBus defers via
+                  setTimeout(0), so onPress flushes first). */}
+              <Button size="small" onPress={() => openFooterModal({})}>
+                Dialog (modal)
+              </Button>
+
+              {/* Case 3: toggle - opts out of the auto-dismiss with
+                  data-popover-keep so multiple presses are possible without
+                  reopening the FilterPicker. */}
+              <Button
+                data-popover-keep
+                size="small"
+                onPress={() => console.log('Toggle pressed (popover stays)')}
+              >
+                Toggle (keeps popover)
+              </Button>
+            </Flex>
+          }
         >
           {(item) => (
             <FilterPicker.Item key={item.id}>{item.name}</FilterPicker.Item>
           )}
         </FilterPicker>
+
+        {/* DialogTrigger (popover) */}
+        <DialogTrigger type="popover" placement="bottom start">
+          <Button size="small">DialogTrigger (popover)</Button>
+          <Dialog>
+            <Header>
+              <Title>Popover Dialog</Title>
+            </Header>
+            <Content>
+              <Paragraph>
+                Opening this dialog closes any other open popover, and opening
+                another popover closes this dialog.
+              </Paragraph>
+            </Content>
+          </Dialog>
+        </DialogTrigger>
+
+        {/* DialogTrigger (modal) */}
+        <DialogTrigger type="modal">
+          <Button size="small">DialogTrigger (modal)</Button>
+          <Dialog>
+            <Header>
+              <Title>Modal Dialog</Title>
+            </Header>
+            <Content>
+              <Paragraph>
+                Opening this modal dialog closes any other open popover.
+              </Paragraph>
+            </Content>
+          </Dialog>
+        </DialogTrigger>
       </Flex>
     </Flow>
   );

--- a/src/components/actions/Menu/Menu.test.tsx
+++ b/src/components/actions/Menu/Menu.test.tsx
@@ -667,8 +667,8 @@ describe('<Menu />', () => {
     );
 
     const menu = getByRole('menu');
-    expect(menuRef.current).toBeDefined();
-    expect(menuRef.current.UNSAFE_getDOMNode).toBeDefined();
+    expect(menuRef.current).toBeInstanceOf(HTMLUListElement);
+    expect(menuRef.current).toBe(menu);
   });
 
   // Combined functionality tests

--- a/src/components/actions/Menu/Menu.tsx
+++ b/src/components/actions/Menu/Menu.tsx
@@ -1,6 +1,5 @@
-import { useSyncRef } from '@react-aria/utils';
-import { useDOMRef } from '@react-spectrum/utils';
-import { DOMRef, FocusStrategy, ItemProps } from '@react-types/shared';
+import { useObjectRef, useSyncRef } from '@react-aria/utils';
+import { FocusStrategy, ItemProps } from '@react-types/shared';
 import {
   BasePropsWithoutChildren,
   CONTAINER_STYLES,
@@ -8,7 +7,7 @@ import {
   filterBaseProps,
   Styles,
 } from '@tenphi/tasty';
-import React, { ReactElement, ReactNode, useMemo } from 'react';
+import React, { ReactElement, ReactNode, Ref, useMemo } from 'react';
 import { AriaMenuProps, useMenu } from 'react-aria';
 import { Section as BaseSection, useTreeState } from 'react-stately';
 
@@ -72,7 +71,7 @@ export interface CubeMenuProps<T>
 
 function Menu<T extends object>(
   props: CubeMenuProps<T>,
-  ref: DOMRef<HTMLUListElement>,
+  ref: Ref<HTMLUListElement>,
 ) {
   const {
     header,
@@ -91,7 +90,7 @@ function Menu<T extends object>(
     onSelectionChange,
     ...rest
   } = props;
-  const domRef = useDOMRef(ref);
+  const domRef = useObjectRef(ref);
   const contextProps = useMenuContext();
 
   // Convert string[] to Set<Key> for React Aria compatibility
@@ -150,9 +149,9 @@ function Menu<T extends object>(
     };
   }, [hasSections]);
 
-  // Sync the ref stored in the context object with the DOM ref returned by useDOMRef.
-  // The helper from @react-aria/utils expects the context object as the first argument
-  // to keep it up-to-date, and a ref object as the second.
+  // Sync the ref stored in the context object with the menu's DOM ref.
+  // `useSyncRef` from @react-aria/utils expects the context object as the
+  // first argument to keep it up-to-date, and a ref object as the second.
   useSyncRef(contextProps, domRef);
 
   const renderedItems = useMemo(() => {

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -1,10 +1,11 @@
 import { PressResponder } from '@react-aria/interactions';
-import { useDOMRef, useIsMobileDevice } from '@react-spectrum/utils';
-import { DOMRef } from '@react-types/shared';
+import { useObjectRef } from '@react-aria/utils';
+import { useIsMobileDevice } from '@react-spectrum/utils';
 import {
   forwardRef,
   Fragment,
   ReactElement,
+  Ref,
   useEffect,
   useMemo,
   useRef,
@@ -49,10 +50,10 @@ export type CubeMenuTriggerProps = AriaMenuTriggerProps &
     mobileType?: 'popover' | 'tray';
   };
 
-function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
+function MenuTrigger(props: CubeMenuTriggerProps, ref: Ref<HTMLElement>) {
   const menuPopoverRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLElement>(null);
-  const domRef = useDOMRef(ref);
+  const domRef = useObjectRef(ref);
   const menuTriggerRef = props.targetRef || domRef || triggerRef;
   const menuRef = useRef<HTMLUListElement>(null);
   const wasOpenRef = useRef(false);

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -81,6 +81,8 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: DOMRef<HTMLElement>) {
     isOpen: state.isOpen,
     onClose: () => state.close(),
     enabled: !isDummy,
+    triggerRef: menuTriggerRef,
+    containerRef: menuPopoverRef,
   });
 
   // Restore focus manually when the menu closes

--- a/src/components/actions/Menu/SubMenuTrigger.tsx
+++ b/src/components/actions/Menu/SubMenuTrigger.tsx
@@ -106,16 +106,18 @@ function InternalSubMenuTrigger(props: InternalSubMenuTriggerProps) {
   // Generate a unique ID for this submenu instance
   const submenuId = useMemo(() => generateRandomId(), []);
 
-  usePopoverSync({
-    menuId: submenuId,
-    isOpen: state.isOpen,
-    onClose: () => state.close(),
-  });
-
   // Refs – trigger (MenuItem <li>) and overlay (<div> from Popover)
   const domTriggerRef = useRef<HTMLElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLUListElement>(null);
+
+  usePopoverSync({
+    menuId: submenuId,
+    isOpen: state.isOpen,
+    onClose: () => state.close(),
+    triggerRef: domTriggerRef,
+    containerRef: popoverRef,
+  });
 
   // Strip keyboard/press handlers that we will implement ourselves
   const { menuTriggerProps: rawTriggerProps, menuProps } = useMenuTrigger(

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -83,10 +83,17 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
+  // `containerRef` is intentionally omitted: the underlying `MenuTrigger` is
+  // `isDummy`, so its own popover container ref isn't reachable from here.
+  // Passing `triggerRef` is enough to let peers (e.g. a `DialogTrigger`
+  // opened inside the menu's content) identify themselves as nested and stay
+  // open — the menu's own `MenuTrigger` already maintains its container ref
+  // via its non-dummy usage elsewhere; here the dummy proxies a real one.
   usePopoverSync({
     menuId,
     isOpen,
     onClose: () => setIsOpen(false),
+    triggerRef: anchorRef,
   });
 
   function setupCheck() {

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -114,6 +114,10 @@ export function useContextMenu<
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
+  // `containerRef` is intentionally omitted: the underlying `MenuTrigger` is
+  // `isDummy`, so its own popover container ref isn't reachable from here.
+  // Providing `triggerRef` (the context-menu target element) is enough to let
+  // peers identify themselves correctly when they emit `popover:open`.
   usePopoverSync({
     menuId,
     isOpen,
@@ -121,6 +125,7 @@ export function useContextMenu<
       setIsOpen(false);
       setAnchorPosition(null);
     },
+    triggerRef: targetRef as RefObject<HTMLElement | null>,
   });
 
   function setupCheck() {

--- a/src/components/fields/Checkbox/CheckboxGroup.tsx
+++ b/src/components/fields/Checkbox/CheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import { useDOMRef } from '@react-spectrum/utils';
+import { useObjectRef } from '@react-aria/utils';
 import {
   BaseProps,
   CONTAINER_STYLES,
@@ -86,7 +86,7 @@ function CheckboxGroup(props: WithNullableValue<CubeCheckboxGroupProps>, ref) {
     form,
     ...otherProps
   } = props;
-  let domRef = useDOMRef(ref);
+  let domRef = useObjectRef(ref);
 
   let styles = extractStyles(otherProps, CONTAINER_STYLES);
 

--- a/src/components/fields/ComboBox/ComboBox.tsx
+++ b/src/components/fields/ComboBox/ComboBox.tsx
@@ -259,6 +259,8 @@ interface UseComboBoxStateProps {
   inputValue?: string;
   defaultInputValue?: string;
   comboBoxId: string;
+  triggerRef?: RefObject<HTMLElement | null>;
+  popoverRef?: RefObject<HTMLElement | null>;
 }
 
 interface UseComboBoxStateReturn {
@@ -278,6 +280,8 @@ function useComboBoxState({
   inputValue,
   defaultInputValue,
   comboBoxId,
+  triggerRef,
+  popoverRef,
 }: UseComboBoxStateProps): UseComboBoxStateReturn {
   // Internal state for uncontrolled mode
   const [internalSelectedKey, setInternalSelectedKey] = useState<Key | null>(
@@ -304,6 +308,8 @@ function useComboBoxState({
     menuId: comboBoxId,
     isOpen: isPopoverOpen,
     onClose: () => setIsPopoverOpen(false),
+    triggerRef,
+    containerRef: popoverRef,
   });
 
   return {
@@ -1027,6 +1033,12 @@ export const ComboBox = forwardRef(function ComboBox<T extends object>(
   // Generate a unique ID for this combobox instance
   const comboBoxId = useMemo(() => generateRandomId(), []);
 
+  // Hoist the wrapper/popover ref normalization above `useComboBoxState` so
+  // the popover-sync inside it sees stable, attached refs. Other ref combines
+  // happen below alongside the legacy ordering.
+  wrapperRef = useCombinedRefs(wrapperRef);
+  popoverRef = useCombinedRefs(popoverRef);
+
   // State management hook
   const {
     effectiveSelectedKey,
@@ -1043,6 +1055,8 @@ export const ComboBox = forwardRef(function ComboBox<T extends object>(
     inputValue,
     defaultInputValue,
     comboBoxId,
+    triggerRef: wrapperRef as RefObject<HTMLElement | null>,
+    popoverRef: popoverRef as RefObject<HTMLElement | null>,
   });
 
   // Track if sortSelectedToTop was explicitly provided
@@ -1057,10 +1071,8 @@ export const ComboBox = forwardRef(function ComboBox<T extends object>(
   styles = extractStyles(otherProps, PROP_STYLES, styles);
 
   ref = useCombinedRefs(ref);
-  wrapperRef = useCombinedRefs(wrapperRef);
   inputRef = useCombinedRefs(inputRef);
   triggerRef = useCombinedRefs(triggerRef);
-  popoverRef = useCombinedRefs(popoverRef);
   listBoxRef = useCombinedRefs(listBoxRef);
 
   // Sort items with selected on top if enabled

--- a/src/components/fields/FilterPicker/FilterPicker.test.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.test.tsx
@@ -2,7 +2,7 @@ import { createRef } from 'react';
 
 import { Dialog, DialogTrigger, FilterPicker } from '../../../index';
 import { renderWithRoot, userEvent, waitFor, within } from '../../../test';
-import { Button } from '../../actions';
+import { Button, ItemButton } from '../../actions';
 
 vi.mock('../../../_internal/hooks/use-warn');
 
@@ -889,6 +889,228 @@ describe('<FilterPicker />', () => {
         const icon = suffix?.querySelector('[data-qa="LoadingIcon"]');
         expect(icon).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('Footer Button dismiss-on-press behavior', () => {
+    // Asserting that the search input (only rendered inside the popover) is
+    // present in the DOM is a reliable open/closed signal — independent of
+    // any text on footer buttons or the trigger.
+    const isPopoverOpen = (baseElement: HTMLElement) =>
+      !!baseElement.querySelector('[data-qa="FilterListBoxSearchWrapper"]');
+
+    // The FilterPicker trigger has qa="FilterPicker" by default. Footer
+    // buttons have their own qa, so we target the trigger explicitly.
+    const getTrigger = (baseElement: HTMLElement) =>
+      baseElement.querySelector('[data-qa="FilterPicker"]') as HTMLElement;
+
+    it('plain Button in footer closes the FilterPicker on press (default)', async () => {
+      const onPress = vi.fn();
+      const { getByText, baseElement } = renderWithRoot(
+        <FilterPicker
+          label="Pick"
+          placeholder="Choose..."
+          selectionMode="single"
+          footer={
+            <Button qa="FooterAction" onPress={onPress}>
+              Footer Action
+            </Button>
+          }
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      await user.click(getTrigger(baseElement));
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(true));
+
+      await user.click(getByText('Footer Action'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      // The EventBus defers via setTimeout(0); allow a few ticks for the
+      // dismiss event to flush before asserting the popover closed.
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(false), {
+        timeout: 1500,
+      });
+    });
+
+    it('Button with data-popover-keep keeps the FilterPicker open', async () => {
+      const onPress = vi.fn();
+      const { getByText, baseElement } = renderWithRoot(
+        <FilterPicker
+          label="Pick"
+          placeholder="Choose..."
+          selectionMode="single"
+          footer={
+            <Button data-popover-keep qa="StickyFooterAction" onPress={onPress}>
+              Sticky Action
+            </Button>
+          }
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      await user.click(getTrigger(baseElement));
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(true));
+
+      await user.click(getByText('Sticky Action'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      // Wait a tick so any setTimeout(0) dismiss would land — then assert
+      // the popover is still open.
+      await new Promise((resolve) => setTimeout(resolve, 16));
+      expect(isPopoverOpen(baseElement)).toBe(true);
+    });
+
+    it('Button wrapped in an ancestor with data-popover-keep keeps the FilterPicker open', async () => {
+      const onPress = vi.fn();
+      const { getByText, baseElement } = renderWithRoot(
+        <FilterPicker
+          label="Pick"
+          placeholder="Choose..."
+          selectionMode="single"
+          footer={
+            <div data-popover-keep>
+              <Button qa="NestedFooterAction" onPress={onPress}>
+                Wrapped Action
+              </Button>
+            </div>
+          }
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      await user.click(getTrigger(baseElement));
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(true));
+
+      await user.click(getByText('Wrapped Action'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      await new Promise((resolve) => setTimeout(resolve, 16));
+      expect(isPopoverOpen(baseElement)).toBe(true);
+    });
+
+    it('DialogTrigger type="popover" child auto-skips dismiss (nested popover)', async () => {
+      const { getByText, baseElement } = renderWithRoot(
+        <FilterPicker
+          label="Pick"
+          placeholder="Choose..."
+          selectionMode="single"
+          footer={
+            <DialogTrigger type="popover" placement="bottom start">
+              <Button qa="PopoverTriggerButton">Open Popover</Button>
+              <Dialog qa="NestedPopoverDialog">
+                <div>Nested content</div>
+              </Dialog>
+            </DialogTrigger>
+          }
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      await user.click(getTrigger(baseElement));
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(true));
+
+      // Sanity-check the DOM-level contract: DialogTrigger type="popover"
+      // must propagate data-popover-trigger to its Button child.
+      const popoverTriggerButton = baseElement.querySelector(
+        '[data-qa="PopoverTriggerButton"]',
+      );
+      expect(popoverTriggerButton).toHaveAttribute('data-popover-trigger');
+
+      await user.click(getByText('Open Popover'));
+
+      // Wait for any potential dismiss to fire; the parent FilterPicker
+      // must still be open because DialogTrigger type="popover" marks its
+      // child with data-popover-trigger.
+      await new Promise((resolve) => setTimeout(resolve, 16));
+      expect(isPopoverOpen(baseElement)).toBe(true);
+    });
+
+    it('ItemButton inside footer closes the FilterPicker on press (default)', async () => {
+      const onPress = vi.fn();
+      const { getByText, baseElement } = renderWithRoot(
+        <FilterPicker
+          label="Pick"
+          placeholder="Choose..."
+          selectionMode="single"
+          footer={
+            <ItemButton qa="FooterItemAction" onPress={onPress}>
+              Item Action
+            </ItemButton>
+          }
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      await user.click(getTrigger(baseElement));
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(true));
+
+      await user.click(getByText('Item Action'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(false), {
+        timeout: 1500,
+      });
+    });
+
+    it('ItemButton with data-popover-keep keeps the FilterPicker open', async () => {
+      const onPress = vi.fn();
+      const { getByText, baseElement } = renderWithRoot(
+        <FilterPicker
+          label="Pick"
+          placeholder="Choose..."
+          selectionMode="single"
+          footer={
+            <ItemButton
+              data-popover-keep
+              qa="StickyFooterItemAction"
+              onPress={onPress}
+            >
+              Sticky Item
+            </ItemButton>
+          }
+        >
+          {basicItems}
+        </FilterPicker>,
+      );
+
+      await user.click(getTrigger(baseElement));
+      await waitFor(() => expect(isPopoverOpen(baseElement)).toBe(true));
+
+      await user.click(getByText('Sticky Item'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      await new Promise((resolve) => setTimeout(resolve, 16));
+      expect(isPopoverOpen(baseElement)).toBe(true);
+    });
+
+    it('DialogTrigger type="modal" does NOT propagate data-popover-trigger (regression test)', () => {
+      // This is the critical correctness check for the modal-DialogTrigger
+      // case. If we accidentally marked every DialogTrigger child as
+      // data-popover-trigger, a modal opener inside a popover footer would
+      // skip the auto-dismiss and leave the popover behind the modal —
+      // the exact bug this feature fixes.
+      //
+      // Rendering the full modal Dialog inside jsdom hits an unrelated
+      // intlmessageformat issue, so we validate the contract at the DOM
+      // level instead: the Button rendered as DialogTrigger type="modal"
+      // child must NOT carry data-popover-trigger.
+      const { baseElement } = renderWithRoot(
+        <DialogTrigger type="modal">
+          <Button qa="ModalTriggerButton">Open Modal</Button>
+          {() => <span />}
+        </DialogTrigger>,
+      );
+
+      const modalTriggerButton = baseElement.querySelector(
+        '[data-qa="ModalTriggerButton"]',
+      );
+      expect(modalTriggerButton).not.toHaveAttribute('data-popover-trigger');
     });
   });
 });

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -29,8 +29,6 @@ import { useEvent } from '../../../_internal';
 import { useWarn } from '../../../_internal/hooks/use-warn';
 import { CloseIcon, DirectionIcon, LoadingIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
-import { generateRandomId } from '../../../utils/random';
-import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { processSelectionArray } from '../../../utils/selection';
 import { extractStyles } from '../../../utils/styles';
 import {
@@ -291,8 +289,6 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
 
   styles = extractStyles(otherProps, PROP_STYLES, styles);
 
-  const filterPickerId = useMemo(() => generateRandomId(), []);
-
   useWarn(isCheckable === false && selectionMode === 'single', {
     key: ['filterpicker-checkable-single-mode'],
     args: [
@@ -465,11 +461,7 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
     onOpenChange?.(isOpen);
   });
 
-  usePopoverSync({
-    menuId: filterPickerId,
-    isOpen: isPopoverOpen,
-    onClose: () => handleOpenChange(false),
-  });
+  // Popover sync is handled by the inner `DialogTrigger` (type="popover").
 
   // Keyboard handler for arrow keys to open popover
   const { keyboardProps } = useKeyboard({

--- a/src/components/fields/Picker/Picker.tsx
+++ b/src/components/fields/Picker/Picker.tsx
@@ -29,8 +29,6 @@ import { useEvent } from '../../../_internal';
 import { useWarn } from '../../../_internal/hooks/use-warn';
 import { CloseIcon, DirectionIcon, LoadingIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
-import { generateRandomId } from '../../../utils/random';
-import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { processSelectionArray } from '../../../utils/selection';
 import { extractStyles } from '../../../utils/styles';
 import {
@@ -250,9 +248,6 @@ export const Picker = forwardRef(function Picker<T extends object>(
 
   styles = extractStyles(otherProps, PROP_STYLES, styles);
 
-  // Generate a unique ID for this Picker instance
-  const pickerId = useMemo(() => generateRandomId(), []);
-
   // Warn if isCheckable is false in single selection mode
   useWarn(isCheckable === false && selectionMode === 'single', {
     key: ['picker-checkable-single-mode'],
@@ -466,11 +461,7 @@ export const Picker = forwardRef(function Picker<T extends object>(
     onOpenChange?.(isOpen);
   });
 
-  usePopoverSync({
-    menuId: pickerId,
-    isOpen: isPopoverOpen,
-    onClose: () => handleOpenChange(false),
-  });
+  // Popover sync is handled by the inner `DialogTrigger` (type="popover").
 
   // Keyboard handler for arrow keys to open popover
   const { keyboardProps } = useKeyboard({

--- a/src/components/fields/RadioGroup/RadioGroup.tsx
+++ b/src/components/fields/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { useDOMRef } from '@react-spectrum/utils';
+import { useObjectRef } from '@react-aria/utils';
 import {
   BaseProps,
   CONTAINER_STYLES,
@@ -114,7 +114,7 @@ function RadioGroup(props: WithNullableValue<CubeRadioGroupProps>, ref) {
     form,
     ...otherProps
   } = props;
-  let domRef = useDOMRef(ref);
+  let domRef = useObjectRef(ref);
 
   styles = extractStyles(otherProps, CONTAINER_STYLES, styles);
 

--- a/src/components/fields/Select/Select.tsx
+++ b/src/components/fields/Select/Select.tsx
@@ -323,12 +323,6 @@ function Select<T extends object>(
   // Generate a unique ID for this select instance
   const selectId = useMemo(() => generateRandomId(), []);
 
-  usePopoverSync({
-    menuId: selectId,
-    isOpen: state.isOpen,
-    onClose: () => state.close(),
-  });
-
   // Call onOpenChange when open state changes
   useEffect(() => {
     onOpenChange?.(state.isOpen);
@@ -340,6 +334,14 @@ function Select<T extends object>(
   triggerRef = useCombinedRefs(triggerRef);
   popoverRef = useCombinedRefs(popoverRef);
   listBoxRef = useCombinedRefs(listBoxRef);
+
+  usePopoverSync({
+    menuId: selectId,
+    isOpen: state.isOpen,
+    onClose: () => state.close(),
+    triggerRef: triggerRef as RefObject<HTMLElement | null>,
+    containerRef: popoverRef as RefObject<HTMLElement | null>,
+  });
 
   let { labelProps, triggerProps, valueProps, menuProps } = useSelect(
     props,

--- a/src/components/form/Form/Form.tsx
+++ b/src/components/form/Form/Form.tsx
@@ -1,5 +1,4 @@
-import { useDOMRef } from '@react-spectrum/utils';
-import { DOMRef } from '@react-types/shared';
+import { useObjectRef } from '@react-aria/utils';
 import {
   BaseProps,
   CONTAINER_STYLES,
@@ -14,6 +13,7 @@ import {
   forwardRef,
   ReactElement,
   ReactNode,
+  Ref,
   useContext,
   useRef,
 } from 'react';
@@ -91,7 +91,7 @@ export interface CubeFormProps<T extends FieldTypes = FieldTypes>
 
 function Form<T extends FieldTypes>(
   props: CubeFormProps<T>,
-  ref: DOMRef<HTMLFormElement>,
+  ref: Ref<HTMLFormElement>,
 ) {
   props = useProviderProps(props);
   let {
@@ -201,7 +201,7 @@ function Form<T extends FieldTypes>(
     styles['$label-width'] = labelWidth;
   }
 
-  let domRef = useDOMRef(ref as any);
+  let domRef = useObjectRef(ref);
 
   let ctx = {
     labelPosition,
@@ -261,7 +261,7 @@ function Form<T extends FieldTypes>(
  * Forms allow users to enter data that can be submitted while providing alignment and styling for form fields.
  */
 const _Form = forwardRef(Form) as unknown as <T extends FieldTypes>(
-  props: CubeFormProps<T> & { ref?: DOMRef<HTMLFormElement> },
+  props: CubeFormProps<T> & { ref?: Ref<HTMLFormElement> },
 ) => ReactElement;
 
 (_Form as any).displayName = 'Form';

--- a/src/components/form/Label.tsx
+++ b/src/components/form/Label.tsx
@@ -1,4 +1,4 @@
-import { useDOMRef } from '@react-spectrum/utils';
+import { useObjectRef } from '@react-aria/utils';
 import {
   BaseProps,
   CONTAINER_STYLES,
@@ -109,7 +109,7 @@ function Label(props: CubeLabelProps, ref) {
     ...otherProps
   } = props;
 
-  let domRef = useDOMRef(ref);
+  let domRef = useObjectRef(ref);
 
   const styles = extractStyles(otherProps, CONTAINER_STYLES);
 

--- a/src/components/overlays/Dialog/Dialog.tsx
+++ b/src/components/overlays/Dialog/Dialog.tsx
@@ -1,6 +1,5 @@
 import { createFocusManager } from '@react-aria/focus';
-import { useDOMRef } from '@react-spectrum/utils';
-import { DOMRef } from '@react-types/shared';
+import { useObjectRef } from '@react-aria/utils';
 import {
   BASE_STYLES,
   BaseProps,
@@ -13,7 +12,7 @@ import {
   Styles,
   tasty,
 } from '@tenphi/tasty';
-import { forwardRef, ReactElement, useEffect, useMemo } from 'react';
+import { forwardRef, ReactElement, Ref, useEffect, useMemo } from 'react';
 import {
   AriaDialogProps,
   DismissButton,
@@ -155,7 +154,7 @@ export interface CubeDialogProps
  */
 export const Dialog = forwardRef(function Dialog(
   props: CubeDialogProps,
-  ref: DOMRef<HTMLDivElement>,
+  ref: Ref<HTMLDivElement>,
 ) {
   const transitionContext = useOpenTransitionContext();
 
@@ -180,7 +179,7 @@ export const Dialog = forwardRef(function Dialog(
 
 const DialogContent = forwardRef(function DialogContent(
   props: CubeDialogProps,
-  ref: DOMRef<HTMLDivElement>,
+  ref: Ref<HTMLDivElement>,
 ) {
   let { type = 'modal', ...contextProps } = useDialogContext();
 
@@ -202,7 +201,7 @@ const DialogContent = forwardRef(function DialogContent(
 
   let formatMessage = useMessageFormatter(intlMessages);
 
-  let domRef = useDOMRef(ref);
+  let domRef = useObjectRef(ref);
   let { dialogProps, titleProps } = useDialog(
     mergeProps(contextProps, props),
     domRef,

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -145,15 +145,20 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
   const syncOverlayRef = useRef<HTMLElement | null>(null);
 
   // Only popover-type Dialogs participate in the "press inside dismisses
-  // me" behaviour: modals/trays/fullscreen Dialogs are persistent workspaces
-  // and buttons inside them should NOT auto-close them.
+  // me" / "peer popover opening dismisses me" behaviours: modals, trays,
+  // fullscreen and panel Dialogs are persistent workspaces and must not be
+  // yanked closed via the EventBus (which would bypass `isDismissable` and
+  // call `state.close()` directly). Non-popover types DO still EMIT
+  // `popover:open`, so opening a modal correctly dismisses peer popovers.
+  const isPopoverFlavored = type === 'popover';
   usePopoverSync({
     menuId: dialogSyncId,
     isOpen: state.isOpen,
     onClose: () => state.close(),
     triggerRef: syncTriggerRef,
     containerRef: syncOverlayRef,
-    dismissOnInnerButtonPress: type === 'popover',
+    dismissOnInnerButtonPress: isPopoverFlavored,
+    closeOnPeerOpen: isPopoverFlavored,
   });
 
   useEffect(() => {

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -19,7 +19,7 @@ import {
 import { OverlayTriggerState, useOverlayTriggerState } from 'react-stately';
 
 import { generateRandomId } from '../../../utils/random';
-import { useCombinedRefs } from '../../../utils/react/index';
+import { useCombinedRefs, useLayoutEffect } from '../../../utils/react/index';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { Modal, Popover, Tray, WithCloseBehavior } from '../Modal';
 
@@ -137,18 +137,23 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
   // inside the branch-specific sub-trees) keeps a single sync registration for
   // the lifetime of the trigger, even when `type` flips between popover and
   // modal at the mobile breakpoint. The refs are then threaded into the
-  // appropriate branch via `useCombinedRefs` so existing positioning /
-  // useOverlayTrigger hooks keep their original ref targets.
+  // appropriate branch so existing positioning / useOverlayTrigger hooks keep
+  // their original ref targets and `usePopoverSync`'s `contains()` check has a
+  // real DOM node to query.
   const dialogSyncId = useMemo(() => generateRandomId(), []);
   const syncTriggerRef = useRef<HTMLElement | null>(null);
   const syncOverlayRef = useRef<HTMLElement | null>(null);
 
+  // Only popover-type Dialogs participate in the "press inside dismisses
+  // me" behaviour: modals/trays/fullscreen Dialogs are persistent workspaces
+  // and buttons inside them should NOT auto-close them.
   usePopoverSync({
     menuId: dialogSyncId,
     isOpen: state.isOpen,
     onClose: () => state.close(),
     triggerRef: syncTriggerRef,
     containerRef: syncOverlayRef,
+    dismissOnInnerButtonPress: type === 'popover',
   });
 
   useEffect(() => {
@@ -187,6 +192,7 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
         shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         syncTriggerRef={syncTriggerRef}
         syncOverlayRef={syncOverlayRef}
+        triggerType={type}
         onClose={onClose}
       />
     );
@@ -260,24 +266,35 @@ function PopoverTrigger(allProps) {
     keepOpenOnScroll,
     syncTriggerRef,
     syncOverlayRef,
+    triggerType,
     ...props
   } = allProps;
 
   let triggerRef = useRef<HTMLButtonElement>(null);
   let overlayRef = useRef<HTMLDivElement>(null);
 
-  // Mirror the (effective) trigger and overlay nodes into the sync refs so
-  // `usePopoverSync` in the parent can perform its nested-popover check. When
-  // an external `targetRef` is provided we mirror that one instead, since the
-  // local triggerRef stays null in that case.
-  let combinedTriggerRef = useCombinedRefs<HTMLElement>(
-    syncTriggerRef,
-    targetRef ?? triggerRef,
-  );
-  let combinedOverlayRef = useCombinedRefs<HTMLElement>(
-    syncOverlayRef,
-    overlayRef,
-  );
+  // Mirror the trigger/overlay DOM nodes into the parent-owned sync refs.
+  //
+  // We deliberately do NOT use `useCombinedRefs` here: that hook returns a
+  // brand new internal ref and propagates to the passed refs via a regular
+  // `useEffect` (post-commit). `useOverlayPosition` below reads
+  // `triggerRef.current` in its own layout effect during the SAME commit, so
+  // if `triggerRef` only receives the DOM node via a delayed effect, the
+  // first measurement sees `null` and the popover positions at the document
+  // origin until something forces a re-measure.
+  //
+  // Keeping `triggerRef`/`overlayRef` as the direct React refs preserves
+  // synchronous assignment for `useOverlayPosition`. The sync refs are only
+  // ever read inside `popover:open` handlers, which fire via setTimeout(0),
+  // so a layout-effect mirror is more than fast enough.
+  useLayoutEffect(() => {
+    if (syncTriggerRef) {
+      syncTriggerRef.current = targetRef?.current ?? triggerRef.current ?? null;
+    }
+    if (syncOverlayRef) {
+      syncOverlayRef.current = overlayRef.current ?? null;
+    }
+  });
 
   let {
     overlayProps: popoverProps,
@@ -310,12 +327,12 @@ function PopoverTrigger(allProps) {
 
   let triggerPropsWithRef = {
     ...triggerProps,
-    ref: targetRef ? undefined : combinedTriggerRef,
+    ref: targetRef ? undefined : triggerRef,
   };
 
   let overlay = (
     <Popover
-      ref={combinedOverlayRef}
+      ref={overlayRef}
       styles={styles}
       hideOnClose={hideOnClose}
       isOpen={state.isOpen}
@@ -345,8 +362,18 @@ function PopoverTrigger(allProps) {
 }
 
 function DialogTriggerBase(props: any) {
-  const ref = useCombinedRefs<HTMLElement>(props.ref, props.syncTriggerRef);
+  const ref = useCombinedRefs<HTMLElement>(props.ref);
   const wasOpenRef = useRef(false);
+
+  // Mirror the press-responder DOM node into the parent's sync trigger ref.
+  // Done via `useLayoutEffect` rather than threading through `useCombinedRefs`
+  // for consistency with `PopoverTrigger` (see comment there) — keeps the
+  // sync-ref population deterministic regardless of branch.
+  useLayoutEffect(() => {
+    if (props.syncTriggerRef) {
+      props.syncTriggerRef.current = ref.current ?? null;
+    }
+  });
 
   let {
     type,
@@ -377,11 +404,21 @@ function DialogTriggerBase(props: any) {
     }
   }, [state.isOpen]);
 
+  // Mark popover-type DialogTrigger children with `data-popover-trigger` so
+  // `Button` / `ItemButton`'s default dismiss-on-press behaviour treats them
+  // as popover triggers (skips the dismiss). Modal/tray/fullscreen children
+  // intentionally stay UNMARKED — when a modal-type DialogTrigger lives
+  // inside a popover footer, pressing it should dismiss the parent popover
+  // (matching the "modal takes over" native UX).
+  const triggerExtraProps =
+    type === 'popover' ? { 'data-popover-trigger': '' } : {};
+
   return (
     <Fragment>
       <PressResponder
         ref={ref}
         {...triggerProps}
+        {...triggerExtraProps}
         isPressed={
           state.isOpen &&
           type !== 'modal' &&

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -1,7 +1,14 @@
 import { PressResponder } from '@react-aria/interactions';
 import { useMediaQuery } from '@react-spectrum/utils';
 import { Styles } from '@tenphi/tasty';
-import { Fragment, ReactElement, RefObject, useEffect, useRef } from 'react';
+import {
+  Fragment,
+  ReactElement,
+  RefObject,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import {
   OverlayTriggerProps,
   Placement,
@@ -11,7 +18,9 @@ import {
 } from 'react-aria';
 import { OverlayTriggerState, useOverlayTriggerState } from 'react-stately';
 
+import { generateRandomId } from '../../../utils/random';
 import { useCombinedRefs } from '../../../utils/react/index';
+import { usePopoverSync } from '../../../utils/react/usePopoverSync';
 import { Modal, Popover, Tray, WithCloseBehavior } from '../Modal';
 
 import { DialogContext } from './context';
@@ -124,6 +133,24 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
 
   wasOpen.current = state.isOpen;
 
+  // Shared identity + refs for `usePopoverSync`. Allocating here (rather than
+  // inside the branch-specific sub-trees) keeps a single sync registration for
+  // the lifetime of the trigger, even when `type` flips between popover and
+  // modal at the mobile breakpoint. The refs are then threaded into the
+  // appropriate branch via `useCombinedRefs` so existing positioning /
+  // useOverlayTrigger hooks keep their original ref targets.
+  const dialogSyncId = useMemo(() => generateRandomId(), []);
+  const syncTriggerRef = useRef<HTMLElement | null>(null);
+  const syncOverlayRef = useRef<HTMLElement | null>(null);
+
+  usePopoverSync({
+    menuId: dialogSyncId,
+    isOpen: state.isOpen,
+    onClose: () => state.close(),
+    triggerRef: syncTriggerRef,
+    containerRef: syncOverlayRef,
+  });
+
   useEffect(() => {
     return () => {
       if (
@@ -158,6 +185,8 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
         isKeyboardDismissDisabled={isKeyboardDismissDisabled}
         hideArrow={hideArrow}
         shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+        syncTriggerRef={syncTriggerRef}
+        syncOverlayRef={syncOverlayRef}
         onClose={onClose}
       />
     );
@@ -171,6 +200,7 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
       case 'modal':
         return (
           <Modal
+            ref={syncOverlayRef}
             hideOnClose={hideOnClose}
             isOpen={state.isOpen}
             isDismissable={isDismissable}
@@ -188,6 +218,7 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
       case 'tray':
         return (
           <Tray
+            ref={syncOverlayRef}
             hideOnClose={hideOnClose}
             isOpen={state.isOpen}
             isKeyboardDismissDisabled={isKeyboardDismissDisabled}
@@ -208,6 +239,7 @@ export function DialogTrigger(props: CubeDialogTriggerProps) {
       trigger={trigger}
       overlay={renderOverlay()}
       hideOnClose={hideOnClose}
+      syncTriggerRef={syncTriggerRef}
       onClose={onClose}
     />
   );
@@ -226,11 +258,26 @@ function PopoverTrigger(allProps) {
     hideOnClose,
     shouldCloseOnInteractOutside,
     keepOpenOnScroll,
+    syncTriggerRef,
+    syncOverlayRef,
     ...props
   } = allProps;
 
   let triggerRef = useRef<HTMLButtonElement>(null);
   let overlayRef = useRef<HTMLDivElement>(null);
+
+  // Mirror the (effective) trigger and overlay nodes into the sync refs so
+  // `usePopoverSync` in the parent can perform its nested-popover check. When
+  // an external `targetRef` is provided we mirror that one instead, since the
+  // local triggerRef stays null in that case.
+  let combinedTriggerRef = useCombinedRefs<HTMLElement>(
+    syncTriggerRef,
+    targetRef ?? triggerRef,
+  );
+  let combinedOverlayRef = useCombinedRefs<HTMLElement>(
+    syncOverlayRef,
+    overlayRef,
+  );
 
   let {
     overlayProps: popoverProps,
@@ -263,12 +310,12 @@ function PopoverTrigger(allProps) {
 
   let triggerPropsWithRef = {
     ...triggerProps,
-    ref: targetRef ? undefined : triggerRef,
+    ref: targetRef ? undefined : combinedTriggerRef,
   };
 
   let overlay = (
     <Popover
-      ref={overlayRef}
+      ref={combinedOverlayRef}
       styles={styles}
       hideOnClose={hideOnClose}
       isOpen={state.isOpen}
@@ -298,7 +345,7 @@ function PopoverTrigger(allProps) {
 }
 
 function DialogTriggerBase(props: any) {
-  const ref = useCombinedRefs<HTMLElement>(props.ref);
+  const ref = useCombinedRefs<HTMLElement>(props.ref, props.syncTriggerRef);
   const wasOpenRef = useRef(false);
 
   let {

--- a/src/components/overlays/Modal/Modal.tsx
+++ b/src/components/overlays/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useDOMRef } from '@react-spectrum/utils';
+import { useObjectRef } from '@react-aria/utils';
 import { BaseProps, Props, Styles, tasty } from '@tenphi/tasty';
 import { forwardRef, ReactNode } from 'react';
 import { useModal, useOverlay, usePreventScroll } from 'react-aria';
@@ -82,7 +82,7 @@ export interface CubeModalProps
 
 function Modal(props: CubeModalProps, ref) {
   let { qa, children, onClose, type, styles, ...otherProps } = props;
-  let domRef = useDOMRef(ref);
+  let domRef = useObjectRef(ref);
 
   let { overlayProps, underlayProps } = useOverlay({ ...props }, domRef);
 

--- a/src/components/overlays/Modal/Tray.tsx
+++ b/src/components/overlays/Modal/Tray.tsx
@@ -1,4 +1,4 @@
-import { useDOMRef } from '@react-spectrum/utils';
+import { useObjectRef } from '@react-aria/utils';
 import { BaseProps, Props, Styles, tasty } from '@tenphi/tasty';
 import { forwardRef, ReactNode } from 'react';
 import {
@@ -82,7 +82,7 @@ function Tray(props: CubeTrayProps, ref) {
     shouldCloseOnInteractOutside,
     ...otherProps
   } = props;
-  let domRef = useDOMRef(ref);
+  let domRef = useObjectRef(ref);
 
   let { overlayProps, underlayProps } = useOverlay(
     { ...props, isDismissable: true, shouldCloseOnInteractOutside },

--- a/src/utils/react/index.ts
+++ b/src/utils/react/index.ts
@@ -11,6 +11,8 @@ export { useViewportSize } from './useViewportSize';
 export { useQaProps } from './useQaProps';
 export { useEventBus, useEventListener, EventBusProvider } from './useEventBus';
 export type { EventBusListener, EventBusContextValue } from './useEventBus';
+export { usePopoverSync, useDismissParentPopover } from './usePopoverSync';
+export type { UsePopoverSyncOptions } from './usePopoverSync';
 export { useControlledFocusVisible } from './useControlledFocusVisible';
 export type { UseControlledFocusVisibleResult } from './useControlledFocusVisible';
 export { RenderCache } from './RenderCache';

--- a/src/utils/react/useEventBus.ts
+++ b/src/utils/react/useEventBus.ts
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
 } from 'react';
 
@@ -96,18 +97,16 @@ export function EventBusProvider({ children }: EventBusProviderProps) {
   );
 
   // Always compute the local contextValue so hook order stays stable, then
-  // pick parent OR local. (`useMemo` keeps the local one stable for any
-  // descendants that DO end up using it.)
+  // pick parent OR local. `useMemo` keeps the local value referentially
+  // stable across renders — every consumer of `EventBusContext` (notably
+  // `useDismissParentPopover` inside every `Button` / `ItemButton`) would
+  // otherwise re-render on every render of this provider.
+  const localContextValue = useMemo<EventBusContextValue>(
+    () => ({ emit, emitSync, on, off }),
+    [emit, emitSync, on, off],
+  );
 
-  const localContextValue = useRef<EventBusContextValue>({
-    emit,
-    emitSync,
-    on,
-    off,
-  });
-  localContextValue.current = { emit, emitSync, on, off };
-
-  const contextValue = parentBus ?? localContextValue.current;
+  const contextValue = parentBus ?? localContextValue;
 
   return React.createElement(
     EventBusContext.Provider,

--- a/src/utils/react/useEventBus.ts
+++ b/src/utils/react/useEventBus.ts
@@ -16,7 +16,7 @@ export interface EventBusContextValue {
   off: <T = any>(event: string, listener: EventBusListener<T>) => void;
 }
 
-const EventBusContext = createContext<EventBusContextValue | null>(null);
+export const EventBusContext = createContext<EventBusContextValue | null>(null);
 
 export interface EventBusProviderProps {
   children: ReactNode;
@@ -37,6 +37,16 @@ export interface EventBusProviderProps {
  * ```
  */
 export function EventBusProvider({ children }: EventBusProviderProps) {
+  // If we're already inside a parent EventBusProvider (e.g. the global Root
+  // one), DO NOT create a fresh bus — that would isolate listeners and
+  // emitters across the boundary. This matters because overlays (Popover,
+  // Modal, Tray) re-wrap their content with our `Provider` from
+  // `provider.tsx`, which transparently nests an EventBusProvider. Cross-
+  // overlay events such as `popover:dismiss-ancestor` (a Button inside a
+  // popover footer dismissing the popover host) only work when both sides
+  // share the same bus.
+  const parentBus = useContext(EventBusContext);
+
   const listeners = useRef<Record<string, EventBusListener[]>>({});
 
   const off = useCallback(
@@ -61,12 +71,14 @@ export function EventBusProvider({ children }: EventBusProviderProps) {
     }
   }, []);
 
-  const emit = useCallback(<T = any>(event: string, data?: T) => {
-    // Use setTimeout to ensure async emission after current render cycle
-    setTimeout(() => {
-      emitSync(event, data);
-    }, 0);
-  }, []);
+  const emit = useCallback(
+    <T = any>(event: string, data?: T) => {
+      setTimeout(() => {
+        emitSync(event, data);
+      }, 0);
+    },
+    [emitSync],
+  );
 
   const on = useCallback(
     <T = any>(event: string, listener: EventBusListener<T>) => {
@@ -83,12 +95,19 @@ export function EventBusProvider({ children }: EventBusProviderProps) {
     [off],
   );
 
-  const contextValue: EventBusContextValue = {
+  // Always compute the local contextValue so hook order stays stable, then
+  // pick parent OR local. (`useMemo` keeps the local one stable for any
+  // descendants that DO end up using it.)
+
+  const localContextValue = useRef<EventBusContextValue>({
     emit,
     emitSync,
     on,
     off,
-  };
+  });
+  localContextValue.current = { emit, emitSync, on, off };
+
+  const contextValue = parentBus ?? localContextValue.current;
 
   return React.createElement(
     EventBusContext.Provider,

--- a/src/utils/react/usePopoverSync.test.tsx
+++ b/src/utils/react/usePopoverSync.test.tsx
@@ -280,6 +280,55 @@ describe('usePopoverSync', () => {
     bTrigger.remove();
   });
 
+  it('closeOnPeerOpen=false: peer popover opening does not close us, but our open still emits to peers (modal scope)', async () => {
+    const closeModal = vi.fn();
+    const closePopover = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ modal, popover }: { modal: boolean; popover: boolean }) => {
+        // Mimic a modal Dialog: emits to dismiss peer popovers, but does NOT
+        // listen for peer popover opens (so it can't be yanked shut bypassing
+        // isDismissable when a popover opens programmatically while it's up).
+        usePopoverSync({
+          menuId: 'modal',
+          isOpen: modal,
+          onClose: closeModal,
+          dismissOnInnerButtonPress: false,
+          closeOnPeerOpen: false,
+        });
+        usePopoverSync({
+          menuId: 'popover',
+          isOpen: popover,
+          onClose: closePopover,
+        });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { modal: false, popover: true },
+      },
+    );
+
+    // Popover opens first.
+    await flushBus();
+    expect(closeModal).not.toHaveBeenCalled();
+    expect(closePopover).not.toHaveBeenCalled();
+
+    // Modal opens. Its emit must close the peer popover (modal "wins").
+    rerender({ modal: true, popover: true });
+    await flushBus();
+    expect(closePopover).toHaveBeenCalledTimes(1);
+    expect(closeModal).not.toHaveBeenCalled();
+
+    // Now the regression: while the modal is up, a peer popover opens
+    // programmatically. The modal must stay open — its onClose must NOT be
+    // called via the popover:open path (that would bypass isDismissable).
+    rerender({ modal: true, popover: false });
+    await flushBus();
+    rerender({ modal: true, popover: true });
+    await flushBus();
+    expect(closeModal).not.toHaveBeenCalled();
+  });
+
   it('enabled=false: no emit and no peer-close', async () => {
     const closeA = vi.fn();
     const closeB = vi.fn();

--- a/src/utils/react/usePopoverSync.test.tsx
+++ b/src/utils/react/usePopoverSync.test.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 
 import { act, renderHook } from '../../test';
 
@@ -97,6 +97,105 @@ describe('usePopoverSync', () => {
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('nested: peer whose trigger lives inside our containerRef does not close us', async () => {
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+
+    // Build the DOM shape that the nesting guard reads. `bTrigger` is rendered
+    // inside `aContainer` to mimic a popover (B) opened from inside another
+    // popover's content (A).
+    const aContainer = document.createElement('div');
+    const aTrigger = document.createElement('button');
+    const bTrigger = document.createElement('button');
+    document.body.append(aContainer, aTrigger);
+    aContainer.append(bTrigger);
+
+    const { rerender } = renderHook(
+      ({ a, b }: { a: boolean; b: boolean }) => {
+        const aTriggerRef = useRef<HTMLElement | null>(aTrigger);
+        const aContainerRef = useRef<HTMLElement | null>(aContainer);
+        const bTriggerRef = useRef<HTMLElement | null>(bTrigger);
+        usePopoverSync({
+          menuId: 'a',
+          isOpen: a,
+          onClose: closeA,
+          triggerRef: aTriggerRef,
+          containerRef: aContainerRef,
+        });
+        usePopoverSync({
+          menuId: 'b',
+          isOpen: b,
+          onClose: closeB,
+          triggerRef: bTriggerRef,
+        });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { a: false, b: false },
+      },
+    );
+
+    rerender({ a: true, b: false });
+    await flushBus();
+    // Opening B: A's listener sees B's trigger inside `aContainer` and stays
+    // open. B opens normally and is unaffected (its own emit is ignored by
+    // identity check).
+    rerender({ a: true, b: true });
+    await flushBus();
+    expect(closeA).not.toHaveBeenCalled();
+    expect(closeB).not.toHaveBeenCalled();
+
+    aTrigger.remove();
+    aContainer.remove();
+  });
+
+  it('non-nested: peer whose trigger lives outside our containerRef closes us', async () => {
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+
+    const aContainer = document.createElement('div');
+    const aTrigger = document.createElement('button');
+    const bTrigger = document.createElement('button');
+    // bTrigger is a sibling of aContainer — explicitly NOT nested.
+    document.body.append(aContainer, aTrigger, bTrigger);
+
+    const { rerender } = renderHook(
+      ({ a, b }: { a: boolean; b: boolean }) => {
+        const aTriggerRef = useRef<HTMLElement | null>(aTrigger);
+        const aContainerRef = useRef<HTMLElement | null>(aContainer);
+        const bTriggerRef = useRef<HTMLElement | null>(bTrigger);
+        usePopoverSync({
+          menuId: 'a',
+          isOpen: a,
+          onClose: closeA,
+          triggerRef: aTriggerRef,
+          containerRef: aContainerRef,
+        });
+        usePopoverSync({
+          menuId: 'b',
+          isOpen: b,
+          onClose: closeB,
+          triggerRef: bTriggerRef,
+        });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { a: false, b: false },
+      },
+    );
+
+    rerender({ a: true, b: false });
+    await flushBus();
+    rerender({ a: true, b: true });
+    await flushBus();
+    expect(closeA).toHaveBeenCalledTimes(1);
+    expect(closeB).not.toHaveBeenCalled();
+
+    aTrigger.remove();
+    aContainer.remove();
+    bTrigger.remove();
   });
 
   it('enabled=false: no emit and no peer-close', async () => {

--- a/src/utils/react/usePopoverSync.test.tsx
+++ b/src/utils/react/usePopoverSync.test.tsx
@@ -151,6 +151,88 @@ describe('usePopoverSync', () => {
     aContainer.remove();
   });
 
+  it('logical nesting across portals: opening a grandchild popover does not close the grandparent', async () => {
+    // Build the shape of 3 nested popovers as the Overlay portal would
+    // produce: each popover container is a sibling of the others (not a
+    // DOM descendant), but each popover's TRIGGER lives inside its
+    // parent's container. This mirrors the SubMenuTrigger story where
+    // popover content is portaled to `document.body`.
+    const aContainer = document.createElement('div');
+    const aTrigger = document.createElement('button');
+    const bContainer = document.createElement('div');
+    const bTrigger = document.createElement('button');
+    const cContainer = document.createElement('div');
+    const cTrigger = document.createElement('button');
+    // a's trigger lives outside any popover; a's container is portaled
+    // alongside it. b's trigger is rendered into a's container; b's
+    // container is portaled separately. Same for c relative to b.
+    document.body.append(aTrigger, aContainer, bContainer, cContainer);
+    aContainer.append(bTrigger);
+    bContainer.append(cTrigger);
+
+    const closeA = vi.fn();
+    const closeB = vi.fn();
+    const closeC = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ a, b, c }: { a: boolean; b: boolean; c: boolean }) => {
+        const aTriggerRef = useRef<HTMLElement | null>(aTrigger);
+        const aContainerRef = useRef<HTMLElement | null>(aContainer);
+        const bTriggerRef = useRef<HTMLElement | null>(bTrigger);
+        const bContainerRef = useRef<HTMLElement | null>(bContainer);
+        const cTriggerRef = useRef<HTMLElement | null>(cTrigger);
+        const cContainerRef = useRef<HTMLElement | null>(cContainer);
+        usePopoverSync({
+          menuId: 'a',
+          isOpen: a,
+          onClose: closeA,
+          triggerRef: aTriggerRef,
+          containerRef: aContainerRef,
+        });
+        usePopoverSync({
+          menuId: 'b',
+          isOpen: b,
+          onClose: closeB,
+          triggerRef: bTriggerRef,
+          containerRef: bContainerRef,
+        });
+        usePopoverSync({
+          menuId: 'c',
+          isOpen: c,
+          onClose: closeC,
+          triggerRef: cTriggerRef,
+          containerRef: cContainerRef,
+        });
+      },
+      {
+        wrapper: HookWrapper,
+        initialProps: { a: false, b: false, c: false },
+      },
+    );
+
+    rerender({ a: true, b: false, c: false });
+    await flushBus();
+    rerender({ a: true, b: true, c: false });
+    await flushBus();
+    expect(closeA).not.toHaveBeenCalled();
+    expect(closeB).not.toHaveBeenCalled();
+
+    // Open c (the grandchild). Without logical-chain traversal, a closes
+    // here because c's trigger lives in b's container (sibling portal),
+    // not directly in a's container — which is the regression we are
+    // guarding against.
+    rerender({ a: true, b: true, c: true });
+    await flushBus();
+    expect(closeA).not.toHaveBeenCalled();
+    expect(closeB).not.toHaveBeenCalled();
+    expect(closeC).not.toHaveBeenCalled();
+
+    aTrigger.remove();
+    aContainer.remove();
+    bContainer.remove();
+    cContainer.remove();
+  });
+
   it('non-nested: peer whose trigger lives outside our containerRef closes us', async () => {
     const closeA = vi.fn();
     const closeB = vi.fn();

--- a/src/utils/react/usePopoverSync.test.tsx
+++ b/src/utils/react/usePopoverSync.test.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useEffect, useRef } from 'react';
 import { act, renderHook } from '../../test';
 
 import { EventBusProvider, useEventBus } from './useEventBus';
-import { usePopoverSync } from './usePopoverSync';
+import { useDismissParentPopover, usePopoverSync } from './usePopoverSync';
 
 const HookWrapper = ({ children }: { children: ReactNode }) => (
   <EventBusProvider>{children}</EventBusProvider>
@@ -228,5 +228,171 @@ describe('usePopoverSync', () => {
     rerender({ a: true, b: true });
     await flushBus();
     expect(closeA).not.toHaveBeenCalled();
+  });
+
+  describe('popover:dismiss-ancestor', () => {
+    it('closes the popover when the dispatching element is inside its containerRef', async () => {
+      const closeA = vi.fn();
+
+      const aContainer = document.createElement('div');
+      const aTrigger = document.createElement('button');
+      const innerButton = document.createElement('button');
+      document.body.append(aContainer, aTrigger);
+      aContainer.append(innerButton);
+
+      const { result } = renderHook(
+        () => {
+          const aTriggerRef = useRef<HTMLElement | null>(aTrigger);
+          const aContainerRef = useRef<HTMLElement | null>(aContainer);
+          usePopoverSync({
+            menuId: 'a',
+            isOpen: true,
+            onClose: closeA,
+            triggerRef: aTriggerRef,
+            containerRef: aContainerRef,
+          });
+          return useDismissParentPopover();
+        },
+        { wrapper: HookWrapper },
+      );
+
+      act(() => {
+        result.current(innerButton);
+      });
+      await flushBus();
+      expect(closeA).toHaveBeenCalledTimes(1);
+
+      aTrigger.remove();
+      aContainer.remove();
+    });
+
+    it('does NOT close the popover when the dispatching element is outside its containerRef', async () => {
+      const closeA = vi.fn();
+
+      const aContainer = document.createElement('div');
+      const aTrigger = document.createElement('button');
+      const outerButton = document.createElement('button');
+      document.body.append(aContainer, aTrigger, outerButton);
+
+      const { result } = renderHook(
+        () => {
+          const aTriggerRef = useRef<HTMLElement | null>(aTrigger);
+          const aContainerRef = useRef<HTMLElement | null>(aContainer);
+          usePopoverSync({
+            menuId: 'a',
+            isOpen: true,
+            onClose: closeA,
+            triggerRef: aTriggerRef,
+            containerRef: aContainerRef,
+          });
+          return useDismissParentPopover();
+        },
+        { wrapper: HookWrapper },
+      );
+
+      act(() => {
+        result.current(outerButton);
+      });
+      await flushBus();
+      expect(closeA).not.toHaveBeenCalled();
+
+      aTrigger.remove();
+      aContainer.remove();
+      outerButton.remove();
+    });
+
+    it('does NOT close when no containerRef is set (host has no way to compute containment)', async () => {
+      const closeA = vi.fn();
+      const somewhere = document.createElement('button');
+      document.body.append(somewhere);
+
+      const { result } = renderHook(
+        () => {
+          usePopoverSync({ menuId: 'a', isOpen: true, onClose: closeA });
+          return useDismissParentPopover();
+        },
+        { wrapper: HookWrapper },
+      );
+
+      act(() => {
+        result.current(somewhere);
+      });
+      await flushBus();
+      expect(closeA).not.toHaveBeenCalled();
+
+      somewhere.remove();
+    });
+
+    it('does NOT close when isOpen=false', async () => {
+      const closeA = vi.fn();
+
+      const aContainer = document.createElement('div');
+      const innerButton = document.createElement('button');
+      document.body.append(aContainer);
+      aContainer.append(innerButton);
+
+      const { result } = renderHook(
+        () => {
+          const aContainerRef = useRef<HTMLElement | null>(aContainer);
+          usePopoverSync({
+            menuId: 'a',
+            isOpen: false,
+            onClose: closeA,
+            containerRef: aContainerRef,
+          });
+          return useDismissParentPopover();
+        },
+        { wrapper: HookWrapper },
+      );
+
+      act(() => {
+        result.current(innerButton);
+      });
+      await flushBus();
+      expect(closeA).not.toHaveBeenCalled();
+
+      aContainer.remove();
+    });
+
+    it('dismissOnInnerButtonPress=false: never closes regardless of containment (modal scope)', async () => {
+      const closeA = vi.fn();
+
+      const aContainer = document.createElement('div');
+      const innerButton = document.createElement('button');
+      document.body.append(aContainer);
+      aContainer.append(innerButton);
+
+      const { result } = renderHook(
+        () => {
+          const aContainerRef = useRef<HTMLElement | null>(aContainer);
+          usePopoverSync({
+            menuId: 'a',
+            isOpen: true,
+            onClose: closeA,
+            containerRef: aContainerRef,
+            dismissOnInnerButtonPress: false,
+          });
+          return useDismissParentPopover();
+        },
+        { wrapper: HookWrapper },
+      );
+
+      act(() => {
+        result.current(innerButton);
+      });
+      await flushBus();
+      expect(closeA).not.toHaveBeenCalled();
+
+      aContainer.remove();
+    });
+
+    it('useDismissParentPopover outside EventBusProvider is a no-op (does not throw)', () => {
+      const { result } = renderHook(() => useDismissParentPopover());
+      // No EventBusProvider in the wrapper; calling the dispatcher should
+      // gracefully degrade rather than crashing the consumer.
+      expect(() =>
+        result.current(document.createElement('button')),
+      ).not.toThrow();
+    });
   });
 });

--- a/src/utils/react/usePopoverSync.ts
+++ b/src/utils/react/usePopoverSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 
 import { useEventBus } from './useEventBus';
 
@@ -15,6 +15,26 @@ export interface UsePopoverSyncOptions {
    * `MenuTrigger`'s `isDummy`). Defaults to `true`.
    */
   enabled?: boolean;
+  /**
+   * Ref to the popover's trigger element. When provided, the element is
+   * included in the `popover:open` emit payload so peers can detect whether
+   * the new opener is nested inside their own overlay (and skip closing in
+   * that case). Optional — omitting it preserves the legacy "always close on
+   * peer open" behaviour.
+   */
+  triggerRef?: RefObject<HTMLElement | null>;
+  /**
+   * Ref to the overlay/container element that hosts this popover's content.
+   * When provided, the listener performs a DOM `contains()` check on incoming
+   * peer triggers: peers whose trigger lives inside this container are
+   * considered nested children and do NOT close us.
+   */
+  containerRef?: RefObject<HTMLElement | null>;
+}
+
+interface PopoverOpenPayload {
+  menuId: string;
+  triggerEl: Element | null;
 }
 
 /**
@@ -45,6 +65,8 @@ export function usePopoverSync({
   isOpen,
   onClose,
   enabled = true,
+  triggerRef,
+  containerRef,
 }: UsePopoverSyncOptions): void {
   const { emit, on } = useEventBus();
 
@@ -58,12 +80,30 @@ export function usePopoverSync({
     onCloseRef.current = onClose;
   }, [onClose]);
 
+  // Track the latest containerRef via a stable ref-of-refs so the listener
+  // never resubscribes when callers pass freshly-created ref wrappers across
+  // renders. Same pattern as `onCloseRef` above — without this the listener's
+  // effect would churn for any caller that doesn't memoize its refs.
+  const containerRefRef = useRef(containerRef);
+  useEffect(() => {
+    containerRefRef.current = containerRef;
+  }, [containerRef]);
+
+  const triggerRefRef = useRef(triggerRef);
+  useEffect(() => {
+    triggerRefRef.current = triggerRef;
+  }, [triggerRef]);
+
   useEffect(() => {
     if (!enabled) return;
-    return on('popover:open', (data: { menuId: string }) => {
-      if (data.menuId !== menuId && isOpenRef.current) {
-        onCloseRef.current();
-      }
+    return on('popover:open', (data: PopoverOpenPayload) => {
+      if (data.menuId === menuId || !isOpenRef.current) return;
+      const container = containerRefRef.current?.current;
+      const triggerEl = data.triggerEl;
+      // Nested-popover guard: if the peer's trigger lives inside our own
+      // overlay, treat the open as a child interaction and stay open.
+      if (container && triggerEl && container.contains(triggerEl)) return;
+      onCloseRef.current();
     });
   }, [on, menuId, enabled]);
 
@@ -75,7 +115,10 @@ export function usePopoverSync({
     }
     if (isOpen && !wasOpenRef.current) {
       wasOpenRef.current = true;
-      emit('popover:open', { menuId });
+      emit<PopoverOpenPayload>('popover:open', {
+        menuId,
+        triggerEl: triggerRefRef.current?.current ?? null,
+      });
     } else if (!isOpen) {
       wasOpenRef.current = false;
     }

--- a/src/utils/react/usePopoverSync.ts
+++ b/src/utils/react/usePopoverSync.ts
@@ -40,6 +40,16 @@ export interface UsePopoverSyncOptions {
    * overlay and is effectively a no-op.
    */
   dismissOnInnerButtonPress?: boolean;
+  /**
+   * Whether this overlay closes when a peer popover opens. Defaults to `true`
+   * (popover semantics — only one popover open at a time). Set to `false` for
+   * modals/trays/fullscreen dialogs so a peer popover opening cannot bypass
+   * the dialog's own `isDismissable` / `onClose` handling and yank it shut.
+   *
+   * The host still EMITS `popover:open` regardless of this flag, so opening a
+   * modal/tray correctly dismisses any peer popover that was open before.
+   */
+  closeOnPeerOpen?: boolean;
 }
 
 interface PopoverOpenPayload {
@@ -150,6 +160,7 @@ export function usePopoverSync({
   triggerRef,
   containerRef,
   dismissOnInnerButtonPress = true,
+  closeOnPeerOpen = true,
 }: UsePopoverSyncOptions): void {
   const { emit, on } = useEventBus();
 
@@ -180,47 +191,52 @@ export function usePopoverSync({
   useEffect(() => {
     if (!enabled) return;
 
-    const offOpen = on('popover:open', (data: PopoverOpenPayload) => {
-      if (data.menuId === menuId || !isOpenRef.current) return;
-      const container = containerRefRef.current?.current ?? null;
-      // Nested-popover guard: stay open when the opening peer's trigger is
-      // a LOGICAL descendant of our overlay. Direct DOM containment only
-      // covers the first level — for grand-child popovers the trigger lives
-      // in a sibling portal, so we walk the registered popover chain back
-      // up via each parent's trigger element. Without this, opening a
-      // third-level `SubMenuTrigger` would close every ancestor menu.
-      if (isLogicalDescendantOf(data.triggerEl, menuId, container)) return;
-      onCloseRef.current();
-    });
+    // `popover:open` listener — gated on `closeOnPeerOpen`. Modals/trays opt
+    // out so a peer popover opening cannot bypass the dialog's
+    // `isDismissable` / `onClose` handling and call `state.close()` directly.
+    // Note: the EMIT side (lower in this hook) still fires regardless, so
+    // opening a modal still correctly dismisses peer popovers.
+    const offOpen = closeOnPeerOpen
+      ? on('popover:open', (data: PopoverOpenPayload) => {
+          if (data.menuId === menuId || !isOpenRef.current) return;
+          const container = containerRefRef.current?.current ?? null;
+          // Nested-popover guard: stay open when the opening peer's trigger is
+          // a LOGICAL descendant of our overlay. Direct DOM containment only
+          // covers the first level — for grand-child popovers the trigger lives
+          // in a sibling portal, so we walk the registered popover chain back
+          // up via each parent's trigger element. Without this, opening a
+          // third-level `SubMenuTrigger` would close every ancestor menu.
+          if (isLogicalDescendantOf(data.triggerEl, menuId, container)) return;
+          onCloseRef.current();
+        })
+      : null;
 
     // `popover:dismiss-ancestor` is emitted by `Button` / `ItemButton` (and any
     // consumer using `useDismissParentPopover`) after their `onPress` runs.
     // Only popover-type overlays subscribe; modals/trays opt out via
     // `dismissOnInnerButtonPress: false` so a Button inside a Dialog content
     // does NOT auto-close the Dialog.
-    if (!dismissOnInnerButtonPress) {
-      return offOpen;
-    }
-
-    const offDismiss = on(
-      'popover:dismiss-ancestor',
-      (data: PopoverDismissAncestorPayload) => {
-        if (!isOpenRef.current) return;
-        const container = containerRefRef.current?.current;
-        const from = data?.from;
-        // Require both a container and an originating element so we can do
-        // the contains-check. Hosts without `containerRef` (e.g.
-        // `use-anchored-menu`, `use-context-menu`) are silently no-op.
-        if (!container || !from) return;
-        if (container.contains(from)) onCloseRef.current();
-      },
-    );
+    const offDismiss = dismissOnInnerButtonPress
+      ? on(
+          'popover:dismiss-ancestor',
+          (data: PopoverDismissAncestorPayload) => {
+            if (!isOpenRef.current) return;
+            const container = containerRefRef.current?.current;
+            const from = data?.from;
+            // Require both a container and an originating element so we can do
+            // the contains-check. Hosts without `containerRef` (e.g.
+            // `use-anchored-menu`, `use-context-menu`) are silently no-op.
+            if (!container || !from) return;
+            if (container.contains(from)) onCloseRef.current();
+          },
+        )
+      : null;
 
     return () => {
-      offOpen();
-      offDismiss();
+      offOpen?.();
+      offDismiss?.();
     };
-  }, [on, menuId, enabled, dismissOnInnerButtonPress]);
+  }, [on, menuId, enabled, dismissOnInnerButtonPress, closeOnPeerOpen]);
 
   const wasOpenRef = useRef(false);
   useEffect(() => {

--- a/src/utils/react/usePopoverSync.ts
+++ b/src/utils/react/usePopoverSync.ts
@@ -52,6 +52,73 @@ interface PopoverDismissAncestorPayload {
   from: Element | null;
 }
 
+interface PopoverRegistryEntry {
+  getContainerEl: () => Element | null;
+  getTriggerEl: () => Element | null;
+}
+
+/**
+ * Module-level registry of currently open popovers. Lets us resolve the
+ * LOGICAL parent of an arbitrary element across portal boundaries.
+ *
+ * Popover content is portaled to a shared root (`document.body` by default —
+ * see `Overlay.tsx`), so a grandchild popover's trigger lives inside a
+ * sibling portal rather than physically inside its grandparent's container.
+ * A naive `container.contains(triggerEl)` check therefore misses the
+ * relationship and closes the grandparent — the bug that surfaces with 3+
+ * levels of `SubMenuTrigger` nesting.
+ *
+ * The registry stores closures over the host's refs so reads always see the
+ * latest `.current` value without forcing a re-register per render.
+ */
+const openPopovers = new Map<string, PopoverRegistryEntry>();
+
+/**
+ * Find the open popover whose container directly contains `target`. Returns
+ * `null` for elements that live outside every registered popover (e.g. a
+ * top-level trigger button rendered next to its overlay root).
+ */
+function findOwningPopover(
+  target: Element | null,
+): [string, PopoverRegistryEntry] | null {
+  if (!target) return null;
+  for (const entry of openPopovers) {
+    if (entry[1].getContainerEl()?.contains(target)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns `true` when `target` is nested inside the overlay identified by
+ * `ancestorMenuId` — either as a direct DOM descendant of `ancestorContainer`
+ * or as a descendant of a chain of popovers whose triggers eventually land
+ * inside it. Used by `popover:open` peers to avoid closing themselves when a
+ * grand-child overlay opens through a portal.
+ */
+function isLogicalDescendantOf(
+  target: Element | null,
+  ancestorMenuId: string,
+  ancestorContainer: Element | null,
+): boolean {
+  if (ancestorContainer && target && ancestorContainer.contains(target)) {
+    return true;
+  }
+  let cur: Element | null = target;
+  const visited = new Set<string>();
+  while (cur) {
+    const owner = findOwningPopover(cur);
+    if (!owner) return false;
+    const [id, entry] = owner;
+    if (visited.has(id)) return false;
+    visited.add(id);
+    if (id === ancestorMenuId) return true;
+    cur = entry.getTriggerEl();
+  }
+  return false;
+}
+
 /**
  * Coordinates the "only one popover open at a time" invariant via the EventBus.
  *
@@ -115,11 +182,14 @@ export function usePopoverSync({
 
     const offOpen = on('popover:open', (data: PopoverOpenPayload) => {
       if (data.menuId === menuId || !isOpenRef.current) return;
-      const container = containerRefRef.current?.current;
-      const triggerEl = data.triggerEl;
-      // Nested-popover guard: if the peer's trigger lives inside our own
-      // overlay, treat the open as a child interaction and stay open.
-      if (container && triggerEl && container.contains(triggerEl)) return;
+      const container = containerRefRef.current?.current ?? null;
+      // Nested-popover guard: stay open when the opening peer's trigger is
+      // a LOGICAL descendant of our overlay. Direct DOM containment only
+      // covers the first level — for grand-child popovers the trigger lives
+      // in a sibling portal, so we walk the registered popover chain back
+      // up via each parent's trigger element. Without this, opening a
+      // third-level `SubMenuTrigger` would close every ancestor menu.
+      if (isLogicalDescendantOf(data.triggerEl, menuId, container)) return;
       onCloseRef.current();
     });
 
@@ -155,19 +225,39 @@ export function usePopoverSync({
   const wasOpenRef = useRef(false);
   useEffect(() => {
     if (!enabled) {
+      if (wasOpenRef.current) {
+        openPopovers.delete(menuId);
+      }
       wasOpenRef.current = false;
       return;
     }
     if (isOpen && !wasOpenRef.current) {
       wasOpenRef.current = true;
+      // Register BEFORE emitting so peers' listeners (deferred via the
+      // bus's `setTimeout(0)`) can already see us in the registry when
+      // they walk the logical chain.
+      openPopovers.set(menuId, {
+        getContainerEl: () => containerRefRef.current?.current ?? null,
+        getTriggerEl: () => triggerRefRef.current?.current ?? null,
+      });
       emit<PopoverOpenPayload>('popover:open', {
         menuId,
         triggerEl: triggerRefRef.current?.current ?? null,
       });
-    } else if (!isOpen) {
+    } else if (!isOpen && wasOpenRef.current) {
       wasOpenRef.current = false;
+      openPopovers.delete(menuId);
     }
   }, [isOpen, emit, menuId, enabled]);
+
+  // Final cleanup on unmount: covers the case where a host unmounts while
+  // still flagged open (e.g. a parent unmount tears down a child popover
+  // before its close transition runs).
+  useEffect(() => {
+    return () => {
+      openPopovers.delete(menuId);
+    };
+  }, [menuId]);
 }
 
 /**

--- a/src/utils/react/usePopoverSync.ts
+++ b/src/utils/react/usePopoverSync.ts
@@ -1,6 +1,6 @@
-import { RefObject, useEffect, useRef } from 'react';
+import { RefObject, useCallback, useContext, useEffect, useRef } from 'react';
 
-import { useEventBus } from './useEventBus';
+import { EventBusContext, useEventBus } from './useEventBus';
 
 export interface UsePopoverSyncOptions {
   /** Stable identifier for this popover instance (typically a generateRandomId() memo). */
@@ -30,11 +30,26 @@ export interface UsePopoverSyncOptions {
    * considered nested children and do NOT close us.
    */
   containerRef?: RefObject<HTMLElement | null>;
+  /**
+   * Whether this overlay closes when a Button/ItemButton inside its container
+   * is pressed. Defaults to `true` (popover semantics — popovers are transient
+   * surfaces and any action inside them should dismiss them). Set to `false`
+   * for modals/trays/fullscreen dialogs — buttons inside a Dialog should not
+   * auto-close it. Requires `containerRef` to be set; without it the listener
+   * has no way to determine whether the dispatching button is "inside" this
+   * overlay and is effectively a no-op.
+   */
+  dismissOnInnerButtonPress?: boolean;
 }
 
 interface PopoverOpenPayload {
   menuId: string;
   triggerEl: Element | null;
+}
+
+interface PopoverDismissAncestorPayload {
+  /** The DOM node of the button that requested the dismiss. */
+  from: Element | null;
 }
 
 /**
@@ -67,6 +82,7 @@ export function usePopoverSync({
   enabled = true,
   triggerRef,
   containerRef,
+  dismissOnInnerButtonPress = true,
 }: UsePopoverSyncOptions): void {
   const { emit, on } = useEventBus();
 
@@ -96,7 +112,8 @@ export function usePopoverSync({
 
   useEffect(() => {
     if (!enabled) return;
-    return on('popover:open', (data: PopoverOpenPayload) => {
+
+    const offOpen = on('popover:open', (data: PopoverOpenPayload) => {
       if (data.menuId === menuId || !isOpenRef.current) return;
       const container = containerRefRef.current?.current;
       const triggerEl = data.triggerEl;
@@ -105,7 +122,35 @@ export function usePopoverSync({
       if (container && triggerEl && container.contains(triggerEl)) return;
       onCloseRef.current();
     });
-  }, [on, menuId, enabled]);
+
+    // `popover:dismiss-ancestor` is emitted by `Button` / `ItemButton` (and any
+    // consumer using `useDismissParentPopover`) after their `onPress` runs.
+    // Only popover-type overlays subscribe; modals/trays opt out via
+    // `dismissOnInnerButtonPress: false` so a Button inside a Dialog content
+    // does NOT auto-close the Dialog.
+    if (!dismissOnInnerButtonPress) {
+      return offOpen;
+    }
+
+    const offDismiss = on(
+      'popover:dismiss-ancestor',
+      (data: PopoverDismissAncestorPayload) => {
+        if (!isOpenRef.current) return;
+        const container = containerRefRef.current?.current;
+        const from = data?.from;
+        // Require both a container and an originating element so we can do
+        // the contains-check. Hosts without `containerRef` (e.g.
+        // `use-anchored-menu`, `use-context-menu`) are silently no-op.
+        if (!container || !from) return;
+        if (container.contains(from)) onCloseRef.current();
+      },
+    );
+
+    return () => {
+      offOpen();
+      offDismiss();
+    };
+  }, [on, menuId, enabled, dismissOnInnerButtonPress]);
 
   const wasOpenRef = useRef(false);
   useEffect(() => {
@@ -123,4 +168,46 @@ export function usePopoverSync({
       wasOpenRef.current = false;
     }
   }, [isOpen, emit, menuId, enabled]);
+}
+
+/**
+ * Hook that returns a dispatcher to close the popover that contains a given
+ * DOM element. Used by `Button` / `ItemButton` to implement the default
+ * "press inside a popover closes the popover" behaviour. Custom (non-Cube)
+ * interactive controls can call this directly:
+ *
+ * ```tsx
+ * const dismiss = useDismissParentPopover();
+ * <MyCustomPressable onPress={(e) => { doThing(); dismiss(e.currentTarget); }} />
+ * ```
+ *
+ * The actual dismiss is dispatched through the EventBus, which defers via
+ * `setTimeout(0)` — so the user's synchronous handler (and any React state
+ * updates it triggers) flushes BEFORE the popover closes. This is critical
+ * for the "open a hoisted modal from a popover footer" case: the modal
+ * mounts first, then the popover closes.
+ *
+ * Only popover-type containers (those that pass `dismissOnInnerButtonPress`
+ * as `true`, the default) react to the event. Modal/tray/fullscreen Dialog
+ * containers explicitly opt out so a Button inside their content does not
+ * auto-close them.
+ *
+ * When called outside an `EventBusProvider` (e.g. in unit tests that render
+ * a Button without wrapping in `<Root>`), the returned function is a no-op —
+ * the dismiss flow gracefully degrades rather than throwing.
+ */
+export function useDismissParentPopover() {
+  // Read context defensively: `Button` / `ItemButton` use this hook
+  // unconditionally, but tests (and standalone usages outside `<Root>`) may
+  // mount them without an `EventBusProvider`. A throw would crash every
+  // Button render in those cases.
+  const bus = useContext(EventBusContext);
+  const emit = bus?.emit;
+  return useCallback(
+    (from: Element | null) => {
+      if (!from || !emit) return;
+      emit<PopoverDismissAncestorPayload>('popover:dismiss-ancestor', { from });
+    },
+    [emit],
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Breaking ref API plus default popover-close on button press requires `data-popover-keep` for existing toggles; overlay/EventBus changes affect many pickers and nested dialogs.
> 
> **Overview**
> **Popover sync and overlay behavior** are reworked so transient popovers behave predictably while modals/trays stay stable. `Button` and `ItemButton` now **close the hosting popover after `onPress` by default** (via deferred `popover:dismiss-ancestor` on the EventBus), with opt-outs through `data-popover-keep`, automatic `data-popover-trigger` on popover-type triggers, and exported `useDismissParentPopover()`. `DialogTrigger` only marks **popover** children as triggers so a **modal** opener inside a `FilterPicker` footer dismisses the picker and hands off to the modal.
> 
> `usePopoverSync` gains **`dismissOnInnerButtonPress`** and **`closeOnPeerOpen`** (modals opt out of listening but still emit), **`triggerRef` / `containerRef`** for containment checks, and a **logical open-popover registry** so deeply nested menus (portaled siblings) do not close ancestors. Nested **`EventBusProvider`** instances no longer shadow the root bus. **`FilterPicker` / `Picker`** drop duplicate sync hooks in favor of their inner popover `DialogTrigger`; **`Select` / `ComboBox` / menus** pass refs into sync.
> 
> **Breaking:** forwarded refs on **`Modal`, `Tray`, `Dialog`, `Form`, `Menu`, `CommandMenu`, `MenuTrigger`, groups, `Label`** now point at the **DOM node** (`useObjectRef` instead of `useDOMRef` / `UNSAFE_getDOMNode()`). Apps using `ref.current?.UNSAFE_getDOMNode()` on those components must use `ref.current` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ea5e35e2045e36139bb3ed1b439db26af98328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->