### PR TITLE
fix(LayoutHeader): inner layout

### DIFF
--- a/.changeset/nine-frogs-kneel.md
+++ b/.changeset/nine-frogs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix LayoutHeader inner layout.

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -378,6 +378,7 @@ export const Button = forwardRef(function Button(
     tooltip = true,
     defaultTooltipPlacement = 'top',
     onPress: userOnPress,
+    tokens,
     ...props
   } = allProps;
 
@@ -599,7 +600,10 @@ export const Button = forwardRef(function Button(
         data-size={size}
         data-popover-dismiss=""
         styles={styles}
-        tokens={sizeTokenValue ? { $size: sizeTokenValue } : undefined}
+        tokens={{
+          ...tokens,
+          ...(sizeTokenValue ? { $size: sizeTokenValue } : {}),
+        }}
       >
         <DisplayTransition
           isShown={hasLeftIcon}

--- a/src/components/content/Item/Item.tsx
+++ b/src/components/content/Item/Item.tsx
@@ -634,6 +634,7 @@ const Item = <T extends HTMLElement = HTMLDivElement>(
     highlightStyles,
     insideWrapper = false,
     showActions = false,
+    tokens,
     ...rest
   } = props;
 
@@ -949,7 +950,10 @@ const Item = <T extends HTMLElement = HTMLDivElement>(
         aria-selected={isSelected}
         mods={finalMods}
         styles={styles}
-        tokens={sizeTokenValue ? { $size: sizeTokenValue } : undefined}
+        tokens={{
+          ...tokens,
+          ...(sizeTokenValue ? { $size: sizeTokenValue } : {}),
+        }}
         type={htmlType as any}
         {...mergeProps(rest, tooltipTriggerProps || {})}
         style={style}

--- a/src/components/content/Layout/LayoutHeader.tsx
+++ b/src/components/content/Layout/LayoutHeader.tsx
@@ -26,19 +26,22 @@ const HeaderElement = tasty(LayoutContent, {
     border: 'bottom',
     flexShrink: 0,
     flexGrow: 0,
+    height: 'min 6x',
 
     Inner: {
       $: '>',
       display: 'grid',
       gridTemplate: `
-        "breadcrumbs breadcrumbs breadcrumbs breadcrumbs" auto
-        "back title suffix extra" 1fr
+        "breadcrumbs breadcrumbs breadcrumbs extra" auto
+        "back title suffix extra" max-content
         ".. subtitle subtitle extra" auto
         / auto max-content 1fr minmax(0, auto)
       `,
       gap: 0,
-      placeContent: 'stretch',
+      placeContent: 'center stretch',
       placeItems: 'center stretch',
+      padding: '0 ($content-padding, 1x)',
+      placeSelf: 'center stretch',
     },
 
     Back: {
@@ -64,13 +67,13 @@ const HeaderElement = tasty(LayoutContent, {
       $: '> Inner >',
       gridArea: 'title',
       preset: {
-        '': 'h3',
-        'level=1': 'h1',
-        'level=2': 'h2',
-        'level=3': 'h3',
-        'level=4': 'h4',
-        'level=5': 'h5',
-        'level=6': 'h6',
+        '': 'h3 / tight',
+        'level=1': 'h1 / tight',
+        'level=2': 'h2 / tight',
+        'level=3': 'h3 / tight',
+        'level=4': 'h4 / tight',
+        'level=5': 'h5 / tight',
+        'level=6': 'h6 / tight',
       },
       color: '#dark',
       margin: 0,
@@ -91,7 +94,7 @@ const HeaderElement = tasty(LayoutContent, {
       gridArea: 'extra',
       display: 'flex',
       placeItems: 'center',
-      placeSelf: 'end',
+      placeSelf: 'center',
       gap: '1x',
       width: 'max 100%',
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only layout and token-merge changes in UI components with no auth, data, or API impact.
> 
> **Overview**
> **LayoutHeader** inner grid and spacing are adjusted so breadcrumbs, title row, and **extra** actions align more predictably: the breadcrumbs row now spans into the **extra** column, the title row uses **max-content** height, the header enforces a **min 6x** height, **Inner** gets horizontal padding and vertical centering, title typography switches to **tight** heading presets, and **Extra** is vertically centered instead of end-aligned.
> 
> **Button** and **Item** now **merge** caller-supplied `tokens` with the internal `$size` token (when a custom size is set), so layout-level token overrides are no longer dropped when size tokens are applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04d941ae91bbcfe2d20589cff2ab12aa6003dcb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->