### PR TITLE
fix(Disclosure): prevent trigger closing popover

### DIFF
--- a/.changeset/angry-camels-help.md
+++ b/.changeset/angry-camels-help.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Prevent Disclosure.Trigger closing the parent popover.

--- a/src/components/content/Disclosure/Disclosure.tsx
+++ b/src/components/content/Disclosure/Disclosure.tsx
@@ -223,6 +223,7 @@ const TriggerIcon = tasty(RightIcon, {
 const StyledTrigger = tasty(ItemButton, {
   qa: 'DisclosureTrigger',
   type: 'header',
+  'data-popover-keep': true,
   styles: {
     radius: {
       '': '1r',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single attribute on the disclosure trigger; aligns with documented popover opt-out behavior and does not change auth, data, or core overlay logic.
> 
> **Overview**
> **Disclosure triggers inside popovers** no longer dismiss the enclosing popover when the header is pressed.
> 
> The styled `Disclosure.Trigger` (`ItemButton`) now sets **`data-popover-keep`**, matching the existing opt-out used by `Button` / `ItemButton` so expand/collapse still runs without closing overlay surfaces (pickers, menus, etc.). Patch release noted in changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd19d5a70632688ce76a89295d2b0bc4c26c0472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->