### PR TITLE
fix(Menu): submenu trigger

### DIFF
--- a/.changeset/flat-birds-juggle.md
+++ b/.changeset/flat-birds-juggle.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix submenu trigger behavior inside menus triggered by useAnchoredMenu and useContextMenu.

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -4,6 +4,7 @@ import { useIsMobileDevice } from '@react-spectrum/utils';
 import {
   forwardRef,
   Fragment,
+  MutableRefObject,
   ReactElement,
   Ref,
   useEffect,
@@ -42,6 +43,14 @@ export type CubeMenuTriggerProps = AriaMenuTriggerProps &
     closeOnSelect?: boolean;
     isDummy?: boolean;
     /**
+     * External ref to the popover container element. When provided, it is
+     * aliased to the internal `menuPopoverRef`, letting consumers (e.g.
+     * `useAnchoredMenu` / `useContextMenu`) feed the popover container into
+     * their own `usePopoverSync` so the nested-popover guard can recognize
+     * submenus opened inside this menu. Optional.
+     */
+    popoverRef?: MutableRefObject<HTMLDivElement | null>;
+    /**
      * Overlay variant to use on mobile screens. Defaults to `'popover'`, which
      * keeps the desktop overlay even on small viewports. Pass `'tray'` to opt
      * into the bottom-sheet `Tray` overlay on mobile (the previous implicit
@@ -51,7 +60,8 @@ export type CubeMenuTriggerProps = AriaMenuTriggerProps &
   };
 
 function MenuTrigger(props: CubeMenuTriggerProps, ref: Ref<HTMLElement>) {
-  const menuPopoverRef = useRef<HTMLDivElement>(null);
+  const internalPopoverRef = useRef<HTMLDivElement>(null);
+  const menuPopoverRef = props.popoverRef ?? internalPopoverRef;
   const triggerRef = useRef<HTMLElement>(null);
   const domRef = useObjectRef(ref);
   const menuTriggerRef = props.targetRef || domRef || triggerRef;

--- a/src/components/actions/use-anchored-menu.test.tsx
+++ b/src/components/actions/use-anchored-menu.test.tsx
@@ -1,0 +1,134 @@
+// NOTE: Type checking is disabled in this test file to prevent
+// noisy errors from complex generic typings that do not affect runtime behaviour.
+import { act, renderWithRoot, userEvent, waitFor } from '../../test';
+
+import { Menu } from './Menu';
+import { useAnchoredMenu } from './use-anchored-menu';
+
+vi.mock('../../_internal/hooks/use-warn');
+
+describe('useAnchoredMenu', () => {
+  const TestMenuComponent = ({
+    onAction,
+  }: {
+    onAction?: (key: string) => void;
+  }) => (
+    <Menu onAction={onAction}>
+      <Menu.Item key="edit">Edit</Menu.Item>
+      <Menu.Item key="delete">Delete</Menu.Item>
+    </Menu>
+  );
+
+  // Menu with a SubMenuTrigger nested inside. Hovering the submenu trigger must
+  // NOT close the parent menu.
+  const TestSubMenuComponent = ({
+    onAction,
+  }: {
+    onAction?: (key: string) => void;
+  }) => (
+    <Menu onAction={onAction}>
+      <Menu.Item key="edit">Edit</Menu.Item>
+      <Menu.SubMenuTrigger>
+        <Menu.Item key="more">More</Menu.Item>
+        <Menu onAction={onAction}>
+          <Menu.Item key="nested-1">Nested 1</Menu.Item>
+          <Menu.Item key="nested-2">Nested 2</Menu.Item>
+        </Menu>
+      </Menu.SubMenuTrigger>
+    </Menu>
+  );
+
+  const TestWrapper = ({
+    Component,
+    defaultTriggerProps = {},
+    defaultMenuProps = {},
+    componentProps = {},
+  }: {
+    Component: any;
+    defaultTriggerProps?: any;
+    defaultMenuProps?: any;
+    componentProps?: any;
+  }) => {
+    const { anchorRef, open, rendered } = useAnchoredMenu(
+      Component,
+      defaultTriggerProps,
+      defaultMenuProps,
+    );
+
+    return (
+      <div>
+        <button
+          ref={anchorRef as React.RefObject<HTMLButtonElement>}
+          data-qa="Trigger"
+          onClick={() => open(componentProps)}
+        >
+          Open Menu
+        </button>
+        {rendered}
+      </div>
+    );
+  };
+
+  it('opens the menu with the provided component', async () => {
+    const onAction = vi.fn();
+
+    const { getByTestId, getByRole, getByText } = renderWithRoot(
+      <TestWrapper
+        Component={TestMenuComponent}
+        defaultMenuProps={{ onAction }}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.click(getByTestId('Trigger'));
+    });
+
+    await waitFor(() => {
+      expect(getByRole('menu')).toBeInTheDocument();
+    });
+
+    expect(getByText('Edit')).toBeInTheDocument();
+    expect(getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('keeps the anchored menu open when a nested submenu opens on hover', async () => {
+    const onAction = vi.fn();
+
+    const { getByTestId, getByText, queryByText } = renderWithRoot(
+      <TestWrapper
+        Component={TestSubMenuComponent}
+        defaultMenuProps={{ onAction }}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.click(getByTestId('Trigger'));
+    });
+
+    await waitFor(() => {
+      expect(getByText('More')).toBeInTheDocument();
+    });
+
+    // Wait for the submenu trigger to be wired up.
+    await waitFor(() => {
+      const moreItem = getByText('More').closest('li');
+      expect(moreItem).toHaveAttribute('data-has-submenu', 'true');
+    });
+
+    // Hover the submenu trigger to open the nested submenu.
+    await userEvent.hover(getByText('More'));
+
+    await waitFor(
+      () => {
+        expect(getByText('Nested 1')).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+
+    // The parent menu must still be open — the nested submenu opening must not
+    // have triggered `usePopoverSync`'s peer-close.
+    expect(queryByText('Edit')).toBeInTheDocument();
+    expect(queryByText('More')).toBeInTheDocument();
+    expect(getByText('Nested 2')).toBeInTheDocument();
+  });
+});

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -142,13 +142,13 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
 
     return (
       <MenuTrigger
+        placement="bottom start"
+        {...mergeProps(defaultTriggerProps, triggerProps || undefined)}
         isDummy
         isOpen={isOpen}
         targetRef={anchorRef}
         popoverRef={popoverRef}
-        placement="bottom start"
         onOpenChange={setIsOpen}
-        {...mergeProps(defaultTriggerProps, triggerProps || undefined)}
       >
         <VisuallyHidden>
           <Pressable>

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -68,6 +68,7 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   const [componentProps, setComponentProps] = useState<P | null>(null);
   const [triggerProps, setTriggerProps] = useState<T | null>(null);
   const anchorRef = useRef<HTMLElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const setupRef = useRef(false);
 
   useEffect(() => {
@@ -83,17 +84,18 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
-  // `containerRef` is intentionally omitted: the underlying `MenuTrigger` is
-  // `isDummy`, so its own popover container ref isn't reachable from here.
-  // Passing `triggerRef` is enough to let peers (e.g. a `DialogTrigger`
-  // opened inside the menu's content) identify themselves as nested and stay
-  // open — the menu's own `MenuTrigger` already maintains its container ref
-  // via its non-dummy usage elsewhere; here the dummy proxies a real one.
+  // Feed both the anchor (`triggerRef`) and the popover container
+  // (`containerRef`) into the sync. The container ref is shared with the
+  // rendered `MenuTrigger` via its `popoverRef` prop — the dummy `MenuTrigger`
+  // opts out of `usePopoverSync` (`enabled: !isDummy`), so without this the
+  // nested-popover guard would have no container to match against and a
+  // `SubMenuTrigger` opened inside this menu would close the whole menu.
   usePopoverSync({
     menuId,
     isOpen,
     onClose: () => setIsOpen(false),
     triggerRef: anchorRef,
+    containerRef: popoverRef,
   });
 
   function setupCheck() {
@@ -143,6 +145,7 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
         isDummy
         isOpen={isOpen}
         targetRef={anchorRef}
+        popoverRef={popoverRef}
         placement="bottom start"
         onOpenChange={setIsOpen}
         {...mergeProps(defaultTriggerProps, triggerProps || undefined)}

--- a/src/components/actions/use-context-menu.test.tsx
+++ b/src/components/actions/use-context-menu.test.tsx
@@ -38,6 +38,25 @@ describe('useContextMenu', () => {
     </Menu>
   );
 
+  // Test component with a SubMenuTrigger nested inside the menu. Hovering the
+  // submenu trigger must NOT close the parent context menu.
+  const TestSubMenuComponent = ({
+    onAction,
+  }: {
+    onAction?: (key: string) => void;
+  }) => (
+    <Menu onAction={onAction}>
+      <Menu.Item key="edit">Edit</Menu.Item>
+      <Menu.SubMenuTrigger>
+        <Menu.Item key="more">More</Menu.Item>
+        <Menu onAction={onAction}>
+          <Menu.Item key="nested-1">Nested 1</Menu.Item>
+          <Menu.Item key="nested-2">Nested 2</Menu.Item>
+        </Menu>
+      </Menu.SubMenuTrigger>
+    </Menu>
+  );
+
   // Test component that uses the hook with CommandMenu
   const TestCommandMenuComponent = ({
     onAction,
@@ -947,5 +966,49 @@ describe('useContextMenu', () => {
     });
 
     expect(onAction).toHaveBeenCalledWith('edit');
+  });
+
+  it('keeps the context menu open when a nested submenu opens on hover', async () => {
+    const onAction = vi.fn();
+
+    const { getByTestId, getByText, queryByText } = renderWithRoot(
+      <TestWrapper
+        Component={TestSubMenuComponent}
+        defaultMenuProps={{ onAction }}
+      />,
+    );
+
+    const trigger = getByTestId('Trigger');
+
+    // Open the context menu.
+    await act(async () => {
+      await userEvent.click(trigger);
+    });
+
+    await waitFor(() => {
+      expect(getByText('More')).toBeInTheDocument();
+    });
+
+    // Wait for the submenu trigger to be wired up.
+    await waitFor(() => {
+      const moreItem = getByText('More').closest('li');
+      expect(moreItem).toHaveAttribute('data-has-submenu', 'true');
+    });
+
+    // Hover the submenu trigger to open the nested submenu.
+    await userEvent.hover(getByText('More'));
+
+    await waitFor(
+      () => {
+        expect(getByText('Nested 1')).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+
+    // The parent context menu must still be open — the nested submenu opening
+    // must not have triggered `usePopoverSync`'s peer-close.
+    expect(queryByText('Edit')).toBeInTheDocument();
+    expect(queryByText('More')).toBeInTheDocument();
+    expect(getByText('Nested 2')).toBeInTheDocument();
   });
 });

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -94,6 +94,7 @@ export function useContextMenu<
   } | null>(null);
   const targetRef = useRef<E>(null);
   const invisibleAnchorRef = useRef<HTMLSpanElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const setupRef = useRef(false);
 
   // Mark the container as a popover trigger so that other open menus' close-on-
@@ -114,10 +115,13 @@ export function useContextMenu<
   // Generate a unique ID for this menu instance
   const menuId = useMemo(() => generateRandomId(), []);
 
-  // `containerRef` is intentionally omitted: the underlying `MenuTrigger` is
-  // `isDummy`, so its own popover container ref isn't reachable from here.
-  // Providing `triggerRef` (the context-menu target element) is enough to let
-  // peers identify themselves correctly when they emit `popover:open`.
+  // Feed both the context-menu target (`triggerRef`) and the popover
+  // container (`containerRef`) into the sync. The container ref is shared with
+  // the rendered `MenuTrigger` via its `popoverRef` prop — the dummy
+  // `MenuTrigger` opts out of `usePopoverSync` (`enabled: !isDummy`), so
+  // without this the nested-popover guard would have no container to match
+  // against and a `SubMenuTrigger` opened inside this menu would close the
+  // whole menu.
   usePopoverSync({
     menuId,
     isOpen,
@@ -126,6 +130,7 @@ export function useContextMenu<
       setAnchorPosition(null);
     },
     triggerRef: targetRef as RefObject<HTMLElement | null>,
+    containerRef: popoverRef,
   });
 
   function setupCheck() {
@@ -312,6 +317,7 @@ export function useContextMenu<
           isDummy
           isOpen={isOpen}
           targetRef={invisibleAnchorRef}
+          popoverRef={popoverRef}
           offset={0}
           crossOffset={0}
           placement={

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -314,10 +314,6 @@ export function useContextMenu<
           }}
         />
         <MenuTrigger
-          isDummy
-          isOpen={isOpen}
-          targetRef={invisibleAnchorRef}
-          popoverRef={popoverRef}
           offset={0}
           crossOffset={0}
           placement={
@@ -325,8 +321,12 @@ export function useContextMenu<
             defaultTriggerProps?.placement ||
             'bottom start'
           }
-          onOpenChange={setIsOpen}
           {...mergeProps(defaultTriggerProps, triggerProps || undefined)}
+          isDummy
+          isOpen={isOpen}
+          targetRef={invisibleAnchorRef}
+          popoverRef={popoverRef}
+          onOpenChange={setIsOpen}
         >
           <VisuallyHidden>
             <Pressable>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Targeted overlay sync fix with new optional MenuTrigger API and behavioral tests; no auth or data changes.
> 
> **Overview**
> Fixes a bug where hovering a **nested submenu** inside menus opened via **`useAnchoredMenu`** or **`useContextMenu`** incorrectly closed the parent menu, because the hook-level **`usePopoverSync`** had no popover **container** to match against (dummy **`MenuTrigger`** disables its own sync).
> 
> **`MenuTrigger`** now accepts an optional **`popoverRef`** that aliases the internal popover element ref. Both hooks create a shared **`popoverRef`**, pass it into the rendered dummy **`MenuTrigger`**, and register **`containerRef`** on their **`usePopoverSync`** alongside the anchor/target ref.
> 
> Regression tests assert the parent menu stays open when a **`SubMenuTrigger`** opens on hover. Patch changeset included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328bb6a1d51e3a8e10f16a56f8aae577f56ce244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->