### PR TITLE
chore: update tasty

### DIFF
--- a/.changeset/modern-geese-draw.md
+++ b/.changeset/modern-geese-draw.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Update tasty to the latest version.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "0.13.0",
-    "@tenphi/tasty": "0.0.0-snapshot.4bed60d",
+    "@tenphi/tasty": "2.7.0",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "0.13.0",
-    "@tenphi/tasty": "2.7.0",
+    "@tenphi/tasty": "2.8.0",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "0.13.0",
-    "@tenphi/tasty": "2.6.5",
+    "@tenphi/tasty": "0.0.0-snapshot.4bed60d",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       '@tenphi/tasty':
-        specifier: 2.7.0
-        version: 2.7.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.8.0
+        version: 2.8.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2730,8 +2730,8 @@ packages:
     resolution: {integrity: sha512-t4sIiLAquPuy2SYj9QBKVhICwoPTqkNv4ysMRplbyxwQtvYPzEtEmQ3ZEOtJm7KG7sKSo1RTzrsWC3SllkbkSA==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@2.7.0':
-    resolution: {integrity: sha512-VVswAJqCTqPTwjB11HIvbzwtXocaxGn2c9+Mvf4vpkW1B/8jTLdxDKA5cPqRAAamPsMIn+7loKpZt9MFpB8uuQ==}
+  '@tenphi/tasty@2.8.0':
+    resolution: {integrity: sha512-cX2m85McDvMHtncgQuU1ANNqbVqyGZJyL011VRdnAeQ4LFMccHh3C3VdBRhDTl9S+m+r4JgB921eZfQxmg0lXA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10092,7 +10092,7 @@ snapshots:
 
   '@tenphi/glaze@0.13.0': {}
 
-  '@tenphi/tasty@2.7.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.8.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.4bed60d
-        version: 0.0.0-snapshot.4bed60d(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 2.7.0
+        version: 2.7.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2730,8 +2730,8 @@ packages:
     resolution: {integrity: sha512-t4sIiLAquPuy2SYj9QBKVhICwoPTqkNv4ysMRplbyxwQtvYPzEtEmQ3ZEOtJm7KG7sKSo1RTzrsWC3SllkbkSA==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@0.0.0-snapshot.4bed60d':
-    resolution: {integrity: sha512-z8wwWfNPKQRR3NtlRZE7seCJa3I8sjcs/ija27P5X7Y+MI48092wyk4lw+xFDHFKDmz3/njtBSBvTPsh8uB2Qw==}
+  '@tenphi/tasty@2.7.0':
+    resolution: {integrity: sha512-VVswAJqCTqPTwjB11HIvbzwtXocaxGn2c9+Mvf4vpkW1B/8jTLdxDKA5cPqRAAamPsMIn+7loKpZt9MFpB8uuQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10092,7 +10092,7 @@ snapshots:
 
   '@tenphi/glaze@0.13.0': {}
 
-  '@tenphi/tasty@0.0.0-snapshot.4bed60d(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@2.7.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: 0.13.0
         version: 0.13.0
       '@tenphi/tasty':
-        specifier: 2.6.5
-        version: 2.6.5(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.4bed60d
+        version: 0.0.0-snapshot.4bed60d(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2730,8 +2730,8 @@ packages:
     resolution: {integrity: sha512-t4sIiLAquPuy2SYj9QBKVhICwoPTqkNv4ysMRplbyxwQtvYPzEtEmQ3ZEOtJm7KG7sKSo1RTzrsWC3SllkbkSA==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@2.6.5':
-    resolution: {integrity: sha512-K1oIGO7fvT4m0qN2q3oLeycl0PmrkRJab37XXzSdds5WkzHK6Yhr4qEj/wzMmrHsqT+rSajCl/jDIahe5nwNqw==}
+  '@tenphi/tasty@0.0.0-snapshot.4bed60d':
+    resolution: {integrity: sha512-z8wwWfNPKQRR3NtlRZE7seCJa3I8sjcs/ija27P5X7Y+MI48092wyk4lw+xFDHFKDmz3/njtBSBvTPsh8uB2Qw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -10092,7 +10092,7 @@ snapshots:
 
   '@tenphi/glaze@0.13.0': {}
 
-  '@tenphi/tasty@2.6.5(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.4bed60d(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/src/components/fields/NumberInput/StepButton.tsx
+++ b/src/components/fields/NumberInput/StepButton.tsx
@@ -7,7 +7,7 @@ const StepButtonElement = tasty(Button, {
   preventDefault: true,
   type: 'clear',
   styles: {
-    width: '2.5x',
+    width: '($local-size * 1.25)',
     height: 'auto',
     radius: {
       '': '0 (1r - 1bw) 0 0',
@@ -15,7 +15,8 @@ const StepButtonElement = tasty(Button, {
     },
     padding: 0,
 
-    '$icon-size': '1em',
+    $size: 'inherit',
+    '$local-size': '(($size - 2bw) / 2)',
 
     Icon: {
       width: 'auto',
@@ -39,7 +40,10 @@ export function StepButton(props) {
       label={`Step ${props.direction}`}
       {...props}
     >
-      <DirectionIcon to={props.direction} />
+      <DirectionIcon
+        to={props.direction}
+        styles={{ fontSize: '$local-size' }}
+      />
     </StepButtonElement>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency patch with localized NumberInput stepper styling; no auth, data, or API changes.
> 
> **Overview**
> Bumps **`@tenphi/tasty`** from **2.6.5** to **2.8.0** (lockfile + patch changeset for `@cube-dev/ui-kit`).
> 
> **`NumberInput` stepper** (`StepButton`) is adjusted for the new styling model: button width uses **`$local-size`** derived from inherited **`$size`** instead of a fixed **`2.5x`**, and the caret **`DirectionIcon`** scales via **`fontSize: '$local-size'`** rather than **`$icon-size: '1em'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ab56834a8dd8721eb5dd0784bbb7bd45b4512e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->