### PR TITLE
fix(Calendar): prevent the parent popover closing

### DIFF
--- a/.changeset/friendly-steaks-leave.md
+++ b/.changeset/friendly-steaks-leave.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Prevent the parent popover closing for calendar buttons.

--- a/src/components/fields/DatePicker/DatePicker.test.tsx
+++ b/src/components/fields/DatePicker/DatePicker.test.tsx
@@ -1,0 +1,109 @@
+import { CalendarDate } from '@internationalized/date';
+
+import { renderWithRoot, userEvent, waitFor, within } from '../../../test';
+
+import { DatePicker } from './DatePicker';
+
+vi.mock('../../../_internal/hooks/use-warn');
+
+describe('<DatePicker />', () => {
+  const user = userEvent.setup({ delay: null });
+
+  const isCalendarOpen = (baseElement: HTMLElement) =>
+    !!baseElement.querySelector('[data-qa="Dialog"]');
+
+  describe('calendar popover month navigation', () => {
+    it('clicking next-month keeps the popover open (data-popover-keep regression)', async () => {
+      const { baseElement } = renderWithRoot(
+        <DatePicker
+          label="Date"
+          defaultValue={new CalendarDate(2025, 6, 15)}
+        />,
+      );
+
+      // Open the calendar popover via the calendar icon trigger
+      await user.click(
+        baseElement.querySelector('[data-popover-trigger]') as HTMLElement,
+      );
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(true));
+
+      const dialog = baseElement.querySelector(
+        '[data-qa="Dialog"]',
+      ) as HTMLElement;
+
+      expect(
+        within(dialog).getByRole('heading', { level: 6 }),
+      ).toHaveTextContent('June 2025');
+
+      // Click the "Next" month navigation button
+      await user.click(within(dialog).getByRole('button', { name: /next/i }));
+
+      // Allow the deferred setTimeout(0) dismiss to settle
+      await new Promise((resolve) => setTimeout(resolve, 16));
+
+      expect(isCalendarOpen(baseElement)).toBe(true);
+      expect(
+        within(dialog).getByRole('heading', { level: 6 }),
+      ).toHaveTextContent('July 2025');
+    });
+
+    it('clicking prev-month keeps the popover open', async () => {
+      const { baseElement } = renderWithRoot(
+        <DatePicker
+          label="Date"
+          defaultValue={new CalendarDate(2025, 6, 15)}
+        />,
+      );
+
+      await user.click(
+        baseElement.querySelector('[data-popover-trigger]') as HTMLElement,
+      );
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(true));
+
+      const dialog = baseElement.querySelector(
+        '[data-qa="Dialog"]',
+      ) as HTMLElement;
+
+      await user.click(
+        within(dialog).getByRole('button', { name: /previous/i }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 16));
+
+      expect(isCalendarOpen(baseElement)).toBe(true);
+      expect(
+        within(dialog).getByRole('heading', { level: 6 }),
+      ).toHaveTextContent('May 2025');
+    });
+
+    it('selecting a date closes the popover', async () => {
+      const { baseElement } = renderWithRoot(
+        <DatePicker
+          label="Date"
+          defaultValue={new CalendarDate(2025, 6, 15)}
+        />,
+      );
+
+      await user.click(
+        baseElement.querySelector('[data-popover-trigger]') as HTMLElement,
+      );
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(true));
+
+      const dialog = baseElement.querySelector(
+        '[data-qa="Dialog"]',
+      ) as HTMLElement;
+
+      // Click a date cell that is not the currently selected one
+      await user.click(
+        within(dialog).getByRole('button', { name: /June 10/i }),
+      );
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(false), {
+        timeout: 1500,
+      });
+    });
+  });
+});

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -1192,6 +1192,7 @@ export const WithHeaderAndFooter: Story = {
             <Badge type="purple">12</Badge>
           </Space>
           <Button
+            data-popover-keep
             type="clear"
             size="small"
             icon={<SettingsIcon />}
@@ -1204,7 +1205,7 @@ export const WithHeaderAndFooter: Story = {
           <Text color="#dark.50" preset="t4">
             Popular languages shown
           </Text>
-          <Button type="link" rightIcon={<RightIcon />}>
+          <Button data-popover-keep type="link" rightIcon={<RightIcon />}>
             View all
           </Button>
         </>
@@ -1895,12 +1896,14 @@ export const ComplexExample: Story = {
           </Space>
           <Space gap="1x" flow="row">
             <Button
+              data-popover-keep
               type="clear"
               size="small"
               icon={<SearchIcon />}
               aria-label="Advanced search"
             />
             <Button
+              data-popover-keep
               type="clear"
               size="small"
               icon={<PlusIcon />}
@@ -1914,7 +1917,7 @@ export const ComplexExample: Story = {
           <Text color="#dark.50" preset="t4">
             Select multiple filters to combine conditions
           </Text>
-          <Button type="link" size="small">
+          <Button data-popover-keep type="link" size="small">
             Reset all
           </Button>
         </>

--- a/src/components/other/Calendar/Calendar.tsx
+++ b/src/components/other/Calendar/Calendar.tsx
@@ -20,6 +20,7 @@ import { Space } from '../../layout/Space';
 import { CalendarGrid } from './CalendarGrid';
 
 const CalendarElement = tasty({
+  'data-popover-keep': true,
   styles: {
     padding: '1x',
     gap: '1x',

--- a/src/components/other/Calendar/RangeCalendar.tsx
+++ b/src/components/other/Calendar/RangeCalendar.tsx
@@ -20,6 +20,7 @@ import { Space } from '../../layout/Space';
 import { CalendarGrid } from './CalendarGrid';
 
 const CalendarElement = tasty({
+  'data-popover-keep': true,
   styles: {
     padding: '1x',
     gap: '1x',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized popover-dismiss opt-out on calendar UI plus tests and story tweaks; no auth, data, or API changes.
> 
> **Overview**
> Fixes **DatePicker** (and range pickers) so the calendar popover no longer closes when users click **previous/next month**—those interactions were incorrectly treated like dismiss-on-press.
> 
> The fix marks the shared **`Calendar`** and **`RangeCalendar`** root elements with **`data-popover-keep`**, so month navigation buttons inside the calendar opt out of the library’s “button press closes parent popover” behavior. **Choosing a date** still closes the popover (covered by new **`DatePicker`** tests). **FilterPicker** story examples also add **`data-popover-keep`** on header/footer action buttons to match the same pattern. Patch changeset for **`@cube-dev/ui-kit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d097e4b67291d20cef28b73693b1f68ae7f9210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->