### PR TITLE
fix(Calendar): prevent the parent popover closing * 2

### DIFF
--- a/.changeset/odd-shrimps-boil.md
+++ b/.changeset/odd-shrimps-boil.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+One more fix to Calendar popover.

--- a/src/components/actions/Menu/MenuTrigger.tsx
+++ b/src/components/actions/Menu/MenuTrigger.tsx
@@ -198,6 +198,7 @@ function MenuTrigger(props: CubeMenuTriggerProps, ref: Ref<HTMLElement>) {
 
     const menuTriggerEl = el.closest('[data-popover-trigger]');
     if (!menuTriggerEl) {
+      if (el.closest('[data-popover-keep]')) return false;
       // Plain interactive controls (Button, ItemButton) opt in via
       // `data-popover-dismiss`. We schedule the close via setTimeout(0) so
       // it lands AFTER the click event finishes — the button's onPress

--- a/src/components/actions/Menu/SubMenuTrigger.tsx
+++ b/src/components/actions/Menu/SubMenuTrigger.tsx
@@ -335,6 +335,7 @@ function InternalSubMenuTrigger(props: InternalSubMenuTriggerProps) {
 
     const menuTriggerEl = el.closest('[data-popover-trigger]');
     if (!menuTriggerEl) {
+      if (el.closest('[data-popover-keep]')) return false;
       if (el.closest('[data-popover-dismiss]')) {
         // Let the button's onPress fire first, then collapse the chain.
         setTimeout(() => parentContext.onClose?.(), 0);

--- a/src/components/fields/ComboBox/ComboBox.tsx
+++ b/src/components/fields/ComboBox/ComboBox.tsx
@@ -861,6 +861,7 @@ function ComboBoxOverlay({
       shouldCloseOnInteractOutside: (el) => {
         const menuTriggerEl = el.closest('[data-popover-trigger]');
         if (!menuTriggerEl) {
+          if (el.closest('[data-popover-keep]')) return false;
           // Plain interactive controls (Button, ItemButton) opt in via
           // `data-popover-dismiss` to dismiss us without losing their click
           // to useOverlay's stopPropagation. Schedule the close after the

--- a/src/components/fields/DatePicker/DatePicker.test.tsx
+++ b/src/components/fields/DatePicker/DatePicker.test.tsx
@@ -1,6 +1,8 @@
 import { CalendarDate } from '@internationalized/date';
 
 import { renderWithRoot, userEvent, waitFor, within } from '../../../test';
+import { Button } from '../../actions/Button';
+import { Dialog, DialogTrigger } from '../../overlays/Dialog';
 
 import { DatePicker } from './DatePicker';
 
@@ -13,6 +15,57 @@ describe('<DatePicker />', () => {
     !!baseElement.querySelector('[data-qa="Dialog"]');
 
   describe('calendar popover month navigation', () => {
+    it('clicking next-month inside a nested popover keeps the parent popover open', async () => {
+      const { baseElement } = renderWithRoot(
+        <DialogTrigger type="popover">
+          <Button qa="Trigger">Open Parent</Button>
+          <Dialog>
+            <DatePicker
+              label="Date"
+              defaultValue={new CalendarDate(2025, 6, 15)}
+            />
+          </Dialog>
+        </DialogTrigger>,
+      );
+
+      // Open parent popover
+      await user.click(
+        baseElement.querySelector('[data-qa="Trigger"]') as HTMLElement,
+      );
+
+      // Wait for parent popover to open
+      let dialogs = await waitFor(() => {
+        const d = baseElement.querySelectorAll('[data-qa="Dialog"]');
+        expect(d.length).toBe(1);
+        return d;
+      });
+      const parentDialog = dialogs[0] as HTMLElement;
+
+      // Open the calendar popover via the calendar icon trigger
+      await user.click(
+        parentDialog.querySelector('[data-popover-trigger]') as HTMLElement,
+      );
+
+      // Wait for calendar to be open
+      dialogs = await waitFor(() => {
+        const d = baseElement.querySelectorAll('[data-qa="Dialog"]');
+        expect(d.length).toBe(2);
+        return d;
+      });
+
+      const calendarDialog = dialogs[1] as HTMLElement;
+
+      // Click the "Next" month navigation button
+      await user.click(
+        within(calendarDialog).getByRole('button', { name: /next/i }),
+      );
+
+      // Wait a bit
+      await new Promise((resolve) => setTimeout(resolve, 16));
+
+      expect(baseElement.querySelectorAll('[data-qa="Dialog"]').length).toBe(2);
+    });
+
     it('clicking next-month keeps the popover open (data-popover-keep regression)', async () => {
       const { baseElement } = renderWithRoot(
         <DatePicker

--- a/src/components/fields/Select/Select.tsx
+++ b/src/components/fields/Select/Select.tsx
@@ -568,6 +568,7 @@ export function ListBoxPopup({
       shouldCloseOnInteractOutside: (el) => {
         const menuTriggerEl = el.closest('[data-popover-trigger]');
         if (!menuTriggerEl) {
+          if (el.closest('[data-popover-keep]')) return false;
           // Plain interactive controls (Button, ItemButton) opt in via
           // `data-popover-dismiss` to dismiss us without losing their click
           // to useOverlay's stopPropagation. Schedule the close after the

--- a/src/components/other/Calendar/Calendar.tsx
+++ b/src/components/other/Calendar/Calendar.tsx
@@ -20,7 +20,6 @@ import { Space } from '../../layout/Space';
 import { CalendarGrid } from './CalendarGrid';
 
 const CalendarElement = tasty({
-  'data-popover-keep': true,
   styles: {
     padding: '1x',
     gap: '1x',
@@ -73,8 +72,18 @@ function Calendar(props: CubeCalendarProps, ref: FocusableRef<HTMLElement>) {
           {title}
         </Title>
         <Space gap=".5x">
-          <Button size="xsmall" {...prevButtonProps} icon={<LeftIcon />} />
-          <Button size="xsmall" {...nextButtonProps} icon={<RightIcon />} />
+          <Button
+            data-popover-keep
+            size="xsmall"
+            {...prevButtonProps}
+            icon={<LeftIcon />}
+          />
+          <Button
+            data-popover-keep
+            size="xsmall"
+            {...nextButtonProps}
+            icon={<RightIcon />}
+          />
         </Space>
       </CalendarHeaderElement>
       <CalendarGrid state={state} selectedRange={props.selectedRange} />

--- a/src/components/other/Calendar/CalendarCell.tsx
+++ b/src/components/other/Calendar/CalendarCell.tsx
@@ -12,6 +12,7 @@ const CalendarCellElement = tasty({
 });
 
 const CalendarButtonElement = tasty({
+  'data-popover-keep': true,
   styles: {
     display: 'grid',
     placeItems: 'center',

--- a/src/components/other/Calendar/RangeCalendar.tsx
+++ b/src/components/other/Calendar/RangeCalendar.tsx
@@ -20,7 +20,6 @@ import { Space } from '../../layout/Space';
 import { CalendarGrid } from './CalendarGrid';
 
 const CalendarElement = tasty({
-  'data-popover-keep': true,
   styles: {
     padding: '1x',
     gap: '1x',
@@ -67,8 +66,18 @@ function RangeCalendar<T extends DateValue>(
           {title}
         </Title>
         <Space gap=".5x">
-          <Button size="small" {...prevButtonProps} icon={<LeftIcon />} />
-          <Button size="small" {...nextButtonProps} icon={<RightIcon />} />
+          <Button
+            data-popover-keep
+            size="small"
+            {...prevButtonProps}
+            icon={<LeftIcon />}
+          />
+          <Button
+            data-popover-keep
+            size="small"
+            {...nextButtonProps}
+            icon={<RightIcon />}
+          />
         </Space>
       </CalendarHeaderElement>
       <CalendarGrid state={state} />

--- a/src/components/overlays/Dialog/DialogTrigger.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.tsx
@@ -346,6 +346,7 @@ function PopoverTrigger(allProps) {
     (el: Element): boolean => {
       const popoverTriggerEl = el.closest('[data-popover-trigger]');
       if (!popoverTriggerEl) {
+        if (el.closest('[data-popover-keep]')) return false;
         // Plain interactive controls (Button, ItemButton) opt in via
         // `data-popover-dismiss`. Schedule the close after the click finishes so
         // the control's `onPress` runs first instead of losing the click to


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized popover dismiss predicate and calendar DOM attributes; behavior change is intentional for calendar/nested popover UX with regression tests.
> 
> **Overview**
> Fixes **Calendar** popover behavior when navigating months or picking dates inside **nested popovers** (e.g. `DatePicker` inside a parent `DialogTrigger`).
> 
> **`data-popover-keep` is applied only on interactive calendar controls** — prev/next month buttons and date cells — instead of the whole calendar root. **`useOverlay` “interact outside” handlers** in `DialogTrigger`, `MenuTrigger`, `SubMenuTrigger`, `Select`, and `ComboBox` now treat clicks on `[data-popover-keep]` like in-overlay interactions and **do not dismiss** the overlay.
> 
> Adds a **DatePicker** test that month navigation with two open dialogs leaves both popovers open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c052039826577d37490772a929dffc755b550cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->