### PR TITLE
fix(Button): border styling

### DIFF
--- a/.changeset/cyan-moles-search.md
+++ b/.changeset/cyan-moles-search.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Improve border styling for buttons.

--- a/src/data/item-themes.ts
+++ b/src/data/item-themes.ts
@@ -66,8 +66,8 @@ export const DEFAULT_PRIMARY_STYLES: Styles = {
     focused: '1bw #primary-accent-text',
   },
   border: {
-    '': '#white.2',
-    pressed: '#primary-accent-text',
+    '': '#primary-accent-surface-border',
+    pressed: '#primary-accent-surface-border',
     disabled: 'transparent',
   },
   // All states share the same `#surface` base layer (opaque). Only the
@@ -750,8 +750,8 @@ export const SPECIAL_PRIMARY_STYLES: Styles = {
     focused: '1bw #special-accent-text',
   },
   border: {
-    '': '#white.2',
-    pressed: '#white.4',
+    '': '#special-accent-surface-border',
+    pressed: '#special-accent-surface-border',
     disabled: 'transparent',
   },
   // See `DEFAULT_PRIMARY_STYLES.fill` for the layer-shape + ramp rationale.
@@ -795,8 +795,8 @@ export const SPECIAL_OUTLINE_STYLES: Styles = {
     focused: '1bw #special-accent-text',
   },
   border: {
-    '': '#white.3',
-    selected: '#white.4',
+    '': '#white.15',
+    selected: '#white.2',
     ...(VALIDATION_STYLES.border as Record<string, string>),
   },
   fill: {

--- a/src/tasty-augment.d.ts
+++ b/src/tasty-augment.d.ts
@@ -25,6 +25,7 @@ declare module '@tenphi/tasty' {
     'accent-surface': true;
     'accent-surface-2': true;
     'accent-surface-3': true;
+    'accent-surface-border': true;
     'accent-surface-text': true;
     'accent-text': true;
     'accent-text-soft': true;

--- a/src/tokens/palette.ts
+++ b/src/tokens/palette.ts
@@ -249,6 +249,16 @@ defaultTheme.colors({
     contrast: [6, 10],
     mode: 'fixed',
   },
+  // Border for accent surfaces — mirrors the default-theme `border` shape
+  // (a relative lightness step down from its surface base) but anchored to the
+  // fixed accent surface so it stays in the brand hue family and does not flip
+  // in dark mode. Used for outlines/dividers on top of `accent-surface`.
+  'accent-surface-border': {
+    base: 'accent-surface',
+    lightness: '+1',
+    contrast: [1.4, 1.8],
+    mode: 'fixed',
+  },
   // Saturated foreground variants. Anchored to `surface` (NOT `accent-surface`)
   // with `mode: 'auto'` so they adapt with the scheme: in dark mode the solver
   // pushes them lighter to stay readable on the dark surface. Anchoring to the
@@ -521,6 +531,12 @@ specialTheme.colors({
     base: 'accent-surface-text',
     lightness: '-1',
     contrast: [5.5, 9],
+    mode: 'fixed',
+  },
+  'accent-surface-border': {
+    base: 'accent-surface',
+    lightness: '+1',
+    contrast: [1.4, 1.8],
     mode: 'fixed',
   },
   'accent-surface-hover': {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Visual/token styling only for button borders; no logic, auth, or API changes.
> 
> **Overview**
> Introduces a fixed-mode **`accent-surface-border`** Glaze token (anchored to `accent-surface`, brand-hue borders that do not invert in dark mode) and wires **primary** button borders to it instead of semi-transparent `#white` strokes.
> 
> **Default** primary buttons now use `#primary-accent-surface-border` for default and pressed borders (pressed no longer switches to accent text color). **Special** primary buttons use `#special-accent-surface-border` the same way. **Special outline** borders are retuned from `#white.3` / `#white.4` to `#white.15` / `#white.2` for subtler edges on the dark special surface.
> 
> TypeScript picks up the unprefixed token via `tasty-augment.d.ts`; a patch changeset documents the button border improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219a704cc707fa6c125381db10bd21945f011802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->