### PR TITLE
fix(ListBox): add bottom spacing for last item in reorderable mode

### DIFF
--- a/.changeset/listbox-reorderable-bottom-spacing.md
+++ b/.changeset/listbox-reorderable-bottom-spacing.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+`ListBox`: fix missing bottom spacing for the last item in `isReorderable` mode.

--- a/src/components/fields/ListBox/ListBox.stories.tsx
+++ b/src/components/fields/ListBox/ListBox.stories.tsx
@@ -1595,8 +1595,6 @@ export const Reorderable: StoryObj = {
       { key: 'retention', label: 'Retention' },
       { key: 'churn', label: 'Churn Rate' },
       { key: 'ltv', label: 'Lifetime Value' },
-      { key: 'arpu', label: 'ARPU' },
-      { key: 'mrr', label: 'MRR' },
     ];
 
     const [keyOrder, setKeyOrder] = useState<Key[]>(

--- a/src/components/fields/ListBox/ListBox.tsx
+++ b/src/components/fields/ListBox/ListBox.tsx
@@ -139,6 +139,7 @@ const ListBoxItem = tasty(Item, {
     margin: {
       '': '0 0 1bw 0',
       ':last-of-type': '0',
+      'draggable & :last-of-type': '0 0 .5x 0',
       all: '.5x',
     },
     Icon: {


### PR DESCRIPTION
### Describe changes

`ListBox`: fix missing bottom spacing for the last item in `isReorderable` mode.

<img width="313" height="351" alt="Снимок экрана — 2026-05-27 в 17 37 13" src="https://github.com/user-attachments/assets/a16daf03-8939-4394-84eb-393c670e2a6d" />
<img width="291" height="516" alt="Снимок экрана — 2026-05-27 в 17 37 59" src="https://github.com/user-attachments/assets/87eca979-2895-408c-a61b-112f6344d122" />


##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single margin style override in ListBoxItem; no behavior, API, or selection/DnD logic changes.
> 
> **Overview**
> Fixes a **layout bug** in `ListBox` when **`isReorderable`** is on: the last row had no bottom margin because `:last-of-type` zeroed margins for every list.
> 
> **`ListBoxItem`** now applies **`0 0 .5x 0`** under **`draggable & :last-of-type`**, so the final reorderable row keeps spacing consistent with other items. A **patch** changeset documents the fix; the **Reorderable** story drops two demo rows (story-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e987024e45f544bc026c191841bd0c1c3c23fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->