### PR TITLE
feat(Board): new features

### DIFF
--- a/.changeset/board-widget-enhancements.md
+++ b/.changeset/board-widget-enhancements.md
@@ -1,0 +1,12 @@
+---
+"@cube-dev/ui-kit": minor
+---
+
+Enhance `Board` with widget defaults, card styling, and aligned nested-board improvements:
+
+- Add `widgetProps` on `Board` to set default props for every hosted widget (e.g. `widgetProps={{ isCard: true }}`).
+- Add `isCard` on `Board.Widget` for optional card borders; widgets are filled (`#surface-2`) and rounded by default.
+- Add per-widget `minW`/`maxW`/`minH`/`maxH` bounds on `Board.Widget` (used when layout items omit them).
+- Accept container style props directly on `Board.Widget` (merged into `styles`).
+- Aligned nested boards (`isAligned`) now use the parent's row height verbatim (no shrinking to fit) and default `containerPadding` to `[0, 0]` so columns line up with the ancestor grid.
+- Nested boards inherit an ancestor's `showGridLines` while dragging when they do not set their own.

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "*.(js|ts|tsx|jsx)": ["prettier --write", "oxlint --fix"]
+  "*.{js,jsx,ts,tsx}": ["prettier --write", "oxlint --fix"]
 }

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "dedent": "^0.7.0",
     "husky": "^6.0.0",
     "jsdom": "^29.1.1",
-    "lint-staged": "^10.0.0",
+    "lint-staged": "^17.0.8",
     "markdown-table": "^3.0.3",
     "npm-run-all": "^4.1.5",
     "oxlint": "^1.72.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,10 +143,10 @@ importers:
         version: 5.20.1
       '@storybook/addon-docs':
         specifier: ^10.3.6
-        version: 10.3.6(@types/react@19.1.10)(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))
+        version: 10.3.6(@types/react@19.1.10)(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@storybook/react-vite':
         specifier: ^10.3.6
-        version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))
+        version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^0.6.2
         version: 0.6.2(eslint@9.25.1(jiti@2.6.1))(typescript@5.6.3)
@@ -188,10 +188,10 @@ importers:
         version: 4.25.4(@babel/runtime@7.28.3)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(codemirror@6.0.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@vitejs/plugin-react':
         specifier: ^6.0.0
-        version: 6.0.1(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+        version: 6.0.1(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)))
+        version: 4.1.0(vitest@4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)))
       best-effort-json-parser:
         specifier: ^1.2.1
         version: 1.2.1
@@ -214,8 +214,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       lint-staged:
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^17.0.8
+        version: 17.0.8
       markdown-table:
         specifier: ^3.0.3
         version: 3.0.3
@@ -266,10 +266,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+        version: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+        version: 4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))
 
 packages:
 
@@ -1948,18 +1948,6 @@ packages:
       rollup:
         optional: true
 
-  '@samverschueren/stream-to-observable@0.3.1':
-    resolution: {integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zen-observable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zen-observable:
-        optional: true
-
   '@size-limit/file@8.2.4':
     resolution: {integrity: sha512-xLuF97W7m7lxrRJvqXRlxO/4t7cpXtfxOnjml/t4aRVUCMXLdyvebRr9OM4jjoK8Fmiz8jomCbETUCI3jVhLzA==}
     engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
@@ -2318,9 +2306,6 @@ packages:
   '@types/pako@2.0.0':
     resolution: {integrity: sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==}
 
-  '@types/parse-json@4.0.0':
-    resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
@@ -2571,17 +2556,9 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-escapes@3.2.0:
-    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
-    engines: {node: '>=4'}
-
-  ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-
-  ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
-    engines: {node: '>=4'}
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2591,9 +2568,9 @@ packages:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
 
-  ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -2611,21 +2588,13 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
-
-  any-observable@0.3.0:
-    resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      rxjs: '*'
-      zenObservable: '*'
-    peerDependenciesMeta:
-      rxjs:
-        optional: true
-      zenObservable:
-        optional: true
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -2801,10 +2770,6 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
-
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2854,13 +2819,13 @@ packages:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
 
-  cli-cursor@2.1.0:
-    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
-    engines: {node: '>=4'}
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
 
-  cli-truncate@0.2.1:
-    resolution: {integrity: sha512-f4r4yJnbT++qUPI9NR4XLDLq41gQ+uqnPItWG0F5ZkehuNiTTa3EY0S4AqTSUOeJ7/zU41oWPQSNkW5BqPL9bg==}
-    engines: {node: '>=0.10.0'}
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   clipboard-copy@4.0.1:
     resolution: {integrity: sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==}
@@ -2888,10 +2853,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  code-point-at@1.1.0:
-    resolution: {integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==}
-    engines: {node: '>=0.10.0'}
-
   codemirror@6.0.2:
     resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
@@ -2910,10 +2871,6 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -2949,10 +2906,6 @@ packages:
       cosmiconfig: '>=7'
       ts-node: '>=10'
       typescript: '>=3'
-
-  cosmiconfig@6.0.0:
-    resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
-    engines: {node: '>=8'}
 
   cosmiconfig@8.1.3:
     resolution: {integrity: sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==}
@@ -3023,9 +2976,6 @@ packages:
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-
-  date-fns@1.30.1:
-    resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==}
 
   debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
@@ -3172,13 +3122,12 @@ packages:
   electron-to-chromium@1.5.38:
     resolution: {integrity: sha512-VbeVexmZ1IFh+5EfrYz1I0HTzHVIlJa112UEWhciPyeOcKJGeTv6N8WnG4wsQB81DGCaVEGhpSb6o6a8WYFXXg==}
 
-  elegant-spinner@1.0.1:
-    resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
-    engines: {node: '>=0.10.0'}
-
   email-validator@2.0.4:
     resolution: {integrity: sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==}
     engines: {node: '>4.0'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3189,9 +3138,6 @@ packages:
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
-
-  end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
   enhanced-resolve@5.14.1:
     resolution: {integrity: sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==}
@@ -3204,6 +3150,10 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -3324,13 +3274,12 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-
-  execa@3.4.0:
-    resolution: {integrity: sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==}
-    engines: {node: ^8.12.0 || >=9.7.0}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -3374,14 +3323,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  figures@1.7.0:
-    resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
-    engines: {node: '>=0.10.0'}
-
-  figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
-    engines: {node: '>=4'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3456,20 +3397,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-own-enumerable-property-symbols@3.0.2:
-    resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -3547,10 +3485,6 @@ packages:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
 
-  has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
-
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -3604,10 +3538,6 @@ packages:
   human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
 
-  human-signals@1.1.1:
-    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
-    engines: {node: '>=8.12.0'}
-
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -3635,10 +3565,6 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-
-  indent-string@3.2.0:
-    resolution: {integrity: sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==}
-    engines: {node: '>=4'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -3721,17 +3647,13 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
-  is-fullwidth-code-point@1.0.0:
-    resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
-    engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
-    engines: {node: '>=4'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
@@ -3758,17 +3680,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-obj@1.0.1:
-    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
-    engines: {node: '>=0.10.0'}
-
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
-
-  is-observable@1.1.0:
-    resolution: {integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==}
-    engines: {node: '>=4'}
 
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
@@ -3781,16 +3695,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
-  is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
-
-  is-regexp@1.0.0:
-    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
-    engines: {node: '>=0.10.0'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -3799,10 +3706,6 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
-
-  is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
-    engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -4039,27 +3942,14 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  lint-staged@10.0.0:
-    resolution: {integrity: sha512-/MrZOLMnljjMHakxlRd1Z5Kr8wWWlrWFasye7HaTv5tx56icwzT/STRty8flMKsyzBGTfTa9QszNVPsDS/yOug==}
+  lint-staged@17.0.8:
+    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+    engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr-silent-renderer@1.1.1:
-    resolution: {integrity: sha512-L26cIFm7/oZeSNVhWB6faeorXhMg4HNlb/dS/7jHhr708jxlXrtrBWo4YUxZQkc6dGoxEAe6J/D3juTRBUzjtA==}
-    engines: {node: '>=4'}
-
-  listr-update-renderer@0.5.0:
-    resolution: {integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      listr: ^0.14.2
-
-  listr-verbose-renderer@0.5.0:
-    resolution: {integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==}
-    engines: {node: '>=4'}
-
-  listr@0.14.3:
-    resolution: {integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==}
-    engines: {node: '>=6'}
+  listr2@10.2.2:
+    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
+    engines: {node: '>=22.13.0'}
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -4117,17 +4007,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
-  log-symbols@1.0.2:
-    resolution: {integrity: sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==}
-    engines: {node: '>=0.10.0'}
-
-  log-symbols@3.0.0:
-    resolution: {integrity: sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==}
-    engines: {node: '>=8'}
-
-  log-update@2.3.0:
-    resolution: {integrity: sha512-vlP11XfFGyeNQlmEn9tJ66rEW1coA/79m5z6BCkudjbAGE83uhAcGYrBFwfs3AdLiLzGRusRPAbSPK9xZteCmg==}
-    engines: {node: '>=4'}
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -4357,13 +4239,13 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mimic-fn@1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
-    engines: {node: '>=4'}
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -4454,10 +4336,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  number-is-nan@1.0.1:
-    resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
-    engines: {node: '>=0.10.0'}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4480,13 +4358,13 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onetime@2.0.1:
-    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
-    engines: {node: '>=4'}
-
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -4526,10 +4404,6 @@ packages:
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
-
-  p-finally@2.0.1:
-    resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
     engines: {node: '>=8'}
 
   p-limit@2.3.0:
@@ -4632,6 +4506,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pidtree@0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
     engines: {node: '>=0.10'}
@@ -4648,9 +4526,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  please-upgrade-node@3.2.0:
-    resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -4701,9 +4576,6 @@ packages:
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-
-  pump@3.0.0:
-    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
 
   punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -4899,13 +4771,16 @@ packages:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
-  restore-cursor@2.0.0:
-    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
-    engines: {node: '>=4'}
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
@@ -4948,10 +4823,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
-
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -4980,9 +4851,6 @@ packages:
   schema-utils@3.1.2:
     resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
     engines: {node: '>= 10.13.0'}
-
-  semver-compare@1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
   semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -5096,9 +4964,13 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  slice-ansi@0.0.4:
-    resolution: {integrity: sha512-up04hB2hR92PgjpyU3y/eg91yIBILyjVY26NvvciY3EVVPjybkMszMpXQ9QAkcS3I5rtJBDLoTxxg+qvW8c7rw==}
-    engines: {node: '>=0.10.0'}
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   smartwrap@1.2.5:
     resolution: {integrity: sha512-bzWRwHwu0RnWjwU7dFy7tF68pDAx/zMSu3g7xr9Nx5J0iSImYInglwEVExyHLxXljy6PWMjkSAbwF7t2mPnRmg==}
@@ -5163,13 +5035,9 @@ packages:
   stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
 
-  string-width@1.0.2:
-    resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
-    engines: {node: '>=0.10.0'}
-
-  string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5178,6 +5046,14 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   string.prototype.padend@3.1.4:
     resolution: {integrity: sha512-67otBXoksdjsnXXRUq+KMVTdlVRZ2af422Y0aTyTjVaoQkGr3mxl2Bc5emi7dOQ3OGVVQQskmLEWwFXwommpNw==}
@@ -5198,24 +5074,16 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
-  stringify-object@3.3.0:
-    resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
-    engines: {node: '>=4'}
-
-  strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-
-  strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
-    engines: {node: '>=4'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom@3.0.0:
@@ -5241,10 +5109,6 @@ packages:
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
-  supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
-
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -5260,10 +5124,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  symbol-observable@1.2.0:
-    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
-    engines: {node: '>=0.10.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5315,6 +5175,10 @@ packages:
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -5422,9 +5286,6 @@ packages:
         optional: true
       unplugin-unused:
         optional: true
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5759,9 +5620,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@3.0.1:
-    resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
-    engines: {node: '>=4'}
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -5774,6 +5635,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -5817,9 +5682,10 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -6682,11 +6548,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.2.2(typescript@5.6.3)
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
     optionalDependencies:
       typescript: 5.6.3
 
@@ -7996,14 +7862,6 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)':
-    dependencies:
-      any-observable: 0.3.0(rxjs@6.6.7)
-    optionalDependencies:
-      rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zenObservable
-
   '@size-limit/file@8.2.4(size-limit@8.2.6)':
     dependencies:
       semver: 7.3.8
@@ -8220,10 +8078,10 @@ snapshots:
     dependencies:
       '@statoscope/types': 5.22.0
 
-  '@storybook/addon-docs@10.3.6(@types/react@19.1.10)(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))':
+  '@storybook/addon-docs@10.3.6(@types/react@19.1.10)(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))':
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@19.1.10)(react@19.1.1)
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@storybook/icons': 2.0.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@storybook/react-dom-shim': 10.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       react: 19.1.1
@@ -8237,24 +8095,24 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))':
+  '@storybook/builder-vite@10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       ts-dedent: 2.2.0
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))':
+  '@storybook/csf-plugin@10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))':
     dependencies:
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       unplugin: 2.3.10
     optionalDependencies:
       esbuild: 0.27.3
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
       webpack: 5.76.1(esbuild@0.27.3)
 
   '@storybook/global@5.0.0': {}
@@ -8270,11 +8128,11 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))':
+  '@storybook/react-vite@10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))
       '@rollup/pluginutils': 5.1.0
-      '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))(webpack@5.76.1(esbuild@0.27.3))
+      '@storybook/builder-vite': 10.3.6(esbuild@0.27.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@storybook/react': 10.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -8284,7 +8142,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       tsconfig-paths: 4.2.0
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -8486,8 +8344,6 @@ snapshots:
 
   '@types/pako@2.0.0': {}
 
-  '@types/parse-json@4.0.0': {}
-
   '@types/prismjs@1.26.5': {}
 
   '@types/react-dom@19.1.7(@types/react@19.1.10)':
@@ -8598,12 +8454,12 @@ snapshots:
       - '@codemirror/lint'
       - '@codemirror/search'
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -8615,7 +8471,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+      vitest: 4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -8634,13 +8490,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8799,17 +8655,15 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
-  ansi-escapes@3.2.0: {}
-
-  ansi-regex@2.1.1: {}
-
-  ansi-regex@3.0.1: {}
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.0.1: {}
 
-  ansi-styles@2.2.1: {}
+  ansi-regex@6.2.2: {}
 
   ansi-styles@3.2.1:
     dependencies:
@@ -8823,11 +8677,9 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  ansis@4.2.0: {}
+  ansi-styles@6.2.3: {}
 
-  any-observable@0.3.0(rxjs@6.6.7):
-    optionalDependencies:
-      rxjs: 6.6.7
+  ansis@4.2.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -8998,14 +8850,6 @@ snapshots:
 
   chai@6.2.2: {}
 
-  chalk@1.1.3:
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
-
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -9048,14 +8892,14 @@ snapshots:
 
   ci-info@3.8.0: {}
 
-  cli-cursor@2.1.0:
+  cli-cursor@5.0.0:
     dependencies:
-      restore-cursor: 2.0.0
+      restore-cursor: 5.1.0
 
-  cli-truncate@0.2.1:
+  cli-truncate@5.2.0:
     dependencies:
-      slice-ansi: 0.0.4
-      string-width: 1.0.2
+      slice-ansi: 8.0.0
+      string-width: 8.2.2
 
   clipboard-copy@4.0.1: {}
 
@@ -9078,8 +8922,6 @@ snapshots:
   clsx@2.1.0: {}
 
   clsx@2.1.1: {}
-
-  code-point-at@1.1.0: {}
 
   codemirror@6.0.2:
     dependencies:
@@ -9104,8 +8946,6 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@2.20.3: {}
-
-  commander@4.1.1: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -9144,14 +8984,6 @@ snapshots:
       cosmiconfig: 8.1.3
       ts-node: 10.9.1(@types/node@24.13.3)(typescript@5.6.3)
       typescript: 5.6.3
-
-  cosmiconfig@6.0.0:
-    dependencies:
-      '@types/parse-json': 4.0.0
-      import-fresh: 3.3.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
 
   cosmiconfig@8.1.3:
     dependencies:
@@ -9236,8 +9068,6 @@ snapshots:
       is-data-view: 1.0.2
 
   dataloader@1.4.0: {}
-
-  date-fns@1.30.1: {}
 
   debug@4.3.5:
     dependencies:
@@ -9345,19 +9175,15 @@ snapshots:
 
   electron-to-chromium@1.5.38: {}
 
-  elegant-spinner@1.0.1: {}
-
   email-validator@2.0.4: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
-
-  end-of-stream@1.4.4:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.14.1:
     dependencies:
@@ -9369,6 +9195,8 @@ snapshots:
       ansi-colors: 4.1.3
 
   entities@8.0.0: {}
+
+  environment@1.1.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -9576,20 +9404,9 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  events@3.3.0: {}
+  eventemitter3@5.0.4: {}
 
-  execa@3.4.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 5.2.0
-      human-signals: 1.1.1
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 4.0.1
-      onetime: 5.1.2
-      p-finally: 2.0.1
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
+  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -9636,15 +9453,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
-
-  figures@1.7.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-      object-assign: 4.1.1
-
-  figures@2.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9727,6 +9535,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9740,16 +9550,10 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-own-enumerable-property-symbols@3.0.2: {}
-
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.0
 
   get-stream@6.0.1: {}
 
@@ -9830,10 +9634,6 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  has-ansi@2.0.0:
-    dependencies:
-      ansi-regex: 2.1.1
-
   has-bigints@1.0.2: {}
 
   has-flag@3.0.0: {}
@@ -9878,8 +9678,6 @@ snapshots:
 
   human-id@1.0.2: {}
 
-  human-signals@1.1.1: {}
-
   human-signals@2.1.0: {}
 
   husky@6.0.0: {}
@@ -9898,8 +9696,6 @@ snapshots:
   import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
-
-  indent-string@3.2.0: {}
 
   indent-string@4.0.0: {}
 
@@ -9978,13 +9774,11 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-fullwidth-code-point@1.0.0:
-    dependencies:
-      number-is-nan: 1.0.1
-
-  is-fullwidth-code-point@2.0.0: {}
-
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
 
   is-generator-function@1.0.10:
     dependencies:
@@ -10007,21 +9801,13 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-obj@1.0.1: {}
-
   is-obj@2.0.0: {}
-
-  is-observable@1.1.0:
-    dependencies:
-      symbol-observable: 1.2.0
 
   is-plain-obj@1.1.0: {}
 
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
-
-  is-promise@2.2.2: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -10030,15 +9816,11 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  is-regexp@1.0.0: {}
-
   is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
-
-  is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
 
@@ -10250,60 +10032,22 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lint-staged@10.0.0:
+  lint-staged@17.0.8:
     dependencies:
-      chalk: 3.0.0
-      commander: 4.1.1
-      cosmiconfig: 6.0.0
-      debug: 4.3.5
-      dedent: 0.7.0
-      execa: 3.4.0
-      listr: 0.14.3
-      log-symbols: 3.0.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      please-upgrade-node: 3.2.0
-      stringify-object: 3.3.0
-    transitivePeerDependencies:
-      - supports-color
-      - zen-observable
-      - zenObservable
+      listr2: 10.2.2
+      picomatch: 4.0.5
+      string-argv: 0.3.2
+      tinyexec: 1.2.4
+    optionalDependencies:
+      yaml: 2.9.0
 
-  listr-silent-renderer@1.1.1: {}
-
-  listr-update-renderer@0.5.0(listr@0.14.3):
+  listr2@10.2.2:
     dependencies:
-      chalk: 1.1.3
-      cli-truncate: 0.2.1
-      elegant-spinner: 1.0.1
-      figures: 1.7.0
-      indent-string: 3.2.0
-      listr: 0.14.3
-      log-symbols: 1.0.2
-      log-update: 2.3.0
-      strip-ansi: 3.0.1
-
-  listr-verbose-renderer@0.5.0:
-    dependencies:
-      chalk: 2.4.2
-      cli-cursor: 2.1.0
-      date-fns: 1.30.1
-      figures: 2.0.0
-
-  listr@0.14.3:
-    dependencies:
-      '@samverschueren/stream-to-observable': 0.3.1(rxjs@6.6.7)
-      is-observable: 1.1.0
-      is-promise: 2.2.2
-      is-stream: 1.1.0
-      listr-silent-renderer: 1.1.1
-      listr-update-renderer: 0.5.0(listr@0.14.3)
-      listr-verbose-renderer: 0.5.0
-      p-map: 2.1.0
-      rxjs: 6.6.7
-    transitivePeerDependencies:
-      - zen-observable
-      - zenObservable
+      cli-truncate: 5.2.0
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 10.0.0
 
   load-json-file@4.0.0:
     dependencies:
@@ -10353,19 +10097,13 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  log-symbols@1.0.2:
+  log-update@6.1.0:
     dependencies:
-      chalk: 1.1.3
-
-  log-symbols@3.0.0:
-    dependencies:
-      chalk: 2.4.2
-
-  log-update@2.3.0:
-    dependencies:
-      ansi-escapes: 3.2.0
-      cli-cursor: 2.1.0
-      wrap-ansi: 3.0.1
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.1.0
+      wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
 
@@ -10775,9 +10513,9 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mimic-fn@1.2.0: {}
-
   mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   min-indent@1.0.1: {}
 
@@ -10861,8 +10599,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  number-is-nan@1.0.1: {}
-
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -10884,13 +10620,13 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  onetime@2.0.1:
-    dependencies:
-      mimic-fn: 1.2.0
-
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   open@10.2.0:
     dependencies:
@@ -10949,8 +10685,6 @@ snapshots:
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
-
-  p-finally@2.0.1: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -11034,6 +10768,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pidtree@0.3.1: {}
 
   pify@3.0.0: {}
@@ -11043,10 +10779,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  please-upgrade-node@3.2.0:
-    dependencies:
-      semver-compare: 1.0.0
 
   possible-typed-array-names@1.0.0: {}
 
@@ -11092,11 +10824,6 @@ snapshots:
       react-is: 16.13.1
 
   pseudomap@1.0.2: {}
-
-  pump@3.0.0:
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
 
   punycode@2.3.0: {}
 
@@ -11386,12 +11113,14 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  restore-cursor@2.0.0:
+  restore-cursor@5.1.0:
     dependencies:
-      onetime: 2.0.1
-      signal-exit: 3.0.7
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   reusify@1.0.4: {}
+
+  rfdc@1.4.1: {}
 
   rimraf@6.0.1:
     dependencies:
@@ -11461,10 +11190,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rxjs@6.6.7:
-    dependencies:
-      tslib: 1.14.1
-
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -11499,8 +11224,6 @@ snapshots:
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
-
-  semver-compare@1.0.0: {}
 
   semver@5.7.1: {}
 
@@ -11619,7 +11342,15 @@ snapshots:
 
   slash@3.0.0: {}
 
-  slice-ansi@0.0.4: {}
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smartwrap@1.2.5:
     dependencies:
@@ -11705,16 +11436,7 @@ snapshots:
     dependencies:
       mixme: 0.5.9
 
-  string-width@1.0.2:
-    dependencies:
-      code-point-at: 1.1.0
-      is-fullwidth-code-point: 1.0.0
-      strip-ansi: 3.0.1
-
-  string-width@2.1.1:
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
+  string-argv@0.3.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -11727,6 +11449,17 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.1.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   string.prototype.padend@3.1.4:
     dependencies:
@@ -11761,20 +11494,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  stringify-object@3.3.0:
-    dependencies:
-      get-own-enumerable-property-symbols: 3.0.2
-      is-obj: 1.0.1
-      is-regexp: 1.0.0
-
-  strip-ansi@3.0.1:
-    dependencies:
-      ansi-regex: 2.1.1
-
-  strip-ansi@4.0.0:
-    dependencies:
-      ansi-regex: 3.0.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -11782,6 +11501,10 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -11799,8 +11522,6 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  supports-color@2.0.0: {}
-
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -11814,8 +11535,6 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  symbol-observable@1.2.0: {}
 
   symbol-tree@3.2.4: {}
 
@@ -11854,6 +11573,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -11952,8 +11673,6 @@ snapshots:
       - oxc-resolver
       - synckit
       - vue-tsc
-
-  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -12137,7 +11856,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1):
+  vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -12151,11 +11870,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.31.1
+      yaml: 2.9.0
 
-  vitest@4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)):
+  vitest@4.1.0(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -12172,7 +11892,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)
+      vite: 8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
@@ -12310,10 +12030,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@3.0.1:
+  wrap-ansi@10.0.0:
     dependencies:
-      string-width: 2.1.1
-      strip-ansi: 4.0.0
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -12331,6 +12052,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
+      strip-ansi: 7.1.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
@@ -12355,7 +12082,8 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@1.10.2: {}
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@18.1.3:
     dependencies:

--- a/src/components/layout/Board/Board.docs.mdx
+++ b/src/components/layout/Board/Board.docs.mdx
@@ -53,7 +53,7 @@ clipped by an ancestor's `overflow: hidden`.
 - **`cols`** `number` (default: `12`) — Number of columns.
 - **`rowHeight`** `number` (default: `100`) — Row height in pixels.
 - **`margin`** `[number, number]` (default: `[8, 8]`) — Horizontal/vertical gap between widgets.
-- **`containerPadding`** `[number, number]` — Inner padding. Defaults to `margin`.
+- **`containerPadding`** `[number, number]` — Inner padding. Defaults to `margin`, or to `[0, 0]` for an aligned nested board (`isAligned`) so its grid lines up with the ancestor board's.
 - **`maxRows`** `number` (default: `Infinity`) — Maximum number of rows.
 - **`compact`** `'vertical' | 'horizontal' | 'free' | null` (default: `'vertical'`) — Compaction behavior. `'vertical'`/`'horizontal'` reflow widgets to remove gaps; `'free'` places each widget exactly where dropped and never pushes its neighbours (blocked from occupied cells unless `allowOverlap`); `null` disables compaction but still resolves collisions the legacy react-grid-layout way.
 - **`allowOverlap`** `boolean` (default: `false`) — Allow widgets to overlap (stack). In `'free'` mode this is what distinguishes stacking from blocking a drop onto an occupied cell.
@@ -65,15 +65,17 @@ clipped by an ancestor's `overflow: hidden`.
 - **`dragCancel`** `string` — CSS selector for elements that must not start a pointer drag (e.g. form controls inside a widget: `"input,textarea,button,a,.no-drag"`). Keyboard moves are unaffected. Can be overridden per widget.
 - **`dragHandle`** `string` — CSS selector for the only elements from which a pointer drag may start. Can be overridden per widget.
 - **`showGridLines`** `boolean | 'drag'` (default: `false`) — Show grid lines behind the widgets. `true` always, `'drag'` only while a widget is being dragged or resized. A nested board that does not set this inherits an enabled ancestor's grid lines, showing its own while a drag is in progress.
-- **`isAligned`** `boolean` (default: `false`) — Align a nested board with its ancestor `Board`'s layout. Only takes effect when the board is nested inside another `Board`'s widget. When set, the board inherits the parent's column pitch (deriving its own column count from its measured width so cells stay parent-sized as the container is resized) and inherits the parent's row height as a target, shrinking rows slightly when needed to fit the height the container widget grants it. `cols`/`rowHeight` then act as fallbacks used only until the parent metrics resolve.
+- **`isAligned`** `boolean` (default: `false`) — Align a nested board with its ancestor `Board`'s layout. Only takes effect when the board is nested inside another `Board`'s widget. When set, every cell matches the parent's cell size exactly: the board inherits the parent's column pitch (deriving its own column count from its measured width so cells stay parent-sized as the container is resized) and uses the parent's row height verbatim. It never shrinks rows to fit — pair it with an `isAutoHeight` container so the widget grows to fit its rows at that height. `cols`/`rowHeight` then act as fallbacks used only until the parent metrics resolve.
 - **`constraints`** `LayoutConstraint[]` — Grid/item layout constraints.
 - **`width`** `number` — Explicit width (disables measurement; useful for SSR/tests).
+- **`widgetProps`** `Partial<Board.Widget props>` — Default props applied to every widget this board hosts (per-widget `Board.Widget` props override these). Use it to add a card border to every widget (`widgetProps={{ isCard: true }}`) or set shared `styles`/sizing defaults without repeating them on each widget.
 - **`place`** `Styles['place']` — Style prop shorthand for `place-items`/`place-content`.
 - **`scrollMargin`** `Styles['scrollMargin']` — Style prop for scroll margin.
 
 ### Board.Widget
 
 - **`id`** `string` (required) — Must match the `i` of a layout item.
+- **`isCard`** `boolean` (default: `false`) — Render this widget as a card by adding a border. Widgets are always filled (`#surface-2`) and rounded (`1cr`); `isCard` adds the border on top. Defaults to `false` (borderless) unless the owning `Board`'s `widgetProps.isCard` opts in; set it per widget to override that default.
 - **`isDraggable`** `boolean` — Disable dragging for this widget.
 - **`isResizable`** `boolean` — Disable resizing for this widget.
 - **`resizeHandles`** `ResizeHandleAxis[]` — Override the board's handles.
@@ -84,6 +86,7 @@ clipped by an ancestor's `overflow: hidden`.
 - **`constraints`** `LayoutConstraint[]` — Per-widget constraints.
 - **`qa`** `string` — Test id for the rendered widget element.
 - **`styles`** `Styles` — Style overrides for the rendered widget element.
+- **Style properties** — `Board.Widget` also accepts container style props directly (e.g. `fill`, `padding`, `radius`, `border`, `shadow`, `color`, `flow`, `gap`), just like `Board`. They are merged into `styles` (the `styles` object wins on conflicts).
 - **`isAutoHeight`** `boolean` (default: `false`) — Grow this widget's height in its board to fit its content (only ever increases, never shrinks). Pair it with a nested `Board isAligned` so the container expands until the inner board's rows fit at the parent's row height. It also pins the widget's resize floor: you cannot drag the widget shorter than the height its content currently needs.
 - **`dragCancel`** `string` — Override the board's `dragCancel` selector for this widget.
 - **`dragHandle`** `string` — Override the board's `dragHandle` selector for this widget.
@@ -182,6 +185,14 @@ Show grid lines behind the widgets while dragging or resizing (or always).
 
 <Story of={BoardStories.GridLines} />
 
+### Card widgets
+
+Widgets are filled (`#surface-2`) and rounded by default, but borderless. Add a
+card border per widget with `isCard`, or for the whole board at once with
+`widgetProps={{ isCard: true }}`. Per-widget `isCard` overrides the board default.
+
+<Story of={BoardStories.CardWidgets} />
+
 ### Drag cancel
 
 Keep interactive controls inside a widget clickable by excluding them from the
@@ -206,18 +217,26 @@ Wrap boards in `Board.Provider` to drag widgets between them.
 A `Board` can be placed inside a `Board.Widget`, making the whole container
 draggable while its children can be dragged out into sibling boards.
 
-Set `isAligned` on the nested board to align it with the surrounding layout: its
-columns keep the parent's pixel pitch (so resizing the container adds or removes
-columns instead of stretching them), and its rows inherit the parent's row
-height, shrinking slightly when needed to fit the space the container widget
-gives it.
+Set `isAligned` on the nested board to align it with the surrounding layout:
+every cell matches the parent's cell size exactly. Its columns keep the parent's
+pixel pitch (so resizing the container adds or removes columns instead of
+stretching them) and its rows use the parent's row height verbatim.
 
-Add `isAutoHeight` to the container `Board.Widget` to grow it (only ever taller)
-until the inner board's rows fit at the parent's row height, so an aligned board
-never has to squeeze its rows. It also stops the container's resize handle at
-that height, so you can't drag it shorter than the inner board needs.
+Because an aligned board never shrinks its rows to fit, add `isAutoHeight` to the
+container `Board.Widget` so it grows (only ever taller) until the inner board's
+rows fit at the parent's row height. It also stops the container's resize handle
+at that height, so you can't drag it shorter than the inner board needs.
 
 <Story of={BoardStories.NestedBoards} />
+
+### Aligned nested boards
+
+A nested `Board` with `isAligned` and no padding, fill, border, or radius of its
+own — only a header above the grid — inherits the parent column pitch with zero
+offset, so its columns line up exactly with the outer board. Grid lines are
+shown on both boards while dragging to verify the alignment.
+
+<Story of={BoardStories.AlignedNestedBoards} />
 
 ### Boards inside Tabs
 

--- a/src/components/layout/Board/Board.docs.mdx
+++ b/src/components/layout/Board/Board.docs.mdx
@@ -86,7 +86,7 @@ clipped by an ancestor's `overflow: hidden`.
 - **`constraints`** `LayoutConstraint[]` — Per-widget constraints.
 - **`qa`** `string` — Test id for the rendered widget element.
 - **`styles`** `Styles` — Style overrides for the rendered widget element.
-- **Style properties** — `Board.Widget` also accepts container style props directly (e.g. `fill`, `padding`, `radius`, `border`, `shadow`, `color`, `flow`, `gap`), just like `Board`. They are merged into `styles` (the `styles` object wins on conflicts).
+- **Style properties** — `Board.Widget` also accepts container style props directly (e.g. `fill`, `padding`, `radius`, `border`, `shadow`, `color`, `flow`, `gap`), just like `Board`. They are merged into `styles` (a direct prop wins over the same key in the `styles` object). Shared `widgetProps.styles` from the owning `Board` are merged underneath, so a per-widget style only overrides the matching keys instead of replacing the whole default.
 - **`isAutoHeight`** `boolean` (default: `false`) — Grow this widget's height in its board to fit its content (only ever increases, never shrinks). Pair it with a nested `Board isAligned` so the container expands until the inner board's rows fit at the parent's row height. It also pins the widget's resize floor: you cannot drag the widget shorter than the height its content currently needs.
 - **`dragCancel`** `string` — Override the board's `dragCancel` selector for this widget.
 - **`dragHandle`** `string` — Override the board's `dragHandle` selector for this widget.

--- a/src/components/layout/Board/Board.docs.mdx
+++ b/src/components/layout/Board/Board.docs.mdx
@@ -64,7 +64,7 @@ clipped by an ancestor's `overflow: hidden`.
 - **`resizeHandles`** `ResizeHandleAxis[]` (default: `['se']`) — Which resize handles to show. Corner handles (`ne`/`nw`/`se`/`sw`) show an angle grip; edge handles (`n`/`s`/`e`/`w`) show a dotted grip. Both are revealed on hover/focus/resize. A single edge (e.g. `['e']` or `['s']`) gives a horizontally- or vertically-only resizable widget.
 - **`dragCancel`** `string` — CSS selector for elements that must not start a pointer drag (e.g. form controls inside a widget: `"input,textarea,button,a,.no-drag"`). Keyboard moves are unaffected. Can be overridden per widget.
 - **`dragHandle`** `string` — CSS selector for the only elements from which a pointer drag may start. Can be overridden per widget.
-- **`showGridLines`** `boolean | 'drag'` (default: `false`) — Show grid lines behind the widgets. `true` always, `'drag'` only while a widget is being dragged or resized.
+- **`showGridLines`** `boolean | 'drag'` (default: `false`) — Show grid lines behind the widgets. `true` always, `'drag'` only while a widget is being dragged or resized. A nested board that does not set this inherits an enabled ancestor's grid lines, showing its own while a drag is in progress.
 - **`isAligned`** `boolean` (default: `false`) — Align a nested board with its ancestor `Board`'s layout. Only takes effect when the board is nested inside another `Board`'s widget. When set, the board inherits the parent's column pitch (deriving its own column count from its measured width so cells stay parent-sized as the container is resized) and inherits the parent's row height as a target, shrinking rows slightly when needed to fit the height the container widget grants it. `cols`/`rowHeight` then act as fallbacks used only until the parent metrics resolve.
 - **`constraints`** `LayoutConstraint[]` — Grid/item layout constraints.
 - **`width`** `number` — Explicit width (disables measurement; useful for SSR/tests).
@@ -77,6 +77,10 @@ clipped by an ancestor's `overflow: hidden`.
 - **`isDraggable`** `boolean` — Disable dragging for this widget.
 - **`isResizable`** `boolean` — Disable resizing for this widget.
 - **`resizeHandles`** `ResizeHandleAxis[]` — Override the board's handles.
+- **`minW`** `number` — Minimum width in grid columns. Used when the layout item omits `minW`; the resize handle stops here.
+- **`maxW`** `number` — Maximum width in grid columns. Used when the layout item omits `maxW`.
+- **`minH`** `number` — Minimum height in grid rows. Used when the layout item omits `minH`.
+- **`maxH`** `number` — Maximum height in grid rows. Used when the layout item omits `maxH`.
 - **`constraints`** `LayoutConstraint[]` — Per-widget constraints.
 - **`qa`** `string` — Test id for the rendered widget element.
 - **`styles`** `Styles` — Style overrides for the rendered widget element.
@@ -165,6 +169,12 @@ blocked from occupied cells.
 ### Non-resizable
 
 <Story of={BoardStories.NonResizable} />
+
+### Min/max widget size
+
+Bound resizing with per-widget `minW`/`maxW` (columns) and `minH`/`maxH` (rows).
+
+<Story of={BoardStories.MinMaxSize} />
 
 ### Grid lines
 

--- a/src/components/layout/Board/Board.stories.tsx
+++ b/src/components/layout/Board/Board.stories.tsx
@@ -486,60 +486,71 @@ const CrossBoardTemplate: StoryFn<CubeBoardProps> = (args) => (
 export const CrossBoardDragging = CrossBoardTemplate.bind({});
 CrossBoardDragging.args = {};
 
-const NestedTemplate: StoryFn<CubeBoardProps> = (args) => (
-  <Board.Provider>
-    <Board
-      id="outer"
-      padding="1x"
-      radius="1r"
-      rowHeight={120}
-      showGridLines="drag"
-      defaultLayout={[
-        // minW/minH keep the container from being resized smaller than the
-        // inner board needs to fit its widgets (the resize handle stops there).
-        { i: 'container', x: 0, y: 0, w: 7, h: 4, minW: 3, minH: 2 },
-        { i: 'side', x: 7, y: 0, w: 5, h: 4 },
-      ]}
-      {...args}
-    >
-      {/* isAutoHeight grows this container in the outer grid until the inner
-          board's rows fit at the parent's row height (only ever increases). */}
-      <Board.Widget id="container" isAutoHeight fill="#surface">
-        <Flow display="flex" flow="column" gap="1x" height="100%">
-          <Flow padding="1x 1.5x" fill="#light">
-            <Title level={6} preset="h6">
-              Container widget (drag the whole container)
-            </Title>
+const NestedTemplate: StoryFn<CubeBoardProps> = (args) => {
+  // Keep the inner board controlled so its positions survive the remount that
+  // happens when the container widget is dragged in the outer board. With an
+  // uncontrolled inner board the layout state lives inside the remounted
+  // subtree and resets to `defaultLayout` on every outer drag.
+  const [outerLayout, setOuterLayout] = useState<LayoutItem[]>([
+    // minW/minH keep the container from being resized smaller than the
+    // inner board needs to fit its widgets (the resize handle stops there).
+    { i: 'container', x: 0, y: 0, w: 7, h: 4, minW: 3, minH: 2 },
+    { i: 'side', x: 7, y: 0, w: 5, h: 4 },
+  ]);
+  const [innerLayout, setInnerLayout] = useState<LayoutItem[]>([
+    { i: 'child-1', x: 0, y: 0, w: 3, h: 2 },
+    { i: 'child-2', x: 3, y: 0, w: 3, h: 2 },
+  ]);
+
+  return (
+    <Board.Provider>
+      <Board
+        id="outer"
+        padding="1x"
+        radius="1r"
+        rowHeight={120}
+        showGridLines="drag"
+        layout={outerLayout}
+        onLayoutChange={setOuterLayout}
+        {...args}
+      >
+        {/* isAutoHeight grows this container in the outer grid until the inner
+            board's rows fit at the parent's row height (only ever increases). */}
+        <Board.Widget id="container" isAutoHeight fill="#surface">
+          <Flow display="flex" flow="column" gap="1x" height="100%">
+            <Flow padding="1x 1.5x" fill="#light">
+              <Title level={6} preset="h6">
+                Container widget (drag the whole container)
+              </Title>
+            </Flow>
+            <Board
+              id="inner"
+              isAligned
+              flexGrow={1}
+              // cols/rowHeight are fallbacks used only until the parent metrics
+              // resolve; `isAligned` then derives the column count from the
+              // parent's pitch and inherits its row height.
+              cols={6}
+              rowHeight={70}
+              layout={innerLayout}
+              onLayoutChange={setInnerLayout}
+            >
+              <Board.Widget id="child-1">
+                <WidgetBody title="Child 1" text="Drag me out" />
+              </Board.Widget>
+              <Board.Widget id="child-2">
+                <WidgetBody title="Child 2" text="Drag me out" />
+              </Board.Widget>
+            </Board>
           </Flow>
-          <Board
-            id="inner"
-            isAligned
-            flexGrow={1}
-            // cols/rowHeight are fallbacks used only until the parent metrics
-            // resolve; `isAligned` then derives the column count from the
-            // parent's pitch and inherits its row height.
-            cols={6}
-            rowHeight={70}
-            defaultLayout={[
-              { i: 'child-1', x: 0, y: 0, w: 3, h: 2 },
-              { i: 'child-2', x: 3, y: 0, w: 3, h: 2 },
-            ]}
-          >
-            <Board.Widget id="child-1">
-              <WidgetBody title="Child 1" text="Drag me out" />
-            </Board.Widget>
-            <Board.Widget id="child-2">
-              <WidgetBody title="Child 2" text="Drag me out" />
-            </Board.Widget>
-          </Board>
-        </Flow>
-      </Board.Widget>
-      <Board.Widget id="side">
-        <WidgetBody title="Sibling" text="Drop children here" />
-      </Board.Widget>
-    </Board>
-  </Board.Provider>
-);
+        </Board.Widget>
+        <Board.Widget id="side">
+          <WidgetBody title="Sibling" text="Drop children here" />
+        </Board.Widget>
+      </Board>
+    </Board.Provider>
+  );
+};
 
 export const NestedBoards = NestedTemplate.bind({});
 NestedBoards.args = {};
@@ -549,62 +560,71 @@ NestedBoards.args = {};
 // column pitch, and because it adds no insets, its columns line up exactly with
 // the outer board's. Grid lines are shown on both while dragging so the
 // alignment is verifiable.
-const AlignedNestedTemplate: StoryFn<CubeBoardProps> = (args) => (
-  <Board.Provider>
-    <Board
-      id="outer-aligned"
-      padding="1x"
-      radius="1r"
-      rowHeight={120}
-      showGridLines="drag"
-      defaultLayout={[
-        { i: 'aligned-container', x: 0, y: 0, w: 7, h: 4, minW: 3, minH: 2 },
-        { i: 'aligned-side', x: 7, y: 0, w: 5, h: 4 },
-      ]}
-      {...args}
-    >
-      <Board.Widget id="aligned-container" isAutoHeight fill="#surface">
-        <Flow display="flex" flow="column" gap="1x" height="100%">
-          <Flow padding="1x 1.5x" fill="#light">
-            <Title level={6} preset="h6">
-              Aligned nested board
-            </Title>
+const AlignedNestedTemplate: StoryFn<CubeBoardProps> = (args) => {
+  // Controlled inner/outer layouts so inner widget positions survive the
+  // container widget remount during an outer drag (see NestedTemplate).
+  const [outerLayout, setOuterLayout] = useState<LayoutItem[]>([
+    { i: 'aligned-container', x: 0, y: 0, w: 7, h: 4, minW: 3, minH: 2 },
+    { i: 'aligned-side', x: 7, y: 0, w: 5, h: 4 },
+  ]);
+  const [innerLayout, setInnerLayout] = useState<LayoutItem[]>([
+    { i: 'aligned-a', x: 0, y: 0, w: 3, h: 2 },
+    { i: 'aligned-b', x: 3, y: 0, w: 3, h: 2 },
+    { i: 'aligned-c', x: 0, y: 2, w: 6, h: 2 },
+  ]);
+
+  return (
+    <Board.Provider>
+      <Board
+        id="outer-aligned"
+        padding="1x"
+        radius="1r"
+        rowHeight={120}
+        showGridLines="drag"
+        layout={outerLayout}
+        onLayoutChange={setOuterLayout}
+        {...args}
+      >
+        <Board.Widget id="aligned-container" isAutoHeight fill="#surface">
+          <Flow display="flex" flow="column" gap="1x" height="100%">
+            <Flow padding="1x 1.5x" fill="#light">
+              <Title level={6} preset="h6">
+                Aligned nested board
+              </Title>
+            </Flow>
+            <Board
+              id="inner-aligned"
+              isAligned
+              // No fill/border/radius: the inner grid's origin sits flush on the
+              // container widget's edge, which already coincides with the outer
+              // board's column-0 origin. `isAligned` defaults the inner board's
+              // `containerPadding` to zero, so its columns line up exactly with
+              // the outer board's without any extra chrome.
+              flexGrow={1}
+              cols={6}
+              rowHeight={70}
+              layout={innerLayout}
+              onLayoutChange={setInnerLayout}
+            >
+              <Board.Widget id="aligned-a">
+                <WidgetBody title="Child A" text="Columns align with parent" />
+              </Board.Widget>
+              <Board.Widget id="aligned-b">
+                <WidgetBody title="Child B" text="Columns align with parent" />
+              </Board.Widget>
+              <Board.Widget id="aligned-c">
+                <WidgetBody title="Child C" text="Spans the full width" />
+              </Board.Widget>
+            </Board>
           </Flow>
-          <Board
-            id="inner-aligned"
-            isAligned
-            // No fill/border/radius: the inner grid's origin sits flush on the
-            // container widget's edge, which already coincides with the outer
-            // board's column-0 origin. `isAligned` defaults the inner board's
-            // `containerPadding` to zero, so its columns line up exactly with
-            // the outer board's without any extra chrome.
-            flexGrow={1}
-            cols={6}
-            rowHeight={70}
-            defaultLayout={[
-              { i: 'aligned-a', x: 0, y: 0, w: 3, h: 2 },
-              { i: 'aligned-b', x: 3, y: 0, w: 3, h: 2 },
-              { i: 'aligned-c', x: 0, y: 2, w: 6, h: 2 },
-            ]}
-          >
-            <Board.Widget id="aligned-a">
-              <WidgetBody title="Child A" text="Columns align with parent" />
-            </Board.Widget>
-            <Board.Widget id="aligned-b">
-              <WidgetBody title="Child B" text="Columns align with parent" />
-            </Board.Widget>
-            <Board.Widget id="aligned-c">
-              <WidgetBody title="Child C" text="Spans the full width" />
-            </Board.Widget>
-          </Board>
-        </Flow>
-      </Board.Widget>
-      <Board.Widget id="aligned-side">
-        <WidgetBody title="Sibling" text="Outer grid reference" />
-      </Board.Widget>
-    </Board>
-  </Board.Provider>
-);
+        </Board.Widget>
+        <Board.Widget id="aligned-side">
+          <WidgetBody title="Sibling" text="Outer grid reference" />
+        </Board.Widget>
+      </Board>
+    </Board.Provider>
+  );
+};
 
 export const AlignedNestedBoards = AlignedNestedTemplate.bind({});
 AlignedNestedBoards.args = {};

--- a/src/components/layout/Board/Board.stories.tsx
+++ b/src/components/layout/Board/Board.stories.tsx
@@ -143,6 +143,20 @@ NonResizable.args = {
   isResizable: false,
 };
 
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+  isDraggable: false,
+  isResizable: false,
+};
+ReadOnly.parameters = {
+  docs: {
+    description: {
+      story:
+        'With `isDraggable={false}` and `isResizable={false}` the board is fully read-only: widgets can neither be moved nor resized. Their content stays fully interactive - you can still select text inside a widget.',
+    },
+  },
+};
+
 // Per-widget `resizeHandles` restrict a widget to a single axis. Edge handles
 // (`e`/`s`) render a dotted grip revealed on hover/focus/resize.
 const SingleAxisTemplate: StoryFn<CubeBoardProps> = (args) => (

--- a/src/components/layout/Board/Board.stories.tsx
+++ b/src/components/layout/Board/Board.stories.tsx
@@ -81,6 +81,7 @@ const Template: StoryFn<CubeBoardProps> = (args) => (
     fill="#light"
     padding="1x"
     radius="1r"
+    widgetProps={{ isCard: true }}
     defaultLayout={defaultLayout}
     {...args}
   >
@@ -149,6 +150,7 @@ const SingleAxisTemplate: StoryFn<CubeBoardProps> = (args) => (
     fill="#light"
     padding="1x"
     radius="1r"
+    widgetProps={{ isCard: true }}
     defaultLayout={[
       { i: 'h', x: 0, y: 0, w: 4, h: 2, minW: 2 },
       { i: 'v', x: 4, y: 0, w: 4, h: 2, minH: 1 },
@@ -187,6 +189,7 @@ const MinMaxTemplate: StoryFn<CubeBoardProps> = (args) => (
     fill="#light"
     padding="1x"
     radius="1r"
+    widgetProps={{ isCard: true }}
     showGridLines="drag"
     defaultLayout={[
       { i: 'clamped', x: 0, y: 0, w: 4, h: 2 },
@@ -231,6 +234,48 @@ GridLines.parameters = {
   },
 };
 
+// Widgets are filled (`#surface-2`) and rounded by default, but borderless. Add
+// a card border per widget with `isCard`, or for the whole board at once with
+// `widgetProps={{ isCard: true }}` (per-widget `isCard` still overrides that
+// default).
+const CardWidgetsTemplate: StoryFn<CubeBoardProps> = (args) => (
+  <Board
+    fill="#light"
+    padding="1x"
+    radius="1r"
+    showGridLines="drag"
+    widgetProps={{ isCard: true }}
+    defaultLayout={[
+      { i: 'card-a', x: 0, y: 0, w: 4, h: 2 },
+      { i: 'card-b', x: 4, y: 0, w: 4, h: 2 },
+      { i: 'flat', x: 8, y: 0, w: 4, h: 2 },
+    ]}
+    {...args}
+  >
+    <Board.Widget id="card-a">
+      <WidgetBody title="Card" text="bordered via widgetProps" />
+    </Board.Widget>
+    <Board.Widget id="card-b">
+      <WidgetBody title="Card" text="bordered via widgetProps" />
+    </Board.Widget>
+    {/* Override the board default to render this one without a border. */}
+    <Board.Widget id="flat" isCard={false}>
+      <WidgetBody title="Flat" text="isCard={false} override" />
+    </Board.Widget>
+  </Board>
+);
+
+export const CardWidgets = CardWidgetsTemplate.bind({});
+CardWidgets.args = {};
+CardWidgets.parameters = {
+  docs: {
+    description: {
+      story:
+        'Widgets are filled (`#surface-2`) and rounded by default, but borderless. Set `widgetProps={{ isCard: true }}` on the `Board` to add a card border to every widget, or set `isCard` on a single `Board.Widget` to opt in/out individually — per-widget `isCard` overrides the board default.',
+    },
+  },
+};
+
 // A widget whose interactive controls must not start a drag. `dragCancel`
 // matches those elements (plus a `.no-drag` escape hatch) so the widget can
 // still be dragged from its empty areas.
@@ -239,6 +284,7 @@ const DragCancelTemplate: StoryFn<CubeBoardProps> = (args) => (
     fill="#light"
     padding="1x"
     radius="1r"
+    widgetProps={{ isCard: true }}
     dragCancel="input,textarea,button,a,.no-drag"
     defaultLayout={[
       { i: 'form', x: 0, y: 0, w: 6, h: 3 },
@@ -281,6 +327,7 @@ const ControlledTemplate: StoryFn<CubeBoardProps> = (args) => {
         fill="#light"
         padding="1x"
         radius="1r"
+        widgetProps={{ isCard: true }}
         layout={layout}
         onLayoutChange={setLayout}
         {...args}
@@ -347,6 +394,7 @@ const ResponsiveTemplate: StoryFn<CubeBoardResponsiveProps> = (args) => {
         fill="#light"
         padding="1x"
         radius="1r"
+        widgetProps={{ isCard: true }}
         breakpoints={RESPONSIVE_BREAKPOINTS}
         cols={RESPONSIVE_COLS}
         layouts={layouts}
@@ -392,6 +440,7 @@ const CrossBoardTemplate: StoryFn<CubeBoardProps> = (args) => (
           fill="#light"
           padding="1x"
           radius="1r"
+          widgetProps={{ isCard: true }}
           cols={6}
           defaultLayout={[
             { i: 'one-1', x: 0, y: 0, w: 3, h: 2 },
@@ -420,6 +469,7 @@ const CrossBoardTemplate: StoryFn<CubeBoardProps> = (args) => (
           fill="#light"
           padding="1x"
           radius="1r"
+          widgetProps={{ isCard: true }}
           cols={6}
           defaultLayout={[{ i: 'two-1', x: 0, y: 0, w: 6, h: 2 }]}
           {...args}
@@ -440,7 +490,6 @@ const NestedTemplate: StoryFn<CubeBoardProps> = (args) => (
   <Board.Provider>
     <Board
       id="outer"
-      fill="#light"
       padding="1x"
       radius="1r"
       rowHeight={120}
@@ -455,17 +504,16 @@ const NestedTemplate: StoryFn<CubeBoardProps> = (args) => (
     >
       {/* isAutoHeight grows this container in the outer grid until the inner
           board's rows fit at the parent's row height (only ever increases). */}
-      <Board.Widget id="container" isAutoHeight>
-        <Flow display="flex" gap="0.5x" padding="1x" height="100%">
-          <Title level={6} preset="h6">
-            Container widget (drag the whole container)
-          </Title>
+      <Board.Widget id="container" isAutoHeight fill="#surface">
+        <Flow display="flex" flow="column" gap="1x" height="100%">
+          <Flow padding="1x 1.5x" fill="#light">
+            <Title level={6} preset="h6">
+              Container widget (drag the whole container)
+            </Title>
+          </Flow>
           <Board
             id="inner"
             isAligned
-            fill="#purple-04.10"
-            padding=".5x"
-            radius="1r"
             flexGrow={1}
             // cols/rowHeight are fallbacks used only until the parent metrics
             // resolve; `isAligned` then derives the column count from the
@@ -495,6 +543,79 @@ const NestedTemplate: StoryFn<CubeBoardProps> = (args) => (
 
 export const NestedBoards = NestedTemplate.bind({});
 NestedBoards.args = {};
+
+// Nested boards with no padding, fill, border, or radius of their own — only a
+// header above the grid. With `isAligned`, the inner board inherits the parent's
+// column pitch, and because it adds no insets, its columns line up exactly with
+// the outer board's. Grid lines are shown on both while dragging so the
+// alignment is verifiable.
+const AlignedNestedTemplate: StoryFn<CubeBoardProps> = (args) => (
+  <Board.Provider>
+    <Board
+      id="outer-aligned"
+      padding="1x"
+      radius="1r"
+      rowHeight={120}
+      showGridLines="drag"
+      defaultLayout={[
+        { i: 'aligned-container', x: 0, y: 0, w: 7, h: 4, minW: 3, minH: 2 },
+        { i: 'aligned-side', x: 7, y: 0, w: 5, h: 4 },
+      ]}
+      {...args}
+    >
+      <Board.Widget id="aligned-container" isAutoHeight fill="#surface">
+        <Flow display="flex" flow="column" gap="1x" height="100%">
+          <Flow padding="1x 1.5x" fill="#light">
+            <Title level={6} preset="h6">
+              Aligned nested board
+            </Title>
+          </Flow>
+          <Board
+            id="inner-aligned"
+            isAligned
+            // No fill/border/radius: the inner grid's origin sits flush on the
+            // container widget's edge, which already coincides with the outer
+            // board's column-0 origin. `isAligned` defaults the inner board's
+            // `containerPadding` to zero, so its columns line up exactly with
+            // the outer board's without any extra chrome.
+            flexGrow={1}
+            cols={6}
+            rowHeight={70}
+            defaultLayout={[
+              { i: 'aligned-a', x: 0, y: 0, w: 3, h: 2 },
+              { i: 'aligned-b', x: 3, y: 0, w: 3, h: 2 },
+              { i: 'aligned-c', x: 0, y: 2, w: 6, h: 2 },
+            ]}
+          >
+            <Board.Widget id="aligned-a">
+              <WidgetBody title="Child A" text="Columns align with parent" />
+            </Board.Widget>
+            <Board.Widget id="aligned-b">
+              <WidgetBody title="Child B" text="Columns align with parent" />
+            </Board.Widget>
+            <Board.Widget id="aligned-c">
+              <WidgetBody title="Child C" text="Spans the full width" />
+            </Board.Widget>
+          </Board>
+        </Flow>
+      </Board.Widget>
+      <Board.Widget id="aligned-side">
+        <WidgetBody title="Sibling" text="Outer grid reference" />
+      </Board.Widget>
+    </Board>
+  </Board.Provider>
+);
+
+export const AlignedNestedBoards = AlignedNestedTemplate.bind({});
+AlignedNestedBoards.args = {};
+AlignedNestedBoards.parameters = {
+  docs: {
+    description: {
+      story:
+        'A nested `Board` with `isAligned` and no padding, fill, border, or radius of its own — only a header above the grid — inherits the parent column pitch with zero offset, so its columns line up exactly with the outer board. Grid lines are shown on both boards while dragging to verify the alignment.',
+    },
+  },
+};
 
 // Static content for the transferable leaf widgets, keyed by id. Because the
 // content lives here (not inline in a tab that can unmount), any board can
@@ -594,7 +715,6 @@ const TabsBoardTemplate: StoryFn<CubeBoardProps> = (args) => {
     <Board.Provider onWidgetTransfer={handleTransfer}>
       <Board
         id="root"
-        fill="#light"
         padding="1x"
         radius="1r"
         rowHeight={120}
@@ -609,14 +729,12 @@ const TabsBoardTemplate: StoryFn<CubeBoardProps> = (args) => {
         <Board.Widget id="kpis">
           <WidgetBody title="KPIs" text="Another top-level widget" />
         </Board.Widget>
-        <Board.Widget id="tabs">
+        <Board.Widget id="tabs" fill="#surface">
           <Tabs activeKey={activeTab} onChange={setActiveTab} height="100%">
             <Tab key="sales" title="Sales">
               <Board
                 id="tab-sales"
-                fill="#purple-04.10"
-                padding=".5x"
-                radius="1r"
+                containerPadding={[0, 8]}
                 cols={6}
                 rowHeight={80}
                 layout={layouts['tab-sales']}
@@ -628,9 +746,7 @@ const TabsBoardTemplate: StoryFn<CubeBoardProps> = (args) => {
             <Tab key="traffic" title="Traffic">
               <Board
                 id="tab-traffic"
-                fill="#purple-04.10"
-                padding=".5x"
-                radius="1r"
+                containerPadding={[0, 8]}
                 cols={6}
                 rowHeight={80}
                 layout={layouts['tab-traffic']}
@@ -642,9 +758,7 @@ const TabsBoardTemplate: StoryFn<CubeBoardProps> = (args) => {
             <Tab key="errors" title="Errors">
               <Board
                 id="tab-errors"
-                fill="#purple-04.10"
-                padding=".5x"
-                radius="1r"
+                containerPadding={[0, 8]}
                 cols={6}
                 rowHeight={80}
                 layout={layouts['tab-errors']}
@@ -655,17 +769,16 @@ const TabsBoardTemplate: StoryFn<CubeBoardProps> = (args) => {
             </Tab>
           </Tabs>
         </Board.Widget>
-        <Board.Widget id="nested" isAutoHeight>
-          <Flow display="flex" gap="0.5x" padding="1x" height="100%">
-            <Title level={6} preset="h6">
-              Nested board (drag the whole container)
-            </Title>
+        <Board.Widget id="nested" isAutoHeight fill="#surface">
+          <Flow display="flex" flow="column" gap="1x" height="100%">
+            <Flow padding="1x 1.5x" fill="#light">
+              <Title level={6} preset="h6">
+                Nested board (drag the whole container)
+              </Title>
+            </Flow>
             <Board
               id="nested-inner"
               isAligned
-              fill="#purple-04.10"
-              padding=".5x"
-              radius="1r"
               flexGrow={1}
               cols={8}
               rowHeight={80}

--- a/src/components/layout/Board/Board.stories.tsx
+++ b/src/components/layout/Board/Board.stories.tsx
@@ -179,6 +179,45 @@ SingleAxisResize.parameters = {
   },
 };
 
+// Per-widget min/max size. `minW`/`maxW` are in grid columns, `minH`/`maxH` in
+// grid rows. Resizing a widget stops at these bounds (the handle won't grow or
+// shrink past them).
+const MinMaxTemplate: StoryFn<CubeBoardProps> = (args) => (
+  <Board
+    fill="#light"
+    padding="1x"
+    radius="1r"
+    showGridLines="drag"
+    defaultLayout={[
+      { i: 'clamped', x: 0, y: 0, w: 4, h: 2 },
+      { i: 'wide', x: 4, y: 0, w: 4, h: 2 },
+      { i: 'tall', x: 8, y: 0, w: 4, h: 2 },
+    ]}
+    {...args}
+  >
+    <Board.Widget id="clamped" minW={2} maxW={6} minH={2} maxH={4}>
+      <WidgetBody title="Clamped" text="min 2x2 - max 6x4" />
+    </Board.Widget>
+    <Board.Widget id="wide" minW={3} maxW={8}>
+      <WidgetBody title="Width bound" text="min 3, max 8 cols" />
+    </Board.Widget>
+    <Board.Widget id="tall" minH={2} maxH={5}>
+      <WidgetBody title="Height bound" text="min 2, max 5 rows" />
+    </Board.Widget>
+  </Board>
+);
+
+export const MinMaxSize = MinMaxTemplate.bind({});
+MinMaxSize.args = {};
+MinMaxSize.parameters = {
+  docs: {
+    description: {
+      story:
+        'Set per-widget `minW`/`maxW` (grid columns) and `minH`/`maxH` (grid rows) on `Board.Widget` to bound resizing. The resize handle stops at each limit, so a widget can never be dragged smaller than its minimum or larger than its maximum. Grid lines are shown while resizing so the bounds are easy to read.',
+    },
+  },
+};
+
 export const GridLines = Template.bind({});
 GridLines.args = {
   showGridLines: 'drag',
@@ -405,6 +444,7 @@ const NestedTemplate: StoryFn<CubeBoardProps> = (args) => (
       padding="1x"
       radius="1r"
       rowHeight={120}
+      showGridLines="drag"
       defaultLayout={[
         // minW/minH keep the container from being resized smaller than the
         // inner board needs to fit its widgets (the resize handle stops there).
@@ -558,6 +598,7 @@ const TabsBoardTemplate: StoryFn<CubeBoardProps> = (args) => {
         padding="1x"
         radius="1r"
         rowHeight={120}
+        showGridLines="drag"
         layout={layouts.root}
         onLayoutChange={handleLayoutChange('root')}
         {...args}

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -682,9 +682,12 @@ describe('Board', () => {
     }
   });
 
-  it('shrinks aligned row height to fit a constrained container', () => {
+  it('uses the parent row height verbatim for aligned cells', () => {
     // jsdom reports 0 for offset dimensions; mock them so a nested board can
     // measure the height it is given (and derive a column count from its width).
+    // The container is intentionally shorter (120px) than the two rows need at
+    // the 100px parent row height: an aligned board must NOT shrink its rows to
+    // fit, so the cell keeps the full parent-sized height regardless.
     const widthSpy = vi
       .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
       .mockReturnValue(600);
@@ -733,10 +736,10 @@ describe('Board', () => {
 
       const aligned = screen.getByTestId('AlignedCell');
       const plain = screen.getByTestId('PlainCell');
-      // The aligned board fits its rows into the 120px it measures, so the same
-      // widget renders shorter than on a board keeping the full parent row
-      // height.
-      expect(parseInt(aligned.style.height, 10)).toBeLessThan(
+      // The aligned board uses the parent's row height verbatim, so the same
+      // widget renders at exactly the same height as on a plain board with the
+      // matching rowHeight - it is not shrunk to fit the short container.
+      expect(parseInt(aligned.style.height, 10)).toBe(
         parseInt(plain.style.height, 10),
       );
     } finally {

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -52,7 +52,7 @@ describe('Board', () => {
     expect(screen.getByTestId('WidgetC')).toBeInTheDocument();
   });
 
-  it('positions widgets using CSS transforms', () => {
+  it('positions widgets using CSS inset (left/top)', () => {
     render(
       <Board
         width={1200}
@@ -69,7 +69,8 @@ describe('Board', () => {
 
     const widget = screen.getByTestId('WidgetA');
     // First item sits at the container padding origin (10, 10).
-    expect(widget.style.transform).toBe('translate(10px, 10px)');
+    expect(widget.style.left).toBe('10px');
+    expect(widget.style.top).toBe('10px');
   });
 
   it('makes draggable widgets focusable', () => {
@@ -243,11 +244,11 @@ describe('Board', () => {
     );
 
     // Free positioning keeps items exactly where placed (no reflow to origin).
-    expect(screen.getByTestId('WidgetA').style.transform).toBe(
-      'translate(10px, 10px)',
-    );
+    const widgetA = screen.getByTestId('WidgetA');
+    expect(widgetA.style.left).toBe('10px');
+    expect(widgetA.style.top).toBe('10px');
     const widgetB = screen.getByTestId('WidgetB');
-    expect(widgetB.style.transform).not.toBe('translate(10px, 10px)');
+    expect(widgetB.style.left).not.toBe('10px');
   });
 
   describe('free positioning', () => {
@@ -984,6 +985,37 @@ describe('Board', () => {
       // Width grew; height stayed the same (edge handle is horizontal-only).
       expect(info.item.w).toBeGreaterThan(2);
       expect(info.item.h).toBe(2);
+    });
+
+    it('bounds a resize by a widget-level maxW', () => {
+      const onResizeStop = vi.fn();
+
+      render(
+        <Board
+          width={1200}
+          cols={12}
+          rowHeight={100}
+          margin={[0, 0]}
+          containerPadding={[0, 0]}
+          onResizeStop={onResizeStop}
+          defaultLayout={[{ i: 'a', x: 0, y: 0, w: 2, h: 2 }]}
+        >
+          <Board.Widget id="a" qa="WidgetA" resizeHandles={['e']} maxW={4}>
+            A
+          </Board.Widget>
+        </Board>,
+      );
+
+      const handle = screen.getByTestId('BoardResizeHandle');
+      // Drag the east handle far right (well past 4 columns).
+      fireEvent(handle, pointerEvent('pointerdown', 200, 200));
+      fireEvent(window, pointerEvent('pointermove', 1000, 200));
+      fireEvent(window, pointerEvent('pointerup', 1000, 200));
+
+      expect(onResizeStop).toHaveBeenCalled();
+      const info = onResizeStop.mock.calls.at(-1)![0];
+      // Width is clamped to the widget-level maxW.
+      expect(info.item.w).toBe(4);
     });
 
     it('blocks a resize from overlapping a neighbour in free mode', () => {

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -4,6 +4,7 @@ import {
   CONTAINER_STYLES,
   ContainerStyleProps,
   filterBaseProps,
+  mergeStyles,
   Styles,
   tasty,
 } from '@tenphi/tasty';
@@ -944,8 +945,15 @@ function BoardInner(
                   // (borderless - widgets are always filled and rounded).
                   const widgetIsCard =
                     registration?.isCard ?? widgetProps?.isCard ?? false;
+                  // Merge board-level `widgetProps.styles` with the per-widget
+                  // styles so shared defaults survive when a widget sets even a
+                  // single style prop; per-widget styles win on conflicts. Only
+                  // merge when both exist to preserve reference stability (and
+                  // avoid churn) in the common single-source case.
                   const widgetStyles =
-                    registration?.styles ?? widgetProps?.styles;
+                    registration?.styles && widgetProps?.styles
+                      ? mergeStyles(widgetProps.styles, registration.styles)
+                      : registration?.styles ?? widgetProps?.styles;
 
                   return (
                     <WidgetHost

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -294,6 +294,16 @@ function BoardInner(
   const host = useBoardHost();
   const inheritedGridLines = useBoardGridLines();
   const aligned = isAligned && !!parentMetrics;
+  // `widgetProps` may carry container style props directly (e.g. `fill`,
+  // `padding`, `radius`) alongside an explicit `styles` object, mirroring
+  // `Board.Widget`. Extract them into a single style map here so those defaults
+  // actually reach every widget - forwarding only `widgetProps.styles` would
+  // drop the direct props. A direct prop wins over the same key in `styles`.
+  const widgetPropsStyles = useMemo<Styles | undefined>(() => {
+    if (!widgetProps) return undefined;
+    const extracted = extractStyles(widgetProps, CONTAINER_STYLES);
+    return Object.keys(extracted).length > 0 ? extracted : undefined;
+  }, [widgetProps]);
   // A nested board with no explicit `showGridLines` inherits the ancestor's:
   // when the ancestor has grid lines enabled, show them here while dragging.
   const effectiveShowGridLines: BoardGridLines =
@@ -945,15 +955,16 @@ function BoardInner(
                   // (borderless - widgets are always filled and rounded).
                   const widgetIsCard =
                     registration?.isCard ?? widgetProps?.isCard ?? false;
-                  // Merge board-level `widgetProps.styles` with the per-widget
-                  // styles so shared defaults survive when a widget sets even a
-                  // single style prop; per-widget styles win on conflicts. Only
-                  // merge when both exist to preserve reference stability (and
-                  // avoid churn) in the common single-source case.
+                  // Merge board-level `widgetProps` styles (its `styles` object
+                  // plus direct style props) with the per-widget styles so
+                  // shared defaults survive when a widget sets even a single
+                  // style prop; per-widget styles win on conflicts. Only merge
+                  // when both exist to preserve reference stability (and avoid
+                  // churn) in the common single-source case.
                   const widgetStyles =
-                    registration?.styles && widgetProps?.styles
-                      ? mergeStyles(widgetProps.styles, registration.styles)
-                      : registration?.styles ?? widgetProps?.styles;
+                    registration?.styles && widgetPropsStyles
+                      ? mergeStyles(widgetPropsStyles, registration.styles)
+                      : registration?.styles ?? widgetPropsStyles;
 
                   return (
                     <WidgetHost

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -955,6 +955,13 @@ function BoardInner(
                   // (borderless - widgets are always filled and rounded).
                   const widgetIsCard =
                     registration?.isCard ?? widgetProps?.isCard ?? false;
+                  // Per-widget `isAutoHeight`/`qa` fall back to the board-level
+                  // `widgetProps` defaults (mirroring the other widget props).
+                  const widgetIsAutoHeight =
+                    registration?.isAutoHeight ??
+                    widgetProps?.isAutoHeight ??
+                    false;
+                  const widgetQa = registration?.qa ?? widgetProps?.qa;
                   // Merge board-level `widgetProps` styles (its `styles` object
                   // plus direct style props) with the per-widget styles so
                   // shared defaults survive when a widget sets even a single
@@ -978,6 +985,8 @@ function BoardInner(
                       isDraggable={widgetDraggable}
                       isResizable={widgetResizable}
                       resizeHandles={handles}
+                      isAutoHeight={widgetIsAutoHeight}
+                      qa={widgetQa}
                       dragCancel={widgetDragCancel}
                       dragHandle={widgetDragHandle}
                       registry={registry}

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -24,8 +24,10 @@ import { extractStyles } from '../../../utils/styles';
 
 import {
   BoardEntry,
+  BoardGridLinesContext,
   BoardMetrics,
   BoardMetricsContext,
+  useBoardGridLines,
   useBoardHost,
   useBoardMetrics,
   useBoardRegistry,
@@ -87,7 +89,7 @@ const PlaceholderElement = tasty({
     border: '#purple.40',
     zIndex: 2,
     pointerEvents: 'none',
-    transition: 'transform 80ms linear, width 80ms linear, height 80ms linear',
+    transition: 'inset 80ms linear, width 80ms linear, height 80ms linear',
     boxSizing: 'border-box',
   },
 });
@@ -260,7 +262,7 @@ function BoardInner(
     resizeHandles = ['se'],
     dragCancel,
     dragHandle,
-    showGridLines = false,
+    showGridLines,
     isAligned = false,
     constraints,
     width: providedWidth,
@@ -271,7 +273,12 @@ function BoardInner(
   const registry = useBoardRegistry()!;
   const parentMetrics = useBoardMetrics();
   const host = useBoardHost();
+  const inheritedGridLines = useBoardGridLines();
   const aligned = isAligned && !!parentMetrics;
+  // A nested board with no explicit `showGridLines` inherits the ancestor's:
+  // when the ancestor has grid lines enabled, show them here while dragging.
+  const effectiveShowGridLines: BoardGridLines =
+    showGridLines ?? (inheritedGridLines ? 'drag' : false);
   const generatedId = useId();
   const boardId = providedId ?? generatedId;
 
@@ -568,12 +575,17 @@ function BoardInner(
       if (phase === 'start') {
         const rawItem = getLayoutItem(layoutRef.current, id);
         if (!rawItem) return;
-        // Layout-item constraints win; otherwise fall back to the ones declared
-        // on the owning `Board.Widget` so `applySizeConstraints` picks them up.
+        // Layout-item min/max and constraints win; otherwise fall back to the
+        // ones declared on the owning `Board.Widget` so `applySizeConstraints`
+        // (via `minMaxSize`) picks them up.
+        const reg = registry.store.get(id);
         const item: LayoutItem = {
           ...rawItem,
-          constraints:
-            rawItem.constraints ?? registry.store.get(id)?.constraints,
+          minW: rawItem.minW ?? reg?.minW,
+          maxW: rawItem.maxW ?? reg?.maxW,
+          minH: rawItem.minH ?? reg?.minH,
+          maxH: rawItem.maxH ?? reg?.maxH,
+          constraints: rawItem.constraints ?? reg?.constraints,
         };
         resizeStateRef.current = {
           id,
@@ -768,7 +780,8 @@ function BoardInner(
           placeholder.h,
         );
         return {
-          transform: `translate(${pos.left}px, ${pos.top}px)`,
+          left: `${pos.left}px`,
+          top: `${pos.top}px`,
           width: `${pos.width}px`,
           height: `${pos.height}px`,
         };
@@ -778,8 +791,8 @@ function BoardInner(
   const showPlaceholder = placeholder && placeholderStyle;
 
   const gridLinesVisible =
-    showGridLines === true ||
-    (showGridLines === 'drag' && (!!dragState || !!placeholder));
+    effectiveShowGridLines === true ||
+    (effectiveShowGridLines === 'drag' && (!!dragState || !!placeholder));
   const gridOverlayStyle = gridLinesVisible
     ? (() => {
         const colWidth = calcGridColWidth(positionParams);
@@ -839,74 +852,85 @@ function BoardInner(
 
   return (
     <BoardMetricsContext.Provider value={boardMetrics}>
-      <BoardElement
-        {...filterBaseProps(otherProps, { eventProps: true })}
-        ref={containerRef}
-        styles={styles}
-        // Non-aligned: use min-height (not a fixed height) so the board
-        // auto-sizes to its content by default but can still grow to fill a
-        // taller parent. Widgets are absolutely positioned, so growing never
-        // shifts them, and the content layer (inset: 0) always covers the full
-        // board -> the whole board is droppable. Aligned: omit the inline height
-        // so the board fills (and is bounded by) the space the container grants,
-        // which is what drives the reduced row height.
-        style={aligned ? undefined : { minHeight: `${containerHeight}px` }}
-        mods={{
-          dragging: !!dragState,
-          'drop-target': dragState?.currentBoardId === boardId,
-        }}
+      <BoardGridLinesContext.Provider
+        value={
+          effectiveShowGridLines === true || effectiveShowGridLines === 'drag'
+        }
       >
-        <ContentLayer ref={contentRef}>
-          {ready && gridOverlayStyle ? (
-            <GridOverlayElement aria-hidden="true" style={gridOverlayStyle} />
-          ) : null}
-          {ready
-            ? layout.map((item) => {
-                const registration = registry.store.get(item.i);
-                const widgetDraggable =
-                  isDraggable &&
-                  registration?.isDraggable !== false &&
-                  item.isDraggable !== false &&
-                  !item.static;
-                const widgetResizable =
-                  isResizable &&
-                  registration?.isResizable !== false &&
-                  item.isResizable !== false &&
-                  !item.static;
-                const handles =
-                  item.resizeHandles ??
-                  registration?.resizeHandles ??
-                  resizeHandles;
-                const widgetDragCancel = registration?.dragCancel ?? dragCancel;
-                const widgetDragHandle = registration?.dragHandle ?? dragHandle;
+        <BoardElement
+          {...filterBaseProps(otherProps, { eventProps: true })}
+          ref={containerRef}
+          styles={styles}
+          // Non-aligned: use min-height (not a fixed height) so the board
+          // auto-sizes to its content by default but can still grow to fill a
+          // taller parent. Widgets are absolutely positioned, so growing never
+          // shifts them, and the content layer (inset: 0) always covers the full
+          // board -> the whole board is droppable. Aligned: omit the inline height
+          // so the board fills (and is bounded by) the space the container grants,
+          // which is what drives the reduced row height.
+          style={aligned ? undefined : { minHeight: `${containerHeight}px` }}
+          mods={{
+            dragging: !!dragState,
+            'drop-target': dragState?.currentBoardId === boardId,
+          }}
+        >
+          <ContentLayer ref={contentRef}>
+            {ready && gridOverlayStyle ? (
+              <GridOverlayElement aria-hidden="true" style={gridOverlayStyle} />
+            ) : null}
+            {ready
+              ? layout.map((item) => {
+                  const registration = registry.store.get(item.i);
+                  const widgetDraggable =
+                    isDraggable &&
+                    registration?.isDraggable !== false &&
+                    item.isDraggable !== false &&
+                    !item.static;
+                  const widgetResizable =
+                    isResizable &&
+                    registration?.isResizable !== false &&
+                    item.isResizable !== false &&
+                    !item.static;
+                  const handles =
+                    item.resizeHandles ??
+                    registration?.resizeHandles ??
+                    resizeHandles;
+                  const widgetDragCancel =
+                    registration?.dragCancel ?? dragCancel;
+                  const widgetDragHandle =
+                    registration?.dragHandle ?? dragHandle;
 
-                return (
-                  <WidgetHost
-                    key={item.i}
-                    boardId={boardId}
-                    item={item}
-                    positionParams={positionParams}
-                    registration={registration}
-                    isDraggable={widgetDraggable}
-                    isResizable={widgetResizable}
-                    resizeHandles={handles}
-                    dragCancel={widgetDragCancel}
-                    dragHandle={widgetDragHandle}
-                    registry={registry}
-                    dragState={dragState}
-                    onResize={handleResize}
-                    onAutoHeight={handleAutoHeight}
-                    onDragLifecycle={handleDragLifecycle}
-                  />
-                );
-              })
-            : null}
-          {showPlaceholder ? (
-            <PlaceholderElement aria-hidden="true" style={placeholderStyle!} />
-          ) : null}
-        </ContentLayer>
-        {children}
-      </BoardElement>
+                  return (
+                    <WidgetHost
+                      key={item.i}
+                      boardId={boardId}
+                      item={item}
+                      positionParams={positionParams}
+                      registration={registration}
+                      isDraggable={widgetDraggable}
+                      isResizable={widgetResizable}
+                      resizeHandles={handles}
+                      dragCancel={widgetDragCancel}
+                      dragHandle={widgetDragHandle}
+                      registry={registry}
+                      dragState={dragState}
+                      onResize={handleResize}
+                      onAutoHeight={handleAutoHeight}
+                      onDragLifecycle={handleDragLifecycle}
+                    />
+                  );
+                })
+              : null}
+            {showPlaceholder ? (
+              <PlaceholderElement
+                aria-hidden="true"
+                style={placeholderStyle!}
+              />
+            ) : null}
+          </ContentLayer>
+          {children}
+        </BoardElement>
+      </BoardGridLinesContext.Provider>
     </BoardMetricsContext.Provider>
   );
 }

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -39,7 +39,6 @@ import {
   calcGridColWidth,
   calcGridItemPosition,
   calcWH,
-  clamp,
   cloneLayout,
   Compactor,
   CompactType,
@@ -58,6 +57,8 @@ import {
 import { useBoardLayout } from './use-board-layout';
 import { ResizePhase, WidgetHost } from './WidgetHost';
 
+import type { CubeBoardWidgetProps } from './Widget';
+
 const BoardElement = tasty({
   qa: 'Board',
   styles: {
@@ -66,7 +67,7 @@ const BoardElement = tasty({
     width: '100%',
     flexGrow: 1,
     minHeight: '0',
-    fill: '#clear',
+    fill: '#surface',
     boxSizing: 'border-box',
   },
 });
@@ -112,12 +113,6 @@ const GridOverlayElement = tasty({
   },
 });
 
-/**
- * Lower bound for the reduced row height used by an aligned nested board, so a
- * very short container can never collapse its rows to zero.
- */
-const MIN_ALIGNED_ROW_HEIGHT = 24;
-
 export type BoardCompactType = 'vertical' | 'horizontal' | 'free' | null;
 
 /**
@@ -136,6 +131,16 @@ export interface BoardInteractionInfo {
 
 /** Visibility of the internal grid-line overlay. */
 export type BoardGridLines = boolean | 'drag';
+
+/**
+ * The subset of `Board.Widget` props a `Board` can set as defaults for every
+ * widget it hosts (via `widgetProps`). Excludes `id`/`children`, which are
+ * per-widget. Per-widget `Board.Widget` props override these.
+ */
+export type CubeBoardWidgetDefaults = Omit<
+  CubeBoardWidgetProps,
+  'id' | 'children'
+>;
 
 export interface CubeBoardProps
   extends Omit<
@@ -168,7 +173,11 @@ export interface CubeBoardProps
   rowHeight?: number;
   /** [horizontal, vertical] margin between widgets in pixels. @default [8, 8] */
   margin?: [number, number];
-  /** [horizontal, vertical] padding inside the board. Defaults to `margin`. */
+  /**
+   * [horizontal, vertical] padding inside the board. Defaults to `margin`, or
+   * to `[0, 0]` for an aligned nested board (`isAligned`) so its grid lines up
+   * with the ancestor board's.
+   */
   containerPadding?: [number, number];
   /** Maximum number of rows. @default Infinity */
   maxRows?: number;
@@ -212,10 +221,11 @@ export interface CubeBoardProps
   /**
    * Align this board's grid with an ancestor `Board`'s layout. Only takes
    * effect when the board is nested inside another `Board`'s widget. When set,
-   * the board inherits the parent's column pitch (deriving its own column count
-   * from its measured width so cells stay parent-sized) and inherits the
-   * parent's row height as a target, shrinking rows slightly when needed to fit
-   * the height the container widget grants it. @default false
+   * every cell matches the parent's cell size exactly: the board inherits the
+   * parent's column pitch (deriving its own column count from its measured
+   * width) and uses the parent's row height verbatim. It never shrinks rows to
+   * fit; pair it with an `isAutoHeight` container so the widget grows to fit its
+   * rows at that height. @default false
    */
   isAligned?: boolean;
   /** Grid/item layout constraints. */
@@ -225,6 +235,13 @@ export interface CubeBoardProps
    * measurement (useful for SSR and tests).
    */
   width?: number;
+  /**
+   * Default props applied to every widget this board hosts. Per-widget
+   * `Board.Widget` props override these. Use it to add a card border to every
+   * widget (`widgetProps={{ isCard: true }}`) or set shared sizing/`styles`
+   * defaults without repeating them on each `Board.Widget`.
+   */
+  widgetProps?: Partial<CubeBoardWidgetDefaults>;
   children?: ReactNode;
 }
 
@@ -266,6 +283,7 @@ function BoardInner(
     isAligned = false,
     constraints,
     width: providedWidth,
+    widgetProps,
     children,
     ...otherProps
   } = props;
@@ -335,9 +353,14 @@ function BoardInner(
     ? parentMetrics!.margin
     : margin;
   // The board keeps its own padding (it sits inside the container's chrome);
-  // when unspecified it defaults to the effective gap.
+  // when unspecified it defaults to the effective gap. An aligned nested board
+  // is the exception: its grid origin must sit flush on the container widget's
+  // edge (which already coincides with the parent's column-0 origin) so its
+  // columns line up with the ancestor board's. Inheriting the gap there would
+  // inset every column by one margin and break the alignment, so it defaults
+  // to zero padding instead.
   const resolvedPadding: readonly [number, number] =
-    containerPadding ?? effectiveMargin;
+    containerPadding ?? (aligned ? [0, 0] : effectiveMargin);
 
   const rows = Math.max(
     bottom(layout),
@@ -349,12 +372,23 @@ function BoardInner(
   // than stretched. `containerWidth` is then back-solved so `calcGridColWidth`
   // returns exactly the parent's column width.
   const parentColWidth = aligned ? parentMetrics!.colWidth : 0;
+  // `width` is `offsetWidth` (an integer the browser rounds), while
+  // `parentColWidth` is fractional. A container sized to exactly N parent
+  // columns can therefore measure a fraction of a pixel short, so a bare
+  // `Math.floor` would drop the last column and leave its space unused. Add a
+  // small pixel tolerance to absorb that rounding; it only rounds up when the
+  // width is within ~2px of a full column, so it can't invent a column that
+  // genuinely doesn't fit.
+  const ALIGN_WIDTH_TOLERANCE = 2;
   const alignedCols =
     aligned && width > 0
       ? Math.max(
           1,
           Math.floor(
-            (width - resolvedPadding[0] * 2 + effectiveMargin[0]) /
+            (width -
+              resolvedPadding[0] * 2 +
+              effectiveMargin[0] +
+              ALIGN_WIDTH_TOLERANCE) /
               (parentColWidth + effectiveMargin[0]),
           ),
         )
@@ -366,21 +400,11 @@ function BoardInner(
       resolvedPadding[0] * 2
     : width;
 
-  // Row height inherits the parent's as the target, but shrinks (never grows
-  // beyond it) so the board's rows fit the height the container grants. When
-  // the height is unbounded/unmeasured, it stays at the parent's row height.
-  const parentRowHeight = aligned ? parentMetrics!.rowHeight : rowHeight;
-  const effectiveRowHeight =
-    aligned && rows > 0 && measuredHeight > 0
-      ? clamp(
-          (measuredHeight -
-            Math.max(0, rows - 1) * effectiveMargin[1] -
-            resolvedPadding[1] * 2) /
-            rows,
-          MIN_ALIGNED_ROW_HEIGHT,
-          parentRowHeight,
-        )
-      : parentRowHeight;
+  // An aligned board uses the parent's row height verbatim, so every cell is
+  // exactly the parent's cell size (width already matches via the inherited
+  // column pitch). It never shrinks rows to fit; pair it with an `isAutoHeight`
+  // container so the widget grows to fit the rows at this height instead.
+  const effectiveRowHeight = aligned ? parentMetrics!.rowHeight : rowHeight;
 
   const positionParams = useMemo<PositionParams>(
     () => ({
@@ -519,15 +543,15 @@ function BoardInner(
     recompactForCols(effectiveCols);
   }, [aligned, width, effectiveCols, recompactForCols]);
 
-  // Natural height this board wants: its rows at the (unshrunk) target row
-  // height. When aligned rows are shrunk to fit a short container, this exceeds
-  // the measured height by the amount the board was squeezed.
+  // Natural height this board wants: its rows at the (parent) row height. When
+  // the container is shorter than this, an `isAutoHeight` host grows to fit it
+  // (aligned boards no longer shrink their rows).
   const naturalHeight =
     rows > 0
-      ? rows * parentRowHeight +
+      ? rows * effectiveRowHeight +
         Math.max(0, rows - 1) * effectiveMargin[1] +
         resolvedPadding[1] * 2
-      : parentRowHeight;
+      : effectiveRowHeight;
 
   // Report this aligned board's height deficit to an auto-sizing host so the
   // host can both grow to fit and pin its resize floor. The value is signed:
@@ -576,16 +600,18 @@ function BoardInner(
         const rawItem = getLayoutItem(layoutRef.current, id);
         if (!rawItem) return;
         // Layout-item min/max and constraints win; otherwise fall back to the
-        // ones declared on the owning `Board.Widget` so `applySizeConstraints`
-        // (via `minMaxSize`) picks them up.
+        // ones declared on the owning `Board.Widget` (and then the board-level
+        // `widgetProps` defaults) so `applySizeConstraints` (via `minMaxSize`)
+        // picks them up.
         const reg = registry.store.get(id);
         const item: LayoutItem = {
           ...rawItem,
-          minW: rawItem.minW ?? reg?.minW,
-          maxW: rawItem.maxW ?? reg?.maxW,
-          minH: rawItem.minH ?? reg?.minH,
-          maxH: rawItem.maxH ?? reg?.maxH,
-          constraints: rawItem.constraints ?? reg?.constraints,
+          minW: rawItem.minW ?? reg?.minW ?? widgetProps?.minW,
+          maxW: rawItem.maxW ?? reg?.maxW ?? widgetProps?.maxW,
+          minH: rawItem.minH ?? reg?.minH ?? widgetProps?.minH,
+          maxH: rawItem.maxH ?? reg?.maxH ?? widgetProps?.maxH,
+          constraints:
+            rawItem.constraints ?? reg?.constraints ?? widgetProps?.constraints,
         };
         resizeStateRef.current = {
           id,
@@ -770,6 +796,12 @@ function BoardInner(
   const dragState = registry.dragState;
   const ready = width > 0;
 
+  // When the widget that hosts this nested board is the one being dragged, its
+  // whole content (including this board) floats as a single unit, so its own
+  // grid lines add nothing but clutter. Suppress them for that drag.
+  const hostWidgetIsDragging =
+    !!dragState && dragState.nestedBoardIds.has(boardId);
+
   const placeholderStyle = placeholder
     ? (() => {
         const pos = calcGridItemPosition(
@@ -791,8 +823,9 @@ function BoardInner(
   const showPlaceholder = placeholder && placeholderStyle;
 
   const gridLinesVisible =
-    effectiveShowGridLines === true ||
-    (effectiveShowGridLines === 'drag' && (!!dragState || !!placeholder));
+    !hostWidgetIsDragging &&
+    (effectiveShowGridLines === true ||
+      (effectiveShowGridLines === 'drag' && (!!dragState || !!placeholder)));
   const gridOverlayStyle = gridLinesVisible
     ? (() => {
         const colWidth = calcGridColWidth(positionParams);
@@ -883,22 +916,36 @@ function BoardInner(
                   const registration = registry.store.get(item.i);
                   const widgetDraggable =
                     isDraggable &&
-                    registration?.isDraggable !== false &&
+                    (registration?.isDraggable ?? widgetProps?.isDraggable) !==
+                      false &&
                     item.isDraggable !== false &&
                     !item.static;
                   const widgetResizable =
                     isResizable &&
-                    registration?.isResizable !== false &&
+                    (registration?.isResizable ?? widgetProps?.isResizable) !==
+                      false &&
                     item.isResizable !== false &&
                     !item.static;
                   const handles =
                     item.resizeHandles ??
                     registration?.resizeHandles ??
+                    widgetProps?.resizeHandles ??
                     resizeHandles;
                   const widgetDragCancel =
-                    registration?.dragCancel ?? dragCancel;
+                    registration?.dragCancel ??
+                    widgetProps?.dragCancel ??
+                    dragCancel;
                   const widgetDragHandle =
-                    registration?.dragHandle ?? dragHandle;
+                    registration?.dragHandle ??
+                    widgetProps?.dragHandle ??
+                    dragHandle;
+                  // Per-widget `isCard`/`styles` override the board-level
+                  // `widgetProps` defaults; `isCard` defaults to `false`
+                  // (borderless - widgets are always filled and rounded).
+                  const widgetIsCard =
+                    registration?.isCard ?? widgetProps?.isCard ?? false;
+                  const widgetStyles =
+                    registration?.styles ?? widgetProps?.styles;
 
                   return (
                     <WidgetHost
@@ -907,6 +954,8 @@ function BoardInner(
                       item={item}
                       positionParams={positionParams}
                       registration={registration}
+                      isCard={widgetIsCard}
+                      styles={widgetStyles as Styles}
                       isDraggable={widgetDraggable}
                       isResizable={widgetResizable}
                       resizeHandles={handles}

--- a/src/components/layout/Board/Widget.tsx
+++ b/src/components/layout/Board/Widget.tsx
@@ -17,6 +17,14 @@ export interface CubeBoardWidgetProps {
   isResizable?: boolean;
   /** Which resize handles to show (overrides the board default). */
   resizeHandles?: ResizeHandleAxis[];
+  /** Minimum width in grid columns (used when the layout item omits `minW`). */
+  minW?: number;
+  /** Maximum width in grid columns (used when the layout item omits `maxW`). */
+  maxW?: number;
+  /** Minimum height in grid rows (used when the layout item omits `minH`). */
+  minH?: number;
+  /** Maximum height in grid rows (used when the layout item omits `maxH`). */
+  maxH?: number;
   /** Per-widget layout constraints. */
   constraints?: LayoutConstraint[];
   /** Test id applied to the rendered widget element. */
@@ -53,6 +61,10 @@ export function Widget(props: CubeBoardWidgetProps) {
     isDraggable,
     isResizable,
     resizeHandles,
+    minW,
+    maxW,
+    minH,
+    maxH,
     constraints,
     qa,
     styles,
@@ -75,6 +87,10 @@ export function Widget(props: CubeBoardWidgetProps) {
         isDraggable,
         isResizable,
         resizeHandles,
+        minW,
+        maxW,
+        minH,
+        maxH,
         constraints,
         qa,
         styles,

--- a/src/components/layout/Board/Widget.tsx
+++ b/src/components/layout/Board/Widget.tsx
@@ -1,12 +1,13 @@
-import { Styles } from '@tenphi/tasty';
+import { CONTAINER_STYLES, ContainerStyleProps, Styles } from '@tenphi/tasty';
 import { ReactNode, useEffect, useRef } from 'react';
 
 import { useLayoutEffect } from '../../../utils/react';
+import { extractStyles } from '../../../utils/styles';
 
 import { useBoardRegistry } from './board-context';
 import { LayoutConstraint, ResizeHandleAxis } from './grid-core';
 
-export interface CubeBoardWidgetProps {
+export interface CubeBoardWidgetProps extends ContainerStyleProps {
   /** Unique id, must match the `i` of a layout item in a `Board`. */
   id: string;
   /** Widget content. */
@@ -17,6 +18,13 @@ export interface CubeBoardWidgetProps {
   isResizable?: boolean;
   /** Which resize handles to show (overrides the board default). */
   resizeHandles?: ResizeHandleAxis[];
+  /**
+   * Render this widget as a card by adding a border. Widgets are always filled
+   * (`#surface-2`) and rounded; `isCard` adds the border on top. Defaults to
+   * `false` (borderless) unless the owning `Board`'s `widgetProps.isCard` opts
+   * in. Override per widget to enable or disable.
+   */
+  isCard?: boolean;
   /** Minimum width in grid columns (used when the layout item omits `minW`). */
   minW?: number;
   /** Maximum width in grid columns (used when the layout item omits `maxW`). */
@@ -29,7 +37,12 @@ export interface CubeBoardWidgetProps {
   constraints?: LayoutConstraint[];
   /** Test id applied to the rendered widget element. */
   qa?: string;
-  /** Style overrides applied to the rendered widget element. */
+  /**
+   * Style overrides applied to the rendered widget element. Individual style
+   * props (`fill`, `padding`, `radius`, `border`, ...) can also be passed
+   * directly on `Board.Widget`, just like on `Board`; they are merged into
+   * these styles (the `styles` object wins on conflicts).
+   */
   styles?: Styles;
   /**
    * Grow this widget's height in its board to fit its content (only ever
@@ -61,18 +74,26 @@ export function Widget(props: CubeBoardWidgetProps) {
     isDraggable,
     isResizable,
     resizeHandles,
+    isCard,
     minW,
     maxW,
     minH,
     maxH,
     constraints,
     qa,
-    styles,
     isAutoHeight,
     dragCancel,
     dragHandle,
   } = props;
   const registry = useBoardRegistry();
+
+  // Collect direct style props (e.g. `fill`, `padding`, `radius`) and merge them
+  // with the explicit `styles` prop, mirroring how `Board` extracts its own
+  // styles. Fall back to `undefined` when nothing was provided so widgets with
+  // no styling keep a stable registration (avoids needless store churn).
+  const extractedStyles = extractStyles(props, CONTAINER_STYLES);
+  const styles =
+    Object.keys(extractedStyles).length > 0 ? extractedStyles : undefined;
 
   // Stable per-instance token so a stale unregister (from an unmounting copy of
   // this widget) can't wipe out a newer instance's registration.
@@ -87,6 +108,7 @@ export function Widget(props: CubeBoardWidgetProps) {
         isDraggable,
         isResizable,
         resizeHandles,
+        isCard,
         minW,
         maxW,
         minH,

--- a/src/components/layout/Board/Widget.tsx
+++ b/src/components/layout/Board/Widget.tsx
@@ -41,7 +41,7 @@ export interface CubeBoardWidgetProps extends ContainerStyleProps {
    * Style overrides applied to the rendered widget element. Individual style
    * props (`fill`, `padding`, `radius`, `border`, ...) can also be passed
    * directly on `Board.Widget`, just like on `Board`; they are merged into
-   * these styles (the `styles` object wins on conflicts).
+   * these styles (a direct prop wins over the same key in the `styles` object).
    */
   styles?: Styles;
   /**
@@ -60,6 +60,28 @@ export interface CubeBoardWidgetProps extends ContainerStyleProps {
    * inside this widget (overrides the board's `dragHandle`).
    */
   dragHandle?: string;
+}
+
+/**
+ * Shallow-compare two style maps by their top-level keys. Direct style props
+ * (e.g. `fill`) are primitives, so this reliably detects a real change while
+ * ignoring the fresh object identity `extractStyles` produces each render.
+ */
+function shallowEqualStyles(a?: Styles, b?: Styles): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (
+      (a as Record<string, unknown>)[key] !==
+      (b as Record<string, unknown>)[key]
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**
@@ -92,8 +114,20 @@ export function Widget(props: CubeBoardWidgetProps) {
   // styles. Fall back to `undefined` when nothing was provided so widgets with
   // no styling keep a stable registration (avoids needless store churn).
   const extractedStyles = extractStyles(props, CONTAINER_STYLES);
-  const styles =
+  const nextStyles =
     Object.keys(extractedStyles).length > 0 ? extractedStyles : undefined;
+
+  // `extractStyles` returns a fresh object every render, so passing it straight
+  // to `register` would make the store treat every render as a style change,
+  // bump its version, and re-render the hosting board in a loop. Keep a stable
+  // reference across renders and only swap it when the shallow style values
+  // actually change (direct props are primitives; a `styles` object is compared
+  // per top-level key).
+  const stylesRef = useRef<Styles | undefined>(undefined);
+  if (!shallowEqualStyles(stylesRef.current, nextStyles)) {
+    stylesRef.current = nextStyles;
+  }
+  const styles = stylesRef.current;
 
   // Stable per-instance token so a stale unregister (from an unmounting copy of
   // this widget) can't wipe out a newer instance's registration.

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -36,9 +36,16 @@ const WidgetElement = tasty({
     position: 'absolute',
     top: 0,
     left: 0,
-    fill: '#surface',
+    // Widgets always carry a `#surface-2` fill and rounded corners. The `card`
+    // modifier (board-level `widgetProps.isCard` or per-widget `isCard`) adds a
+    // border on top; a non-card widget is borderless so nested boards can align
+    // their columns flush with the parent grid.
+    fill: '#surface-2',
     radius: '1cr',
-    border: true,
+    border: {
+      '': false,
+      card: true,
+    },
     shadow: {
       '': false,
       // `$dialog-shadow` uses Glaze `#shadow-lg`, which adapts to dark / high-contrast schemes.
@@ -303,6 +310,17 @@ export interface WidgetHostProps {
   item: LayoutItem;
   positionParams: PositionParams;
   registration: WidgetRegistration | undefined;
+  /**
+   * Whether this widget renders with card chrome (fill/border/radius). Resolved
+   * by the owning `Board` from the per-widget `isCard` and the board-level
+   * `widgetProps.isCard` default.
+   */
+  isCard: boolean;
+  /**
+   * Resolved style overrides for the rendered widget element (per-widget
+   * `styles` falling back to the board-level `widgetProps.styles`).
+   */
+  styles?: Styles;
   isDraggable: boolean;
   isResizable: boolean;
   resizeHandles: ResizeHandleAxis[];
@@ -352,6 +370,8 @@ export function WidgetHost(props: WidgetHostProps) {
     item,
     positionParams,
     registration,
+    isCard,
+    styles: widgetStyles,
     isDraggable,
     isResizable,
     resizeHandles,
@@ -551,6 +571,8 @@ export function WidgetHost(props: WidgetHostProps) {
     draggable: isDraggable && !isActiveDrag,
     static: !!item.static,
     resizing: isResizing,
+    card: isCard,
+    hovered: isHovered,
   };
 
   const content = (
@@ -644,7 +666,7 @@ export function WidgetHost(props: WidgetHostProps) {
       )}
       qa={registration?.qa}
       mods={hostMods}
-      styles={registration?.styles as Styles}
+      styles={widgetStyles as Styles}
     >
       {floatInOverlay ? null : content}
     </WidgetElement>
@@ -662,7 +684,7 @@ export function WidgetHost(props: WidgetHostProps) {
             pointerEvents: 'none',
           }}
           mods={{ ...mods, drag: true, floating: true }}
-          styles={registration?.styles as Styles}
+          styles={widgetStyles as Styles}
           aria-hidden="true"
         >
           {content}

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -56,7 +56,13 @@ const WidgetElement = tasty({
       '': 1,
       floating: 0.8,
     },
-    transition: 'theme, shadow, opacity',
+    // Reflowing widgets animate their position via the `inset` group (left/top).
+    // The actively dragged/resized element - and the floating overlay clone -
+    // must track the pointer with no lag, so they drop `inset` from the list.
+    transition: {
+      '': 'theme, shadow, opacity, inset',
+      'drag | floating | resizing': 'theme, shadow, opacity',
+    },
     boxSizing: 'border-box',
     userSelect: {
       '': 'auto',
@@ -604,7 +610,8 @@ export function WidgetHost(props: WidgetHostProps) {
   const floatInOverlay = useOverlay && !!overlayNode && !!dragState;
 
   const hostStyle: CSSProperties = {
-    transform: `translate(${pos.left}px, ${pos.top}px)`,
+    left: `${pos.left}px`,
+    top: `${pos.top}px`,
     width: `${pos.width}px`,
     height: `${pos.height}px`,
     // Kept mounted but hidden while its clone floats, so the gesture stays live

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -48,6 +48,7 @@ const WidgetElement = tasty({
     },
     shadow: {
       '': false,
+      'hovered & !card': '0 0 0 1bw #border',
       // `$dialog-shadow` uses Glaze `#shadow-lg`, which adapts to dark / high-contrast schemes.
       'drag | resizing': '$dialog-shadow',
     },

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -48,7 +48,7 @@ const WidgetElement = tasty({
     },
     shadow: {
       '': false,
-      'hovered & !card': '0 0 0 1bw #border',
+      'hovered & !card & (draggable | resizing)': '0 0 0 1bw #border',
       // `$dialog-shadow` uses Glaze `#shadow-lg`, which adapts to dark / high-contrast schemes.
       'drag | resizing': '$dialog-shadow',
     },
@@ -531,8 +531,15 @@ export function WidgetHost(props: WidgetHostProps) {
   // Skipping `useMove` entirely leaves the target's default behavior and its own
   // handlers fully intact. Keyboard moves go through `onKeyDown` and are never
   // gated.
-  const gatedMoveProps =
-    isDraggable && (dragHandle || dragCancel)
+  //
+  // A non-draggable widget must not carry `moveProps` at all: `useMove`'s
+  // pointer-down handler calls `preventDefault()`, which cancels native text
+  // selection inside the widget. Read-only boards (`isDraggable={false}`) still
+  // need selectable content, so we drop the handlers entirely instead of relying
+  // on the early-returns inside the `onMove*` callbacks.
+  const gatedMoveProps = !isDraggable
+    ? {}
+    : dragHandle || dragCancel
       ? {
           ...moveProps,
           ...(moveProps.onPointerDown && {

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -326,6 +326,18 @@ export interface WidgetHostProps {
   isResizable: boolean;
   resizeHandles: ResizeHandleAxis[];
   /**
+   * Whether this widget grows to fit its content. Resolved by the owning
+   * `Board` from the per-widget `isAutoHeight` and the board-level
+   * `widgetProps.isAutoHeight` default.
+   */
+  isAutoHeight: boolean;
+  /**
+   * Test id / accessible name for the rendered widget element. Resolved by the
+   * owning `Board` from the per-widget `qa` and the board-level `widgetProps.qa`
+   * default; falls back to the layout id.
+   */
+  qa?: string;
+  /**
    * CSS selector for elements that must not start a pointer drag (e.g. form
    * controls inside the widget). A pointer-down whose target matches this
    * selector never begins a drag.
@@ -376,6 +388,8 @@ export function WidgetHost(props: WidgetHostProps) {
     isDraggable,
     isResizable,
     resizeHandles,
+    isAutoHeight,
+    qa,
     dragCancel,
     dragHandle,
     registry,
@@ -387,7 +401,6 @@ export function WidgetHost(props: WidgetHostProps) {
 
   const hostRef = useRef<HTMLDivElement | null>(null);
   const isActiveDrag = dragState?.itemId === item.i;
-  const isAutoHeight = registration?.isAutoHeight === true;
 
   // Translate a nested board's reported height deficit (signed px: positive when
   // it is squeezed, negative when it has slack) into the absolute number of rows
@@ -494,7 +507,7 @@ export function WidgetHost(props: WidgetHostProps) {
   const a11yProps = {
     tabIndex: isDraggable ? 0 : undefined,
     'aria-roledescription': isDraggable ? 'Draggable widget' : undefined,
-    'aria-label': registration?.qa ?? item.i,
+    'aria-label': qa ?? item.i,
   };
 
   // When this widget is draggable it owns its gesture, so stop the pointer-down
@@ -672,7 +685,7 @@ export function WidgetHost(props: WidgetHostProps) {
         a11yProps,
         { style: hostStyle },
       )}
-      qa={registration?.qa}
+      qa={qa}
       mods={hostMods}
       styles={widgetStyles as Styles}
     >

--- a/src/components/layout/Board/board-context.tsx
+++ b/src/components/layout/Board/board-context.tsx
@@ -99,6 +99,18 @@ export function useBoardDragActive(): boolean {
 }
 
 /**
+ * Whether an ancestor `Board` has its grid-line overlay enabled. A nested board
+ * that does not set `showGridLines` explicitly reads this to inherit the
+ * behaviour, showing its own grid lines while a drag is in progress. Defaults to
+ * `false` outside any grid-lined board.
+ */
+export const BoardGridLinesContext = createContext<boolean>(false);
+
+export function useBoardGridLines(): boolean {
+  return useContext(BoardGridLinesContext);
+}
+
+/**
  * The resolved grid metrics a `Board` exposes to any boards nested inside its
  * widgets. A nested board with `isAligned` reads these to inherit the parent's
  * column pitch (column width + horizontal margin) and target row height, so its

--- a/src/components/layout/Board/board-context.tsx
+++ b/src/components/layout/Board/board-context.tsx
@@ -58,6 +58,13 @@ export interface BoardDragState {
   /** Dragged widget rect in viewport coordinates (follows the pointer). */
   rect: ViewportRect;
   pointerType: string;
+  /**
+   * Ids of boards nested inside the dragged widget, captured at drag start.
+   * Such a board is never a drop target, and it suppresses its own grid-line
+   * overlay while its host widget is being dragged (the whole widget floats, so
+   * the inner grid lines would only add clutter).
+   */
+  nestedBoardIds: Set<string>;
 }
 
 export interface BoardRegistryContextValue {

--- a/src/components/layout/Board/board-store.ts
+++ b/src/components/layout/Board/board-store.ts
@@ -16,6 +16,11 @@ export interface WidgetRegistration {
   isDraggable?: boolean;
   isResizable?: boolean;
   resizeHandles?: ResizeHandleAxis[];
+  /**
+   * Add a card border to this widget (widgets are always filled and rounded).
+   * Falls back to the owning board's `widgetProps.isCard` when unset here.
+   */
+  isCard?: boolean;
   /** Minimum width in grid columns (fallback when the layout item omits `minW`). */
   minW?: number;
   /** Maximum width in grid columns (fallback when the layout item omits `maxW`). */
@@ -71,6 +76,7 @@ export class BoardWidgetStore {
       prev.isDraggable !== reg.isDraggable ||
       prev.isResizable !== reg.isResizable ||
       prev.resizeHandles !== reg.resizeHandles ||
+      prev.isCard !== reg.isCard ||
       prev.minW !== reg.minW ||
       prev.maxW !== reg.maxW ||
       prev.minH !== reg.minH ||

--- a/src/components/layout/Board/board-store.ts
+++ b/src/components/layout/Board/board-store.ts
@@ -16,6 +16,14 @@ export interface WidgetRegistration {
   isDraggable?: boolean;
   isResizable?: boolean;
   resizeHandles?: ResizeHandleAxis[];
+  /** Minimum width in grid columns (fallback when the layout item omits `minW`). */
+  minW?: number;
+  /** Maximum width in grid columns (fallback when the layout item omits `maxW`). */
+  maxW?: number;
+  /** Minimum height in grid rows (fallback when the layout item omits `minH`). */
+  minH?: number;
+  /** Maximum height in grid rows (fallback when the layout item omits `maxH`). */
+  maxH?: number;
   constraints?: LayoutConstraint[];
   qa?: string;
   styles?: Styles;
@@ -63,6 +71,10 @@ export class BoardWidgetStore {
       prev.isDraggable !== reg.isDraggable ||
       prev.isResizable !== reg.isResizable ||
       prev.resizeHandles !== reg.resizeHandles ||
+      prev.minW !== reg.minW ||
+      prev.maxW !== reg.maxW ||
+      prev.minH !== reg.minH ||
+      prev.maxH !== reg.maxH ||
       prev.constraints !== reg.constraints ||
       prev.qa !== reg.qa ||
       prev.styles !== reg.styles ||

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -288,6 +288,7 @@ export function useBoardRegistry(
         item: draggedItem,
         rect,
         pointerType,
+        nestedBoardIds: nested,
       };
       setDragState(next);
       entry.setPlaceholder({ ...item });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core `Board` layout, resize constraints, and aligned-nested semantics—apps relying on shrunk rows inside short containers or old transform positioning may see different sizing/animation. Dev-only lint-staged upgrade is low risk.
> 
> **Overview**
> **`Board` / `Board.Widget`** gain **`widgetProps`** for board-wide defaults (card chrome, sizing, drag/resize, merged styles), per-widget **`isCard`**, **`minW`/`maxW`/`minH`/`maxH`** when layout items omit bounds, and **container style props** on `Board.Widget` merged into `styles`.
> 
> **Visual / layout behavior:** widgets default to **`#surface-2`** fill and rounded corners; optional card borders. Positioning moves from **`transform`** to **`left`/`top`** with **`inset`** transitions on reflow. Read-only boards (`isDraggable={false}`) no longer attach drag handlers so text inside widgets stays selectable.
> 
> **Aligned nested boards (`isAligned`):** use the parent **row height verbatim** (no shrinking to fit), default **`containerPadding` to `[0, 0]`**, and a small width tolerance so column pitch lines up with the ancestor grid—intended to pair with **`isAutoHeight`** containers. Nested boards **inherit ancestor `showGridLines` during drag** when unset; inner grid lines hide while the host widget is dragged.
> 
> **Tooling:** fixes **lint-staged** glob (`*.{js,jsx,ts,tsx}`) and bumps **lint-staged** `^10` → `^17` (lockfile churn).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211f3c379dd5132d102fde5ed165eb4a468ebad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->