### PR TITLE
fix(DialogTrigger): popover sync fix

### DIFF
--- a/.changeset/dialog-trigger-popover-sync.md
+++ b/.changeset/dialog-trigger-popover-sync.md
@@ -1,0 +1,12 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+**Fix:** A `DialogTrigger type="popover"` no longer swallows the outside click
+that opens another popover. Previously, while a popover Dialog was open, a
+single click on a sibling popover trigger was consumed and that trigger's
+popover would not open. The popover branch now uses the same
+`shouldCloseOnInteractOutside` predicate as `Select`, `ComboBox`, and
+`MenuTrigger`, letting clicks on other popover triggers (and
+`data-popover-dismiss` controls) through so `usePopoverSync` can hand off
+between popovers correctly.

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -761,23 +761,6 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
         isOpen={isPopoverOpen}
         containerPadding={containerPadding}
         shouldFlip={shouldFlip}
-        shouldCloseOnInteractOutside={(el) => {
-          const menuTriggerEl = el.closest('[data-popover-trigger]');
-          if (!menuTriggerEl) {
-            // Plain interactive controls (Button, ItemButton) opt in via
-            // `data-popover-dismiss` to dismiss us without losing their click
-            // to useOverlay's stopPropagation. Schedule the close after the
-            // click finishes so the button's onPress runs first.
-            if (el.closest('[data-popover-dismiss]')) {
-              setTimeout(() => handleOpenChange(false), 0);
-              return false;
-            }
-            return true;
-          }
-          if (menuTriggerEl === triggerRef?.current?.UNSAFE_getDOMNode())
-            return true;
-          return false;
-        }}
         onOpenChange={handleOpenChange}
       >
         {triggerElement}

--- a/src/components/fields/Picker/Picker.tsx
+++ b/src/components/fields/Picker/Picker.tsx
@@ -678,23 +678,6 @@ export const Picker = forwardRef(function Picker<T extends object>(
         isOpen={isPopoverOpen}
         containerPadding={containerPadding}
         shouldFlip={shouldFlip}
-        shouldCloseOnInteractOutside={(el) => {
-          const menuTriggerEl = el.closest('[data-popover-trigger]');
-          if (!menuTriggerEl) {
-            // Plain interactive controls (Button, ItemButton) opt in via
-            // `data-popover-dismiss` to dismiss us without losing their click
-            // to useOverlay's stopPropagation. Schedule the close after the
-            // click finishes so the button's onPress runs first.
-            if (el.closest('[data-popover-dismiss]')) {
-              setTimeout(() => handleOpenChange(false), 0);
-              return false;
-            }
-            return true;
-          }
-          if (menuTriggerEl === triggerRef?.current?.UNSAFE_getDOMNode())
-            return true;
-          return false;
-        }}
         onOpenChange={handleOpenChange}
       >
         {triggerElement}

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-aria';
 import { OverlayTriggerState, useOverlayTriggerState } from 'react-stately';
 
+import { useEvent } from '../../../_internal';
 import { generateRandomId } from '../../../utils/random';
 import { useCombinedRefs, useLayoutEffect } from '../../../utils/react/index';
 import { usePopoverSync } from '../../../utils/react/usePopoverSync';
@@ -335,6 +336,37 @@ function PopoverTrigger(allProps) {
     ref: targetRef ? undefined : triggerRef,
   };
 
+  // Mirror the Select/ComboBox/MenuTrigger pattern: when an outside click lands
+  // on ANOTHER popover trigger, return `false` so react-aria's `useOverlay`
+  // does NOT `stopPropagation()` the click. The click then reaches that trigger,
+  // its popover opens, and `usePopoverSync` closes this one via the EventBus.
+  // Without this, react-aria swallows every outside click and a single click on
+  // a sibling trigger can't open it while this popover is open.
+  const resolveShouldCloseOnInteractOutside = useEvent(
+    (el: Element): boolean => {
+      const popoverTriggerEl = el.closest('[data-popover-trigger]');
+      if (!popoverTriggerEl) {
+        // Plain interactive controls (Button, ItemButton) opt in via
+        // `data-popover-dismiss`. Schedule the close after the click finishes so
+        // the control's `onPress` runs first instead of losing the click to
+        // useOverlay's stopPropagation.
+        if (el.closest('[data-popover-dismiss]')) {
+          setTimeout(() => state.close(), 0);
+          return false;
+        }
+        return shouldCloseOnInteractOutside
+          ? shouldCloseOnInteractOutside(el)
+          : true;
+      }
+      // Clicking our own trigger again should dismiss us.
+      const ownTrigger = targetRef?.current ?? triggerRef.current;
+      if (popoverTriggerEl === ownTrigger || ownTrigger?.contains(el))
+        return true;
+      // Another popover's trigger: let the click through so it can open.
+      return false;
+    },
+  );
+
   let overlay = (
     <Popover
       ref={overlayRef}
@@ -346,7 +378,7 @@ function PopoverTrigger(allProps) {
       arrowProps={arrowProps}
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}
       hideArrow={hideArrow}
-      shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+      shouldCloseOnInteractOutside={resolveShouldCloseOnInteractOutside}
       onClose={onClose}
     >
       {typeof content === 'function' ? content(state.close) : content}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared overlay dismiss logic used by all popover DialogTriggers; behavior change is intentional but affects every popover consumer, not just pickers.
> 
> **Overview**
> Fixes **popover handoff** when one `DialogTrigger type="popover"` is already open: a single click on another `[data-popover-trigger]` no longer gets swallowed by react-aria’s outside-interaction handling, so the sibling can open and **`usePopoverSync`** can close the previous overlay.
> 
> **`DialogTrigger`**’s popover path now applies the same **`shouldCloseOnInteractOutside`** rules as **Select**, **ComboBox**, and **MenuTrigger**—return `false` for another popover trigger (let the click through), handle **`data-popover-dismiss`** with a deferred close, and still honor an optional consumer predicate. **`FilterPicker`** and **`Picker`** drop their duplicated inline handlers and rely on this shared behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91da8652f3cb50307ec5dd357103adacdd2b7b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->