### PR TITLE
fix(typography): default values

### DIFF
--- a/.changeset/wet-worms-eat.md
+++ b/.changeset/wet-worms-eat.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix default typography values to fallback to the existing t3 preset.

--- a/src/tokens/typography.ts
+++ b/src/tokens/typography.ts
@@ -240,7 +240,7 @@ export const TYPOGRAPHY_PRESETS: Record<string, TypographyPreset> = {
     lineHeight: 'var(--t3-line-height)',
     letterSpacing: 'var(--t3-letter-spacing)',
     fontWeight: 'var(--t3-font-weight)',
-    boldFontWeight: '600',
-    iconSize: 'inherit',
+    boldFontWeight: 'var(--t3-bold-font-weight)',
+    iconSize: 'var(--t3-icon-size)',
   },
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small token definition fix in ui-kit typography with no auth, data, or API impact.
> 
> **Overview**
> The **`default`** typography preset in `typography.ts` now wires **`boldFontWeight`** and **`iconSize`** through the same **`t3`** CSS custom properties as the other default fields, instead of hardcoded **`600`** and **`inherit`**.
> 
> Default text styling stays aligned with **`t3`** when those tokens are consumed (e.g. bold emphasis and icon sizing at **18px** per **`t3`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7373979ec1dfa110f7f5741c7d6740659cbf367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->