### PR TITLE
chore: update glaze

### DIFF
--- a/.changeset/chatty-walls-sin.md
+++ b/.changeset/chatty-walls-sin.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Update glaze to the latest version.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@react-types/shared": "^3.32.1",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
-    "@tenphi/glaze": "0.11.1",
+    "@tenphi/glaze": "0.13.0",
     "@tenphi/tasty": "2.6.4",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tenphi/glaze':
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@tenphi/tasty':
         specifier: 2.6.4
         version: 2.6.4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
@@ -2726,8 +2726,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@tenphi/glaze@0.11.1':
-    resolution: {integrity: sha512-tFg1A6svoqoPUK2GZjVIRw4VVi5joggM3ARAEu4LY5F5stv1FykEbbJOPawe00qFUSRxgmZ+bUhu3yMD9q3Y7g==}
+  '@tenphi/glaze@0.13.0':
+    resolution: {integrity: sha512-t4sIiLAquPuy2SYj9QBKVhICwoPTqkNv4ysMRplbyxwQtvYPzEtEmQ3ZEOtJm7KG7sKSo1RTzrsWC3SllkbkSA==}
     engines: {node: '>=20'}
 
   '@tenphi/tasty@2.6.4':
@@ -10087,7 +10087,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tenphi/glaze@0.11.1': {}
+  '@tenphi/glaze@0.13.0': {}
 
   '@tenphi/tasty@2.6.4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scope is limited to a minor dependency version bump with no direct code edits; residual risk is only from glaze 0.13.0 behavioral or token output changes affecting theming.
> 
> **Overview**
> Bumps the **`@tenphi/glaze`** dependency from **0.11.1** to **0.13.0** in `package.json` and refreshes **`pnpm-lock.yaml`**. A Changesets entry records a **patch** release for **`@cube-dev/ui-kit`** with the note that glaze was updated.
> 
> There are **no application source changes** in this diff; consumers still get glaze APIs via the existing re-export and palette generation in `src/tokens/palette.ts`, but they inherit whatever token or API adjustments ship in glaze 0.13.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d689f2ef2fd864c4c6f856048238ef3514f88b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->