### PR TITLE
fix(ListBox, Tree): restore full click area for checkboxes

### DIFF
--- a/.changeset/listbox-checkbox-click-area.md
+++ b/.changeset/listbox-checkbox-click-area.md
@@ -1,0 +1,8 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix checkbox click area regressions in checkable ListBox and Tree.
+
+- **ListBox:** The `IconSwitch` slot now stretches to fill its parent grid cell, restoring the full-cell click target for checkable multiple-selection options.
+- **Tree:** The checkbox wrapper now stretches to the full row height and toggles on click across the entire wrapper area (not just the inner checkbox box).

--- a/src/components/content/Tree/TreeNode.tsx
+++ b/src/components/content/Tree/TreeNode.tsx
@@ -22,6 +22,7 @@ import type { Styles } from '@tenphi/tasty';
 import type {
   CSSProperties,
   KeyboardEvent,
+  MouseEvent,
   ReactNode,
   Ref,
   SyntheticEvent,
@@ -208,6 +209,15 @@ function TreeNodeInner(props: TreeNodeProps) {
     onToggleChecked(String(node.key));
   });
 
+  const handleWrapperClick = useEvent((e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    if (isDisabled || data.isCheckboxDisabled) return;
+    // The inner <Checkbox> label toggles on direct click; skip to avoid a double toggle.
+    if ((e.target as HTMLElement).closest('[data-qa="CheckboxWrapper"]'))
+      return;
+    onToggleChecked(String(node.key));
+  });
+
   // ---- Keyboard ------------------------------------------------------------
 
   // Composed keydown handler. Runs BEFORE `rowProps.onKeyDown` from
@@ -343,7 +353,7 @@ function TreeNodeInner(props: TreeNodeProps) {
     <TreeNodeCheckboxWrapper
       data-element="Checkbox"
       role="presentation"
-      onClick={stopPropagation}
+      onClick={handleWrapperClick}
       onKeyDown={stopPropagation}
     >
       <Checkbox

--- a/src/components/content/Tree/styled.ts
+++ b/src/components/content/Tree/styled.ts
@@ -130,6 +130,7 @@ export const TreeNodeCheckboxWrapper = tasty({
     display: 'grid',
     placeItems: 'center',
     placeContent: 'center',
+    placeSelf: 'stretch',
     padding: '0 1x',
   },
 });

--- a/src/components/helpers/IconSwitch/IconSwitch.tsx
+++ b/src/components/helpers/IconSwitch/IconSwitch.tsx
@@ -75,6 +75,7 @@ const IconSlotElement = tasty({
     gridArea: '1 / 1',
     display: 'grid',
     placeItems: 'center',
+    placeSelf: 'stretch',
     opacity: {
       '': 0,
       entered: 1,


### PR DESCRIPTION
### Describe changes

<!-- Please describe the current behavior you are modifying or linking to a relevant issue.

Contribution guide: https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md

-->

##### Checklist

Before taking this PR from the draft, please, make sure you have done the following:

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Pipeline is passed
- [ ] Tests are added (including unit tests and stories in the storybook)
- [ ] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories that describe how this component/prop works
- [ ] Changeset(s) is(are) added
- [ ] You have passed the threshold of the library size
- [ ] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: <!-- Please add tickets id's which are relevant to current pr, e.g. CUK-1, CUK-2 ... CUK-XX--> N/A 

#

### Other information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout and pointer-event behavior for checkbox UI in ListBox and Tree; no auth, data, or API changes.
> 
> **Overview**
> Fixes **checkbox click-area regressions** in checkable **ListBox** and **Tree** rows.
> 
> **ListBox (via `Item`):** `IconSwitch`’s inner slot (`IconSlotElement`) now uses **`placeSelf: 'stretch'`** so the icon/checkmark cell fills its grid area again, restoring a full-cell click target for multiple-selection options.
> 
> **Tree:** `TreeNodeCheckboxWrapper` also **`placeSelf: 'stretch'`** so the checkbox column matches row height. Clicks on the wrapper call **`handleWrapperClick`** to toggle selection across the padded wrapper (not only the inner box), with **`stopPropagation`** and a guard on **`[data-qa="CheckboxWrapper"]`** so direct clicks on the inner `Checkbox` don’t double-toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ae5b02f1c6107bb2023d24e610b491f76aba31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->