### PR TITLE
feat(Board): implement keyboard navigation for widgets and enhance fo…

### DIFF
--- a/.changeset/board-keyboard-movement.md
+++ b/.changeset/board-keyboard-movement.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+`Board`: improve keyboard and focus behavior for draggable widgets. Clicking an eligible drag zone now focuses the widget; keyboard focus shows an adaptive focus ring (`:focus-visible`). Arrow-key moves respect layout constraints, scan past blocked cells to the next valid slot, and reflow neighbours without overlap where the board mode allows. Widget position transitions now include `width` and `height`.

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -4,7 +4,8 @@ import {
   render,
   renderWithRoot,
   screen,
-} from '../../../test/render';
+  userEvent,
+} from '../../../test';
 import { Tab, Tabs } from '../../navigation/Tabs';
 
 import { Board } from './index';
@@ -73,6 +74,40 @@ describe('Board', () => {
     expect(widget.style.top).toBe('10px');
   });
 
+  it('transitions widget position and size after initial placement', () => {
+    const callbacks: FrameRequestCallback[] = [];
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      });
+
+    try {
+      render(
+        <Board
+          width={1200}
+          defaultLayout={[{ i: 'a', x: 0, y: 0, w: 2, h: 2 }]}
+        >
+          <Board.Widget id="a" qa="WidgetA">
+            A
+          </Board.Widget>
+        </Board>,
+      );
+
+      act(() => callbacks.shift()?.(0));
+      act(() => callbacks.shift()?.(0));
+
+      const widget = screen.getByTestId('WidgetA');
+      expect(widget).toHaveAttribute('data-settled');
+      const transition = getComputedStyle(widget).transition;
+      expect(transition).toContain('width');
+      expect(transition).toContain('height');
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+
   it('makes draggable widgets focusable', () => {
     render(
       <Board width={1200} defaultLayout={[{ i: 'a', x: 0, y: 0, w: 2, h: 2 }]}>
@@ -83,6 +118,21 @@ describe('Board', () => {
     );
 
     expect(screen.getByTestId('WidgetA')).toHaveAttribute('tabindex', '0');
+  });
+
+  it('shows the widget focus state only for focus-visible focus', async () => {
+    const user = userEvent.setup();
+    render(
+      <Board width={1200} defaultLayout={[{ i: 'a', x: 0, y: 0, w: 2, h: 2 }]}>
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+      </Board>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByTestId('WidgetA')).toHaveAttribute('data-focus-visible');
   });
 
   it('does not make widgets focusable when dragging is disabled', () => {
@@ -258,7 +308,7 @@ describe('Board', () => {
     // ArrowRight always lands the dragged widget at x=1. Dragging the widget
     // that starts at x=0 therefore gives a deterministic one-column move.
 
-    it('blocks a drop onto an occupied cell and never moves neighbours', () => {
+    it('scans past occupied cells and never moves neighbours', () => {
       const onLayoutChange = vi.fn();
       render(
         <Board
@@ -268,7 +318,7 @@ describe('Board', () => {
           onLayoutChange={onLayoutChange}
           defaultLayout={[
             { i: 'a', x: 0, y: 0, w: 2, h: 2 },
-            { i: 'b', x: 2, y: 0, w: 2, h: 2 },
+            { i: 'b', x: 2, y: 0, w: 4, h: 2 },
           ]}
         >
           <Board.Widget id="a" qa="WidgetA">
@@ -282,13 +332,13 @@ describe('Board', () => {
 
       const widget = screen.getByTestId('WidgetA');
       widget.focus();
-      // Moving A one column right would overlap B; without overlap the move is
-      // blocked, so A stays put and B is neither pushed nor swapped.
+      // Adjacent candidates overlap B, so keyboard movement scans to the first
+      // free slot after it without pushing or swapping in free mode.
       fireEvent.keyDown(widget, { key: 'ArrowRight' });
 
       expect(onLayoutChange).toHaveBeenCalled();
       const last = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
-      expect(last.find((l) => l.i === 'a')?.x).toBe(0);
+      expect(last.find((l) => l.i === 'a')?.x).toBe(6);
       expect(last.find((l) => l.i === 'b')?.x).toBe(2);
     });
 
@@ -359,6 +409,66 @@ describe('Board', () => {
       expect(last.find((l) => l.i === 'a')?.x).toBe(1);
       expect(last.find((l) => l.i === 'b')?.x).toBe(2);
     });
+  });
+
+  it('scans past a larger static widget without changing rows', () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <Board
+        width={1200}
+        cols={12}
+        onLayoutChange={onLayoutChange}
+        defaultLayout={[
+          { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+          { i: 'b', x: 2, y: 0, w: 4, h: 4, static: true },
+        ]}
+      >
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+        <Board.Widget id="b">B</Board.Widget>
+      </Board>,
+    );
+
+    const widget = screen.getByTestId('WidgetA');
+    widget.focus();
+    fireEvent.keyDown(widget, { key: 'ArrowRight' });
+
+    const last = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
+    expect(last.find((l) => l.i === 'a')).toMatchObject({ x: 6, y: 0 });
+    expect(last.find((l) => l.i === 'b')).toMatchObject({ x: 2, y: 0 });
+  });
+
+  it('reflows a larger movable widget without creating overlap', () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <Board
+        width={1200}
+        cols={12}
+        onLayoutChange={onLayoutChange}
+        defaultLayout={[
+          { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+          { i: 'b', x: 2, y: 0, w: 4, h: 4 },
+        ]}
+      >
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+        <Board.Widget id="b">B</Board.Widget>
+      </Board>,
+    );
+
+    const widget = screen.getByTestId('WidgetA');
+    widget.focus();
+    fireEvent.keyDown(widget, { key: 'ArrowRight' });
+
+    const last = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
+    const a = last.find((l) => l.i === 'a')!;
+    const b = last.find((l) => l.i === 'b')!;
+    expect(a.x).toBeGreaterThan(0);
+    expect(
+      a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y,
+    ).toBe(false);
   });
 
   it('supports nested boards inside a widget', () => {
@@ -474,6 +584,29 @@ describe('Board', () => {
     expect(onLayoutChange).toHaveBeenCalled();
     const lastLayout = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
     expect(lastLayout.find((l) => l.i === 'a')?.x).toBe(5);
+  });
+
+  it('keeps keyboard movement within the grid bounds', () => {
+    const onLayoutChange = vi.fn();
+    render(
+      <Board
+        width={1200}
+        cols={12}
+        onLayoutChange={onLayoutChange}
+        defaultLayout={[{ i: 'a', x: 10, y: 0, w: 2, h: 2 }]}
+      >
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+      </Board>,
+    );
+
+    const widget = screen.getByTestId('WidgetA');
+    widget.focus();
+    fireEvent.keyDown(widget, { key: 'ArrowRight' });
+
+    const lastLayout = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
+    expect(lastLayout.find((l) => l.i === 'a')?.x).toBe(10);
   });
 
   it('stays registered and draggable after its id changes', () => {
@@ -1118,6 +1251,34 @@ describe('Board', () => {
       Object.defineProperty(event, 'pageY', { get: () => pageY });
       return event;
     };
+
+    it('focuses the widget from an eligible pointer drag zone', () => {
+      render(
+        <Board
+          width={1200}
+          dragHandle=".handle"
+          defaultLayout={[{ i: 'a', x: 0, y: 0, w: 4, h: 2 }]}
+        >
+          <Board.Widget id="a" qa="WidgetA">
+            <div className="handle" data-qa="Handle">
+              Grip
+            </div>
+            <div data-qa="Body">Body</div>
+          </Board.Widget>
+        </Board>,
+      );
+
+      const widget = screen.getByTestId('WidgetA');
+      fireEvent(screen.getByTestId('Body'), pointerEvent('pointerdown', 0, 0));
+      expect(widget).not.toHaveFocus();
+
+      fireEvent(
+        screen.getByTestId('Handle'),
+        pointerEvent('pointerdown', 0, 0),
+      );
+      expect(widget).toHaveFocus();
+      expect(widget).not.toHaveAttribute('data-focus-visible');
+    });
 
     it('does not start a drag from an element matching dragCancel', () => {
       const onDragStart = vi.fn();

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -1,6 +1,6 @@
 import { Styles, tasty } from '@tenphi/tasty';
 import { CSSProperties, useMemo, useRef, useState } from 'react';
-import { useFocusWithin, useHover, useMove } from 'react-aria';
+import { useFocusRing, useFocusWithin, useHover, useMove } from 'react-aria';
 import { createPortal } from 'react-dom';
 
 import { useEvent } from '../../../_internal/hooks';
@@ -52,6 +52,11 @@ const WidgetElement = tasty({
       // `$dialog-shadow` uses Glaze `#shadow-lg`, which adapts to dark / high-contrast schemes.
       'drag | resizing': '$dialog-shadow',
     },
+    outline: {
+      '': '1bw #primary-text.0',
+      'focus-visible': '1bw #primary-text',
+    },
+    outlineOffset: '1bw',
     zIndex: {
       '': 1,
       'drag | resizing': 10,
@@ -64,16 +69,16 @@ const WidgetElement = tasty({
       '': 1,
       floating: 0.8,
     },
-    // Reflowing widgets animate their position via the `inset` group (left/top).
-    // The actively dragged/resized element - and the floating overlay clone -
-    // must track the pointer with no lag, so they drop `inset` from the list.
-    // `inset` is also dropped until the board reports `settled`: on init widgets
-    // jump to their first measured positions, and without this gate they would
-    // slide in from their default (0, 0) spot. The board lifts the gate after
-    // the first positioned paint so subsequent reflows animate normally.
+    // Reflowing widgets animate their position and size. The actively
+    // dragged/resized element - and the floating overlay clone - must track the
+    // pointer with no lag, so they drop geometry from the list. Geometry is also
+    // dropped until the board reports `settled`: on init widgets jump to their
+    // first measured positions, and without this gate they would slide/grow in
+    // from their default box. The board lifts the gate after the first
+    // positioned paint so subsequent reflows animate normally.
     transition: {
       '': 'theme, shadow, opacity',
-      settled: 'theme, shadow, opacity, inset',
+      settled: 'theme, shadow, opacity, inset, width, height',
       'drag | floating | resizing': 'theme, shadow, opacity',
     },
     boxSizing: 'border-box',
@@ -453,6 +458,7 @@ export function WidgetHost(props: WidgetHostProps) {
   const [isResizing, setIsResizing] = useState(false);
   const [isFocusWithin, setIsFocusWithin] = useState(false);
   const { hoverProps, isHovered } = useHover({ isDisabled: isActiveDrag });
+  const { focusProps, isFocusVisible } = useFocusRing();
   const { focusWithinProps } = useFocusWithin({
     onFocusWithinChange: setIsFocusWithin,
   });
@@ -565,29 +571,29 @@ export function WidgetHost(props: WidgetHostProps) {
   // on the early-returns inside the `onMove*` callbacks.
   const gatedMoveProps = !isDraggable
     ? {}
-    : dragHandle || dragCancel
-      ? {
-          ...moveProps,
-          ...(moveProps.onPointerDown && {
-            onPointerDown: (e: React.PointerEvent) => {
-              if (shouldGateDrag(e.target)) return;
-              moveProps.onPointerDown!(e);
-            },
-          }),
-          ...(moveProps.onMouseDown && {
-            onMouseDown: (e: React.MouseEvent) => {
-              if (shouldGateDrag(e.target)) return;
-              moveProps.onMouseDown!(e);
-            },
-          }),
-          ...(moveProps.onTouchStart && {
-            onTouchStart: (e: React.TouchEvent) => {
-              if (shouldGateDrag(e.target)) return;
-              moveProps.onTouchStart!(e);
-            },
-          }),
-        }
-      : moveProps;
+    : {
+        ...moveProps,
+        ...(moveProps.onPointerDown && {
+          onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => {
+            if (shouldGateDrag(e.target)) return;
+            hostRef.current?.focus({ preventScroll: true });
+            moveProps.onPointerDown!(e);
+          },
+        }),
+        ...(moveProps.onMouseDown && {
+          onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => {
+            if (shouldGateDrag(e.target)) return;
+            hostRef.current?.focus({ preventScroll: true });
+            moveProps.onMouseDown!(e);
+          },
+        }),
+        ...(moveProps.onTouchStart && {
+          onTouchStart: (e: React.TouchEvent<HTMLDivElement>) => {
+            if (shouldGateDrag(e.target)) return;
+            moveProps.onTouchStart!(e);
+          },
+        }),
+      };
 
   const handleResize = (
     axis: ResizeHandleAxis,
@@ -607,6 +613,7 @@ export function WidgetHost(props: WidgetHostProps) {
     resizing: isResizing,
     card: isCard,
     hovered: isHovered,
+    'focus-visible': isFocusVisible,
   };
 
   const content = (
@@ -694,6 +701,7 @@ export function WidgetHost(props: WidgetHostProps) {
         gatedMoveProps,
         stopBubbleProps,
         hoverProps,
+        focusProps,
         focusWithinProps,
         a11yProps,
         { style: hostStyle },

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -12,8 +12,10 @@ import {
 import { BoardWidgetStore } from './board-store';
 import {
   applyPositionConstraints,
+  bottom,
   calcXYRaw,
   cloneLayout,
+  getAllCollisions,
   getLayoutItem,
   LayoutItem,
   moveElement,
@@ -361,6 +363,112 @@ export function useBoardRegistry(
   );
 
   /**
+   * Move a widget by one logical keyboard step. Unlike pointer movement, this
+   * starts from the live grid coordinates rather than DOM geometry and scans
+   * farther in the requested direction when the adjacent slot cannot produce a
+   * valid move.
+   */
+  const moveWithKeyboard = useCallback(
+    (entry: BoardEntry, item: LayoutItem, deltaX: number, deltaY: number) => {
+      const pp = entry.getPositionParams();
+      const compactor = entry.getCompactor();
+      const layout = entry.getLayout();
+      const live = getLayoutItem(layout, item.i);
+      if (!live) return;
+
+      const directionX = Math.sign(deltaX);
+      const directionY = Math.sign(deltaY);
+      if (directionX === 0 && directionY === 0) return;
+
+      const maxRows = entry.getMaxRows();
+      const attempts =
+        directionX < 0
+          ? live.x
+          : directionX > 0
+            ? Math.max(0, pp.cols - live.w - live.x)
+            : directionY < 0
+              ? live.y
+              : Number.isFinite(maxRows)
+                ? Math.max(0, maxRows - live.h - live.y)
+                : Math.max(1, bottom(layout) - live.y);
+      const seen = new Set<string>();
+
+      for (let distance = 1; distance <= attempts; distance++) {
+        const rawX = live.x + directionX * distance;
+        const rawY = live.y + directionY * distance;
+        const candidate = applyPositionConstraints(
+          entry.getConstraints(),
+          item,
+          rawX,
+          rawY,
+          {
+            cols: pp.cols,
+            maxRows,
+            containerWidth: pp.containerWidth,
+            containerHeight: entry.getContainerHeight(),
+            rowHeight: pp.rowHeight,
+            margin: pp.margin,
+            layout,
+          },
+        );
+        const candidateKey = `${candidate.x}:${candidate.y}`;
+        if (seen.has(candidateKey)) continue;
+        seen.add(candidateKey);
+
+        // A custom constraint may jump farther than one cell. It is still a
+        // valid candidate only when it advances in the requested direction and
+        // does not introduce movement on the orthogonal axis.
+        if (
+          (directionX !== 0 &&
+            (Math.sign(candidate.x - live.x) !== directionX ||
+              candidate.y !== live.y)) ||
+          (directionY !== 0 &&
+            (Math.sign(candidate.y - live.y) !== directionY ||
+              candidate.x !== live.x))
+        ) {
+          continue;
+        }
+
+        const working = cloneLayout(layout);
+        const target = getLayoutItem(working, item.i);
+        if (!target) return;
+        const moved = moveElement(
+          working,
+          target,
+          candidate.x,
+          candidate.y,
+          true,
+          compactor.preventCollision,
+          compactor.type,
+          pp.cols,
+          compactor.allowOverlap,
+        );
+        const compacted = [...compactor.compact(moved, pp.cols)];
+        const landed = getLayoutItem(compacted, item.i);
+        if (!landed) continue;
+
+        const advanced =
+          directionX !== 0
+            ? Math.sign(landed.x - live.x) === directionX && landed.y === live.y
+            : Math.sign(landed.y - live.y) === directionY &&
+              landed.x === live.x;
+        const overlaps =
+          !compactor.allowOverlap &&
+          getAllCollisions(compacted, landed).some(
+            (other) => other.i !== landed.i,
+          );
+        if (!advanced || overlaps) continue;
+
+        entry.applyLayout(compacted, false);
+        entry.setPlaceholder(landed);
+        lastLandingRef.current = { x: landed.x, y: landed.y };
+        return;
+      }
+    },
+    [],
+  );
+
+  /**
    * Live cross-board reflow preview. Pushes the target board's *other* widgets
    * aside to make room for the incoming item, without ever adding the dragged
    * item's host to the target (it stays visualized as a placeholder + overlay
@@ -429,9 +537,15 @@ export function useBoardRegistry(
   );
 
   const onDragMove = useEvent(
-    (deltaX: number, deltaY: number, _pointerType: string) => {
+    (deltaX: number, deltaY: number, pointerType: string) => {
       const ds = dragStateRef.current;
       if (!ds) return;
+
+      if (pointerType === 'keyboard') {
+        const source = boardsRef.current.get(ds.sourceBoardId);
+        if (source) moveWithKeyboard(source, ds.item, deltaX, deltaY);
+        return;
+      }
 
       const newRect: ViewportRect = {
         ...ds.rect,


### PR DESCRIPTION
…cus handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches drag registry layout logic and widget interaction paths used by dashboards; behavior changes for keyboard moves and collisions, though covered by expanded tests.
> 
> **Overview**
> Improves **Board** widget keyboard and pointer focus, and changes how arrow-key moves land on the grid.
> 
> **Focus:** Eligible pointer drags now focus the widget host (`preventScroll`); keyboard tab focus gets a `:focus-visible` outline via `useFocusRing`, without showing that ring on pointer-only focus. Pointer-down on non-drag zones (e.g. `dragHandle`) still does not focus.
> 
> **Keyboard movement:** Arrow keys no longer stop at the first blocked adjacent cell. The registry’s new `moveWithKeyboard` steps along grid coordinates, tries successive slots in the move direction (respecting constraints and bounds), and accepts the first layout where the item advances without overlap (when overlap is disallowed). Compaction/reflow behavior matches the board mode—e.g. free mode scans to the next empty slot without moving neighbors; compact modes can reflow neighbors to avoid overlap.
> 
> **Motion:** Settled widgets animate **width** and **height** in addition to position (`inset`), so reflows resize smoothly after the initial placement gate lifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a94b2bea0c700a0e798004e78299ea9d1a829b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->