### PR TITLE
fix(TextInput): autofill text and caret color

### DIFF
--- a/.changeset/red-files-retire.md
+++ b/.changeset/red-files-retire.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix the input autofill text and caret color.

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -78,10 +78,10 @@ configure({
       },
       '-webkit-text-fill-color': {
         '': 'currentColor',
-        '@autofill': '#primary',
+        '@autofill': '#primary-text',
       },
       caretColor: {
-        '@autofill': '#primary',
+        '@autofill': '#primary-text',
       },
       shadow: {
         '@autofill': '0 0 0 9999rem #surface inset',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-token swap in global input autofill CSS with no auth, data, or API impact.
> 
> **Overview**
> Fixes **browser autofill** styling for text inputs by updating the global `input-autofill` recipe in `Root.tsx`.
> 
> When `:-webkit-autofill` / `:autofill` applies, **autofilled text** (`-webkit-text-fill-color`) and the **caret** now use `#primary-text` instead of `#primary`, so filled values and the insertion caret match intended primary-theme **text** color rather than the accent/fill token.
> 
> Patch release noted in the changeset for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90684481894a452aab16545a7f95063a5cdffb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->