### PR TITLE
fix(Disclosure): hidden content bug

### DIFF
--- a/.changeset/disclosure-content-visibility.md
+++ b/.changeset/disclosure-content-visibility.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix Disclosure.Content collapsing to 0px height when content-visibility skips the panel.

--- a/src/components/content/Disclosure/Disclosure.tsx
+++ b/src/components/content/Disclosure/Disclosure.tsx
@@ -197,7 +197,10 @@ const ContentElement = tasty({
   styles: {
     display: 'block',
     flow: 'column',
-    contentVisibility: 'auto',
+    contentVisibility: {
+      '': 'auto',
+      shown: 'visible',
+    },
   },
 });
 
@@ -429,7 +432,7 @@ const DisclosureContent = forwardRef<
         >
           <ContentElement
             ref={mergeRefs(ref, panelRef)}
-            mods={mods}
+            mods={{ ...mods, shown: isShown }}
             styles={mergedStyles}
             {...filteredPanelProps}
             {...otherProps}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized styling and mod wiring on Disclosure.Content with no API or auth/data changes.
> 
> **Overview**
> Fixes **Disclosure.Content** panels that could collapse to **0px height** when the browser’s `content-visibility: auto` skipped layout for the inner panel while the wrapper was animating open.
> 
> **`ContentElement`** now uses a **`shown`** mod to set `content-visibility` to **`visible`** while the panel is shown (via `DisplayTransition`’s `isShown`), and **`auto`** otherwise—matching the wrapper’s `shown` state instead of leaving the inner panel always on `auto`. Consumer **`mods`** are still merged in.
> 
> Patch release noted in the changeset for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44e2e1741db576ebd50d3fb573f36e63c764772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->