### PR TITLE
feat(Board): enhance drag-and-drop behavior and widget transitions

### DIFF
--- a/.changeset/board-center-drop-target.md
+++ b/.changeset/board-center-drop-target.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+`Board`: a board now becomes the drop target when the dragged widget's center enters it, instead of only once its top-left corner is inside. Empty boards open (expand to preview the drop) as soon as the widget's center touches them. The landing/placeholder stays anchored to the grabbed point, so it keeps tracking the floating widget.

--- a/.changeset/board-settle-transitions.md
+++ b/.changeset/board-settle-transitions.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+`Board`: widgets no longer animate (`inset` transition) on initial render. The board now waits for widgets to paint at their first measured positions before activating position transitions, so they settle into place instead of sliding in from their default spot. Transitions still apply to subsequent reflows (drag/resize of neighbours, compaction, aligned-column changes).

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -1509,29 +1509,30 @@ describe('Board', () => {
       return { ...utils, widget };
     }
 
-    it('does not transfer when only the widget center crosses into the target', () => {
+    it('does not transfer while the widget center is still over the source', () => {
       const onWidgetTransfer = vi.fn();
       const { widget } = setupSideBySideBoards(onWidgetTransfer);
 
-      // Drag the top-left to x=500: the widget center (700) is over the target
-      // board, but its top-left - the anchor the landing and overlay use - is
-      // still over the source. The drop must follow the top-left, not the
-      // center, so the widget stays on the source board.
+      // Drag the top-left to x=300: the widget center (500) is still over the
+      // source board (x:[0,600]). Selection follows the center, so the widget
+      // stays on the source board.
       fireEvent(widget, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 500, 0));
-      fireEvent(window, pointerEvent('pointerup', 500, 0));
+      fireEvent(window, pointerEvent('pointermove', 300, 0));
+      fireEvent(window, pointerEvent('pointerup', 300, 0));
 
       expect(onWidgetTransfer).not.toHaveBeenCalled();
     });
 
-    it('transfers once the widget top-left crosses into the target', () => {
+    it('transfers once the widget center crosses into the target', () => {
       const onWidgetTransfer = vi.fn();
       const { widget } = setupSideBySideBoards(onWidgetTransfer);
 
-      // Drag the top-left to x=700, inside the target board's rect.
+      // Drag the top-left to x=500: the widget center (700) is inside the target
+      // board (x:[600,1200]) even though the top-left is still over the source.
+      // Selection follows the center, so the widget transfers.
       fireEvent(widget, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 700, 0));
-      fireEvent(window, pointerEvent('pointerup', 700, 0));
+      fireEvent(window, pointerEvent('pointermove', 500, 0));
+      fireEvent(window, pointerEvent('pointerup', 500, 0));
 
       expect(onWidgetTransfer).toHaveBeenCalledTimes(1);
       expect(onWidgetTransfer).toHaveBeenCalledWith(

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -807,6 +807,30 @@ function BoardInner(
   const dragState = registry.dragState;
   const ready = width > 0;
 
+  // Gate widget position transitions off until the widgets have been painted at
+  // their initial positions once. Without this, the first render animates every
+  // widget sliding in from its default spot (0, 0). We render one frame with the
+  // gate closed (no `inset` transition), let the browser paint, then lift it so
+  // later reflows animate. A double rAF waits past the first committed paint;
+  // re-arm whenever the board (re)becomes ready so a board that hides and
+  // remeasures (e.g. inside a tab) re-settles too.
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    if (!ready) {
+      setSettled(false);
+      return;
+    }
+    let id1 = 0;
+    let id2 = 0;
+    id1 = requestAnimationFrame(() => {
+      id2 = requestAnimationFrame(() => setSettled(true));
+    });
+    return () => {
+      cancelAnimationFrame(id1);
+      if (id2) cancelAnimationFrame(id2);
+    };
+  }, [ready]);
+
   // When the widget that hosts this nested board is the one being dragged, its
   // whole content (including this board) floats as a single unit, so its own
   // grid lines add nothing but clutter. Suppress them for that drag.
@@ -991,6 +1015,7 @@ function BoardInner(
                       dragHandle={widgetDragHandle}
                       registry={registry}
                       dragState={dragState}
+                      settled={settled}
                       onResize={handleResize}
                       onAutoHeight={handleAutoHeight}
                       onDragLifecycle={handleDragLifecycle}

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -67,8 +67,13 @@ const WidgetElement = tasty({
     // Reflowing widgets animate their position via the `inset` group (left/top).
     // The actively dragged/resized element - and the floating overlay clone -
     // must track the pointer with no lag, so they drop `inset` from the list.
+    // `inset` is also dropped until the board reports `settled`: on init widgets
+    // jump to their first measured positions, and without this gate they would
+    // slide in from their default (0, 0) spot. The board lifts the gate after
+    // the first positioned paint so subsequent reflows animate normally.
     transition: {
-      '': 'theme, shadow, opacity, inset',
+      '': 'theme, shadow, opacity',
+      settled: 'theme, shadow, opacity, inset',
       'drag | floating | resizing': 'theme, shadow, opacity',
     },
     boxSizing: 'border-box',
@@ -348,6 +353,13 @@ export interface WidgetHostProps {
    * pointer-down outside a matching element never begins a drag.
    */
   dragHandle?: string;
+  /**
+   * Whether the owning board has settled its widgets' initial positions. While
+   * false, the widget does not animate `inset` (left/top) so the first
+   * positioned paint isn't seen as a transition. Lifted after the board's first
+   * measured render.
+   */
+  settled?: boolean;
   registry: BoardRegistryContextValue;
   dragState: BoardDragState | null;
   onResize: (
@@ -394,6 +406,7 @@ export function WidgetHost(props: WidgetHostProps) {
     dragHandle,
     registry,
     dragState,
+    settled,
     onResize,
     onAutoHeight,
     onDragLifecycle,
@@ -665,7 +678,7 @@ export function WidgetHost(props: WidgetHostProps) {
   // The floating clone carries the "drag" affordance (raised shadow/z-index);
   // keep the hidden host flat. Keyboard drags (which never float) still
   // highlight the in-grid host, so only suppress `drag` when floating.
-  const hostMods = { ...mods, drag: isActiveDrag && !floatInOverlay };
+  const hostMods = { ...mods, drag: isActiveDrag && !floatInOverlay, settled };
 
   // The host is always rendered first, with a stable element shape, so React
   // reuses the same DOM node across the drag transition (never remounts it).

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -20,17 +20,22 @@ import {
 } from './grid-core';
 
 /**
- * The dragged widget's top-left corner in viewport coordinates.
+ * The dragged widget's center in viewport coordinates.
  *
- * This is the anchor `computeLanding` maps into a target board's grid, and the
- * same point the floating overlay clone is positioned at (see `WidgetHost`), so
- * the drop-target hit-test must use it too. Picking the target by the widget's
- * center instead lets a wide/tall widget select a board its top-left has not yet
- * entered: `computeLanding` then clamps the landing to that board's edge and the
- * placeholder/drop slot drift away from where the overlay is actually drawn.
+ * This is the anchor the drop-target hit-test uses to pick which board a drag is
+ * over, so a board (including an empty one) opens as soon as the widget's center
+ * enters it rather than only once its whole top-left corner is inside.
+ *
+ * The landing itself stays anchored to the grabbed top-left (`rect.left/top` in
+ * `computeLanding`): that point is this center offset by the widget's own fixed
+ * pixel size, so the resolved landing cell keeps corresponding to where the
+ * floating overlay clone is drawn (see `WidgetHost`) and the placeholder keeps
+ * tracking the ghost. The only unavoidable divergence is while the widget
+ * physically overhangs a board edge - a placeholder cannot render outside row 0
+ * / column 0 - which is the accepted tradeoff for opening on the center.
  */
-function rectOrigin(rect: ViewportRect): { x: number; y: number } {
-  return { x: rect.left, y: rect.top };
+function rectCenter(rect: ViewportRect): { x: number; y: number } {
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
 }
 
 /**
@@ -435,13 +440,14 @@ export function useBoardRegistry(
       };
 
       const source = boardsRef.current.get(ds.sourceBoardId);
-      // Hit-test with the widget's top-left corner - the same anchor
-      // `computeLanding` and the overlay clone use - so the chosen board always
-      // contains the landing anchor and the placeholder can't diverge from the
-      // floating overlay (see `rectOrigin`). Fall back to the source board so a
-      // pointer outside every board keeps the widget anchored to where it came
-      // from. Frozen rects make this deterministic (no preview-induced flip-flop).
-      const anchor = rectOrigin(newRect);
+      // Hit-test with the widget's center so a board opens as soon as the center
+      // enters it (see `rectCenter`). The landing still resolves from the grabbed
+      // top-left, which is this center offset by the widget's own size, so the
+      // placeholder keeps tracking the floating overlay. Fall back to the source
+      // board so a pointer outside every board keeps the widget anchored to where
+      // it came from. Frozen rects make this deterministic (no preview-induced
+      // flip-flop).
+      const anchor = rectCenter(newRect);
       let target = hitTest(anchor) ?? source ?? null;
 
       // Keep the drag on a nested source board while the cursor is still within


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes cross-board hit-testing semantics and first-paint transition timing in core drag/layout code; behavior is covered by updated transfer tests but edge cases (wide widgets over board edges) are an accepted tradeoff.
> 
> **Overview**
> **Cross-board drag** now picks the active board when the dragged widget’s **center** enters that board’s content rect (including empty boards opening earlier), instead of waiting for the top-left corner. Drop landing and the floating overlay still resolve from the grabbed **top-left**, so the placeholder keeps tracking the ghost; tests were flipped to match center-based transfer.
> 
> **Initial layout** no longer animates widgets sliding in from `(0, 0)`: `Board` gates `settled` with a double `requestAnimationFrame` after the board is measured (`ready`), passes it to `WidgetHost`, and only then enables `inset` transitions for later reflows (drag, resize, compaction). Boards that remeasure after being hidden (e.g. tabs) re-arm the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e402c29dcb8933d73675ceb67a5b8b22eaba6d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->