### PR TITLE
chore: update tasty

### DIFF
--- a/.changeset/bright-monkeys-divide.md
+++ b/.changeset/bright-monkeys-divide.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Update tasty to the latest version.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "0.13.0",
-    "@tenphi/tasty": "2.6.4",
+    "@tenphi/tasty": "0.0.0-snapshot.8848882",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "0.13.0",
-    "@tenphi/tasty": "0.0.0-snapshot.8848882",
+    "@tenphi/tasty": "2.6.5",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       '@tenphi/tasty':
-        specifier: 2.6.4
-        version: 2.6.4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.8848882
+        version: 0.0.0-snapshot.8848882(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2730,14 +2730,15 @@ packages:
     resolution: {integrity: sha512-t4sIiLAquPuy2SYj9QBKVhICwoPTqkNv4ysMRplbyxwQtvYPzEtEmQ3ZEOtJm7KG7sKSo1RTzrsWC3SllkbkSA==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@2.6.4':
-    resolution: {integrity: sha512-skpo2Tx9s0CbUs8CkN0E0lBxzgWlsXDnI8mEFq+2OwdDDna2NWf1nSloD1iCh1WvSlST1+scYRZ9iXmA+mY+gA==}
+  '@tenphi/tasty@0.0.0-snapshot.8848882':
+    resolution: {integrity: sha512-rBQKw5MW12PzcaEXXHV8DBnieQn1AphQJ5VYh0njnekrS/OjFn6Rgd5AOhcYeJ7QDS4Gl+SD6fZCdxiwdbqBAw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
       '@babel/helper-plugin-utils': ^7.24.0
       '@babel/types': ^7.24.0
       jiti: ^2.6.1
+      next: '>=14.0.0'
       react: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@babel/core':
@@ -2747,6 +2748,8 @@ packages:
       '@babel/types':
         optional: true
       jiti:
+        optional: true
+      next:
         optional: true
       react:
         optional: true
@@ -10089,7 +10092,7 @@ snapshots:
 
   '@tenphi/glaze@0.13.0': {}
 
-  '@tenphi/tasty@2.6.4(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.8848882(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.8848882
-        version: 0.0.0-snapshot.8848882(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.6.5
+        version: 2.6.5(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2730,8 +2730,8 @@ packages:
     resolution: {integrity: sha512-t4sIiLAquPuy2SYj9QBKVhICwoPTqkNv4ysMRplbyxwQtvYPzEtEmQ3ZEOtJm7KG7sKSo1RTzrsWC3SllkbkSA==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@0.0.0-snapshot.8848882':
-    resolution: {integrity: sha512-rBQKw5MW12PzcaEXXHV8DBnieQn1AphQJ5VYh0njnekrS/OjFn6Rgd5AOhcYeJ7QDS4Gl+SD6fZCdxiwdbqBAw==}
+  '@tenphi/tasty@2.6.5':
+    resolution: {integrity: sha512-K1oIGO7fvT4m0qN2q3oLeycl0PmrkRJab37XXzSdds5WkzHK6Yhr4qEj/wzMmrHsqT+rSajCl/jDIahe5nwNqw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10092,7 +10092,7 @@ snapshots:
 
   '@tenphi/glaze@0.13.0': {}
 
-  '@tenphi/tasty@0.0.0-snapshot.8848882(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.6.5(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level dependency upgrade with no application source changes; only lockfile metadata adds an optional Next peer on tasty.
> 
> **Overview**
> Bumps **`@tenphi/tasty`** from `2.6.4` to **`2.6.5`** and refreshes **`pnpm-lock.yaml`**. A **changeset** records a patch release for **`@cube-dev/ui-kit`** noting the tasty update.
> 
> The lockfile reflects tasty’s new **optional** peer on **`next` (>=14)**; this repo does not add Next as a dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d7185df649202e9d5e9ec671becce5b1411c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->