### PR TITLE
refactor(Notifications): simplify dismiss action detection and improv…

### DIFF
--- a/.changeset/notification-isdismiss-detection.md
+++ b/.changeset/notification-isdismiss-detection.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Fix Notification rendering a duplicate "Dismiss" button when a custom `NotificationAction` with `isDismiss` is provided. Replaced the render-phase ref-mutation detection with deterministic static inspection of the `actions` tree, so the auto-appended "Dismiss" is reliably suppressed regardless of render order or concurrent rendering timing.

--- a/src/components/overlays/Notifications/NotificationAction.tsx
+++ b/src/components/overlays/Notifications/NotificationAction.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  Key,
-  ReactNode,
-  useContext,
-  useMemo,
-  useRef,
-} from 'react';
+import { createContext, Key, ReactNode, useContext, useMemo } from 'react';
 
 import { useEvent } from '../../../_internal';
 import { ItemAction } from '../../actions/ItemAction/ItemAction';
@@ -65,25 +58,6 @@ export function NotificationDismissProvider({
   );
 }
 
-// ─── Dismiss Action Detection Context ────────────────────────────────
-//
-// Allows NotificationCard to detect whether any child NotificationAction
-// has `isDismiss` set, without requiring a separate `hasDismissAction` prop.
-//
-// Mechanism:
-// - DismissActionDetector provides a ref via context and resets it each render.
-// - NotificationAction writes to the ref during render when isDismiss is true.
-// - DefaultDismissGuard reads the ref to decide whether to show the default button.
-//
-// This relies on React's left-to-right sibling render order: {actions}
-// children render before <DefaultDismissGuard />, so the ref is populated
-// before it's read. The ref is reset at the provider level each render,
-// making it safe under StrictMode double-rendering.
-
-export const DismissActionDetectedContext = createContext<ReturnType<
-  typeof useRef<boolean>
-> | null>(null);
-
 // ─── NotificationAction Component ────────────────────────────────────
 
 /**
@@ -93,7 +67,8 @@ export const DismissActionDetectedContext = createContext<ReturnType<
  * - `closeOnPress` (default: true) — auto-dismisses the notification after `onPress`.
  * - An action with no `onPress` and `closeOnPress: true` acts as a dismiss-only action.
  * - `isDismiss` — marks this action as the dismiss button; when present, the default
- *   "Dismiss" button is auto-suppressed via context detection.
+ *   "Dismiss" button is auto-suppressed (detected statically from the actions tree
+ *   by NotificationCard).
  * - Type (primary/outline/clear/etc.) is set automatically via ItemActionProvider context.
  */
 export function NotificationAction({
@@ -104,14 +79,6 @@ export function NotificationAction({
   isDismiss,
 }: NotificationActionProps) {
   const dismissCtx = useContext(NotificationDismissContext);
-  const dismissDetectedRef = useContext(DismissActionDetectedContext);
-
-  // Register isDismiss during render (synchronous, before DefaultDismissGuard renders).
-  // Safe under StrictMode: the ref is reset at the DismissActionDetector level each render.
-  if (isDismiss && dismissDetectedRef) {
-    dismissDetectedRef.current = true;
-  }
-
   const actionInterceptor = useContext(NotificationActionInterceptorContext);
 
   const handlePress = useEvent(async () => {

--- a/src/components/overlays/Notifications/NotificationCard.tsx
+++ b/src/components/overlays/Notifications/NotificationCard.tsx
@@ -45,9 +45,10 @@ const StyledItem = tasty(Item, {
  * Deterministically checks whether any `NotificationAction` with `isDismiss`
  * is present in the `actions` ReactNode tree.
  *
- * Walks the static element tree (fragments, arrays, single elements) instead
- * of relying on render-phase ref mutation, so suppression does not depend on
- * sibling render order or concurrent rendering timing.
+ * Walks the static element tree (arrays, fragments, host elements, and
+ * composite wrappers via their `children` prop) instead of relying on
+ * render-phase ref mutation, so suppression does not depend on sibling render
+ * order or concurrent rendering timing.
  */
 function hasDismissAction(node: ReactNode): boolean {
   let found = false;
@@ -68,13 +69,12 @@ function hasDismissAction(node: ReactNode): boolean {
         return;
       }
 
-      // Recurse into fragments (and other host-like wrappers with only children)
-      if (
-        n.type === Symbol.for('react.fragment') ||
-        typeof n.type === 'symbol'
-      ) {
-        visit((n.props as any).children);
-      }
+      // Recurse into any wrapper's children (fragments, host elements like
+      // `div`, and composite wrappers like `Flex` that receive the actions as
+      // children). Note: a component that creates the NotificationAction
+      // internally rather than receiving it via children cannot be detected
+      // statically.
+      visit((n.props as any).children);
     }
   };
 

--- a/src/components/overlays/Notifications/NotificationCard.tsx
+++ b/src/components/overlays/Notifications/NotificationCard.tsx
@@ -1,5 +1,5 @@
 import { tasty } from '@tenphi/tasty';
-import { Key, ReactNode, useContext, useRef } from 'react';
+import { isValidElement, Key, ReactNode } from 'react';
 
 import { ItemActionProvider } from '../../actions/ItemActionContext';
 import { Block } from '../../Block';
@@ -9,7 +9,6 @@ import { Space } from '../../layout/Space';
 import { getThemeIcon } from '../Toast/useToast';
 
 import {
-  DismissActionDetectedContext,
   NotificationAction,
   NotificationDismissProvider,
 } from './NotificationAction';
@@ -43,32 +42,51 @@ const StyledItem = tasty(Item, {
 // ─── Dismiss Action Detection ────────────────────────────────────────
 
 /**
- * Provides a ref via context that NotificationAction children write to
- * during render when `isDismiss` is set. The ref is reset each render.
+ * Deterministically checks whether any `NotificationAction` with `isDismiss`
+ * is present in the `actions` ReactNode tree.
+ *
+ * Walks the static element tree (fragments, arrays, single elements) instead
+ * of relying on render-phase ref mutation, so suppression does not depend on
+ * sibling render order or concurrent rendering timing.
  */
-function DismissActionDetector({ children }: { children: ReactNode }) {
-  const ref = useRef(false);
+function hasDismissAction(node: ReactNode): boolean {
+  let found = false;
 
-  // Reset each render so detection is fresh
-  ref.current = false;
+  const visit = (n: ReactNode) => {
+    if (found || n == null || typeof n === 'boolean' || typeof n === 'string') {
+      return;
+    }
 
-  return (
-    <DismissActionDetectedContext.Provider value={ref}>
-      {children}
-    </DismissActionDetectedContext.Provider>
-  );
+    if (Array.isArray(n)) {
+      for (const child of n) visit(child);
+      return;
+    }
+
+    if (isValidElement(n)) {
+      if (n.type === NotificationAction && (n.props as any).isDismiss) {
+        found = true;
+        return;
+      }
+
+      // Recurse into fragments (and other host-like wrappers with only children)
+      if (
+        n.type === Symbol.for('react.fragment') ||
+        typeof n.type === 'symbol'
+      ) {
+        visit((n.props as any).children);
+      }
+    }
+  };
+
+  visit(node);
+  return found;
 }
 
 /**
- * Renders the default "Dismiss" button only if no sibling NotificationAction
- * has `isDismiss` set. Reads from DismissActionDetectedContext ref which is
- * populated by actions that rendered before this component (left-to-right order).
+ * Renders the default "Dismiss" button. Suppression is decided by the caller
+ * via `hasDismissAction(actions)` — this component always renders the button.
  */
 function AutoDismissButton() {
-  const dismissDetectedRef = useContext(DismissActionDetectedContext);
-
-  if (dismissDetectedRef?.current) return null;
-
   return <NotificationAction isDismiss>Dismiss</NotificationAction>;
 }
 
@@ -110,17 +128,17 @@ function ActionsSection({
   onDismiss,
   onRestore,
 }: ActionsSectionProps) {
+  // Suppress the auto-appended "Dismiss" when any provided action is already
+  // marked `isDismiss`. Determined statically from the element tree so it does
+  // not depend on render order or concurrent rendering timing.
+  const hasDismiss = hasDismissAction(actions);
+  const showDefaultDismiss = showAutoDismiss && !hasDismiss;
+
   const actionsContent = (
     <Space placeSelf="end" placeContent="end" flexGrow={1}>
       {actions}
-      {showAutoDismiss && <AutoDismissButton />}
+      {showDefaultDismiss && <AutoDismissButton />}
     </Space>
-  );
-
-  const wrappedContent = showAutoDismiss ? (
-    <DismissActionDetector>{actionsContent}</DismissActionDetector>
-  ) : (
-    actionsContent
   );
 
   return (
@@ -131,10 +149,10 @@ function ActionsSection({
           onDismiss={onDismiss!}
           onRestore={onRestore}
         >
-          {wrappedContent}
+          {actionsContent}
         </NotificationDismissProvider>
       ) : (
-        wrappedContent
+        actionsContent
       )}
     </ItemActionProvider>
   );

--- a/src/components/overlays/Notifications/Notifications.test.tsx
+++ b/src/components/overlays/Notifications/Notifications.test.tsx
@@ -572,6 +572,54 @@ describe('isDismiss context detection', () => {
   });
 });
 
+// ─── isDismiss suppression via notify() overlay path ─────────────────
+
+describe('isDismiss suppression via notify()', () => {
+  it('suppresses default Dismiss when isDismiss action is present via notify()', async () => {
+    function TestComponent() {
+      const { notify } = useNotifications();
+
+      return (
+        <Button
+          onPress={() =>
+            notify({
+              id: 'update-available',
+              theme: 'note',
+              title: 'New version available',
+              description:
+                'A quick refresh will update you to the latest version.',
+              duration: null,
+              persistent: true,
+              actions: (
+                <>
+                  <NotificationAction onPress={() => {}}>
+                    Refresh now
+                  </NotificationAction>
+                  <NotificationAction isDismiss>Later</NotificationAction>
+                </>
+              ),
+            })
+          }
+        >
+          Show
+        </Button>
+      );
+    }
+
+    const { getByRole, getByText, queryAllByText } = renderWithOverlay(
+      <TestComponent />,
+    );
+
+    await act(async () => {
+      getByRole('button', { name: 'Show' }).click();
+    });
+
+    await waitFor(() => expect(getByText('Later')).toBeInTheDocument());
+    await waitFor(() => expect(getByText('Refresh now')).toBeInTheDocument());
+    expect(queryAllByText('Dismiss')).toHaveLength(0);
+  });
+});
+
 // ─── Persistent Notifications ────────────────────────────────────────
 
 describe('Persistent Notifications', () => {


### PR DESCRIPTION
…e static analysis

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized notification UI logic with added tests; static walk cannot see `NotificationAction` created inside opaque wrappers (documented limitation).
> 
> **Overview**
> Fixes notifications showing both a custom **`isDismiss`** action and the auto-appended **"Dismiss"** button.
> 
> **`NotificationCard`** now uses **`hasDismissAction(actions)`** to walk the `actions` ReactNode tree (arrays, fragments, wrappers via `children`) and detect any **`NotificationAction`** with **`isDismiss`**, then only renders the default dismiss when **`showAutoDismiss && !hasDismiss`**. The previous **`DismissActionDetector`** / ref-mutation approach and **`DismissActionDetectedContext`** are removed.
> 
> **`NotificationAction`** no longer writes to that context during render; docs point to static detection on the card. A changeset documents the patch, and tests add **`notify()`** overlay coverage so suppression works on the real overlay path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e54a024875eee12076d6fc2322ec0febbffa2b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->