### PR TITLE
fix: documentation files

### DIFF
--- a/src/components/content/Tag/Tag.docs.mdx
+++ b/src/components/content/Tag/Tag.docs.mdx
@@ -123,7 +123,7 @@ Tags support multiple sizes inherited from the Item component:
 
 Apply custom styling using the `styles` prop:
 
-<Story of={TagStories.CustomStyles} />
+<Story of={TagStories.CustomStyling} />
 
 ```jsx
 <Tag

--- a/src/components/content/TextItem/TextItem.docs.mdx
+++ b/src/components/content/TextItem/TextItem.docs.mdx
@@ -177,7 +177,7 @@ Apply typography and color styles:
 <TextItem weight="bold">Bold text</TextItem>
 ```
 
-<Story of={TextItemStories.WithTextStyles} />
+<Story of={TextItemStories.WithTextStyling} />
 
 ### Search Results List
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only renames of Story references; no runtime or component behavior changes.
> 
> **Overview**
> Fixes broken Storybook doc embeds by aligning **`<Story of={...} />`** references with the actual story export names in `Tag.stories` and `TextItem.stories`.
> 
> In **`Tag.docs.mdx`**, the Custom Styles example now uses `TagStories.CustomStyling` instead of `CustomStyles`. In **`TextItem.docs.mdx`**, the With Text Styles section uses `TextItemStories.WithTextStyling` instead of `WithTextStyles`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c7fffa85b193b24ff0a868a8afd565ec12b518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->