### PR TITLE
fix(Board): prevent overlapping widgets during keyboard moves in non-…

### DIFF
--- a/.changeset/board-keyboard-overlap.md
+++ b/.changeset/board-keyboard-overlap.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+`Board`: fix keyboard moves creating overlapping widgets. When moving a focused widget with the arrow keys in a non-compacting mode (`compact={null}` or `preventCollision`), a pushed neighbour could be stacked on top of another widget. Keyboard moves now reject any step whose resulting layout has overlapping widgets and scan further for a clear slot instead, matching the pointer-drag behavior.

--- a/.changeset/board-keyboard-overlap.md
+++ b/.changeset/board-keyboard-overlap.md
@@ -2,4 +2,4 @@
 "@cube-dev/ui-kit": patch
 ---
 
-`Board`: fix keyboard moves creating overlapping widgets. When moving a focused widget with the arrow keys in a non-compacting mode (`compact={null}` or `preventCollision`), a pushed neighbour could be stacked on top of another widget. Keyboard moves now reject any step whose resulting layout has overlapping widgets and scan further for a clear slot instead, matching the pointer-drag behavior.
+`Board`: fix drags creating overlapping widgets in non-compacting modes (`compact={null}` or `preventCollision`). Moving a widget so it pushed a neighbour could stack that neighbour on top of another widget. Both keyboard and pointer moves now reject any step whose resulting layout has overlapping widgets — keyboard scans further for a clear slot, pointer keeps the widget at its last valid arrangement — so the two inputs behave consistently and neither ever stacks widgets (unless `allowOverlap` is set). Widgets still push/swap neighbours whenever the move resolves without an overlap.

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -473,9 +473,10 @@ describe('Board', () => {
 
   it('never stacks a pushed neighbour during a keyboard move in legacy compaction', () => {
     // Regression: in `compact={null}` (collisions resolved the legacy
-    // react-grid-layout way, no gap compaction) a keyboard move that pushed a
-    // neighbour could drop it on top of the widget below - a z-overlap the
-    // pointer path never produced. Moving A right onto B swaps B down onto C.
+    // react-grid-layout way, no gap compaction) a move that pushed a neighbour
+    // could drop it on top of the widget below - a z-overlap. Moving A right
+    // onto B pushes B down onto C. Both the keyboard path (this test) and the
+    // pointer path (next test) must refuse the stack.
     const onLayoutChange = vi.fn();
     render(
       <Board
@@ -506,6 +507,93 @@ describe('Board', () => {
       | undefined;
     const overlapping = (last ?? []).some((x, i) =>
       (last ?? [])
+        .slice(i + 1)
+        .some(
+          (y) =>
+            x.x < y.x + y.w &&
+            x.x + x.w > y.x &&
+            x.y < y.y + y.h &&
+            x.y + x.h > y.y,
+        ),
+    );
+    expect(overlapping).toBe(false);
+  });
+
+  it('never stacks a pushed neighbour during a pointer drag in legacy compaction', () => {
+    // Same regression as above but driven by the mouse: dragging A one column
+    // right onto B (legacy `compact={null}`) would push B down onto C. The
+    // pointer path must keep the widget at its last valid arrangement instead of
+    // committing the stack, matching the keyboard path.
+    const onLayoutChange = vi.fn();
+    // jsdom drops pageX/pageY passed via init; React Aria's useMove reads them.
+    const pointerEvent = (type: string, pageX: number, pageY: number) => {
+      const event = new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        pointerId: 1,
+        pointerType: 'mouse',
+      });
+      Object.defineProperty(event, 'pageX', { get: () => pageX });
+      Object.defineProperty(event, 'pageY', { get: () => pageY });
+      return event;
+    };
+    const mockRect = (
+      left: number,
+      top: number,
+      width: number,
+      height: number,
+    ): DOMRect =>
+      ({
+        left,
+        top,
+        width,
+        height,
+        right: left + width,
+        bottom: top + height,
+        x: left,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    render(
+      <Board
+        width={1200}
+        cols={12}
+        rowHeight={100}
+        margin={[0, 0]}
+        containerPadding={[0, 0]}
+        compact={null}
+        onLayoutChange={onLayoutChange}
+        defaultLayout={[
+          { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+          { i: 'b', x: 2, y: 0, w: 2, h: 2 },
+          { i: 'c', x: 2, y: 2, w: 2, h: 2 },
+        ]}
+      >
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+        <Board.Widget id="b">B</Board.Widget>
+        <Board.Widget id="c">C</Board.Widget>
+      </Board>,
+    );
+
+    const widget = screen.getByTestId('WidgetA');
+    const content = widget.parentElement as HTMLElement;
+    // 12 cols over 1200px with no margin/padding => 100px per column.
+    content.getBoundingClientRect = () => mockRect(0, 0, 1200, 800);
+    widget.getBoundingClientRect = () => mockRect(0, 0, 200, 200);
+
+    // Drag A one column right, straight onto B.
+    fireEvent(widget, pointerEvent('pointerdown', 0, 0));
+    fireEvent(window, pointerEvent('pointermove', 100, 0));
+    fireEvent(window, pointerEvent('pointerup', 100, 0));
+
+    expect(onLayoutChange).toHaveBeenCalled();
+    const last = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
+    const overlapping = last.some((x, i) =>
+      last
         .slice(i + 1)
         .some(
           (y) =>

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -606,6 +606,48 @@ describe('Board', () => {
     expect(overlapping).toBe(false);
   });
 
+  it('still moves a widget with the keyboard when an unrelated overlap exists', () => {
+    // Regression: the overlap guard must reject only *newly introduced* stacks,
+    // not any overlap in the board. In `compact={null}` a layout is never
+    // gap-compacted, so an app can supply already-overlapping widgets; a
+    // whole-layout collision check would then see an overlap for every candidate
+    // and freeze keyboard navigation for the whole board. Here `b`/`c` overlap
+    // from the start, but moving the unrelated `a` must still work.
+    const onLayoutChange = vi.fn();
+    render(
+      <Board
+        width={1200}
+        cols={12}
+        compact={null}
+        onLayoutChange={onLayoutChange}
+        defaultLayout={[
+          { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+          { i: 'b', x: 6, y: 0, w: 2, h: 2 },
+          { i: 'c', x: 6, y: 0, w: 2, h: 2 },
+        ]}
+      >
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+        <Board.Widget id="b">B</Board.Widget>
+        <Board.Widget id="c">C</Board.Widget>
+      </Board>,
+    );
+
+    const widget = screen.getByTestId('WidgetA');
+    widget.focus();
+    fireEvent.keyDown(widget, { key: 'ArrowRight' });
+
+    const last = onLayoutChange.mock.calls.at(-1)![0] as LayoutItem[];
+    const a = last.find((l) => l.i === 'a');
+    // `a` advanced one column despite the pre-existing `b`/`c` stack.
+    expect(a?.x).toBe(1);
+    expect(a?.y).toBe(0);
+    // The pre-existing overlap is preserved, not "fixed" by the move.
+    expect(last.find((l) => l.i === 'b')).toMatchObject({ x: 6, y: 0 });
+    expect(last.find((l) => l.i === 'c')).toMatchObject({ x: 6, y: 0 });
+  });
+
   it('supports nested boards inside a widget', () => {
     render(
       <Board.Provider>

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -471,6 +471,53 @@ describe('Board', () => {
     ).toBe(false);
   });
 
+  it('never stacks a pushed neighbour during a keyboard move in legacy compaction', () => {
+    // Regression: in `compact={null}` (collisions resolved the legacy
+    // react-grid-layout way, no gap compaction) a keyboard move that pushed a
+    // neighbour could drop it on top of the widget below - a z-overlap the
+    // pointer path never produced. Moving A right onto B swaps B down onto C.
+    const onLayoutChange = vi.fn();
+    render(
+      <Board
+        width={1200}
+        cols={12}
+        compact={null}
+        onLayoutChange={onLayoutChange}
+        defaultLayout={[
+          { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+          { i: 'b', x: 2, y: 0, w: 2, h: 2 },
+          { i: 'c', x: 2, y: 2, w: 2, h: 2 },
+        ]}
+      >
+        <Board.Widget id="a" qa="WidgetA">
+          A
+        </Board.Widget>
+        <Board.Widget id="b">B</Board.Widget>
+        <Board.Widget id="c">C</Board.Widget>
+      </Board>,
+    );
+
+    const widget = screen.getByTestId('WidgetA');
+    widget.focus();
+    fireEvent.keyDown(widget, { key: 'ArrowRight' });
+
+    const last = onLayoutChange.mock.calls.at(-1)?.[0] as
+      | LayoutItem[]
+      | undefined;
+    const overlapping = (last ?? []).some((x, i) =>
+      (last ?? [])
+        .slice(i + 1)
+        .some(
+          (y) =>
+            x.x < y.x + y.w &&
+            x.x + x.w > y.x &&
+            x.y < y.y + y.h &&
+            x.y + x.h > y.y,
+        ),
+    );
+    expect(overlapping).toBe(false);
+  });
+
   it('supports nested boards inside a widget', () => {
     render(
       <Board.Provider>

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -15,7 +15,7 @@ import {
   bottom,
   calcXYRaw,
   cloneLayout,
-  getAllCollisions,
+  collides,
   getLayoutItem,
   LayoutItem,
   moveElement,
@@ -38,6 +38,16 @@ import {
  */
 function rectCenter(rect: ViewportRect): { x: number; y: number } {
   return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+/** Whether any two items in the layout overlap. */
+function hasCollision(layout: LayoutItem[]): boolean {
+  for (let i = 0; i < layout.length; i++) {
+    for (let j = i + 1; j < layout.length; j++) {
+      if (collides(layout[i], layout[j])) return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -452,11 +462,14 @@ export function useBoardRegistry(
             ? Math.sign(landed.x - live.x) === directionX && landed.y === live.y
             : Math.sign(landed.y - live.y) === directionY &&
               landed.x === live.x;
-        const overlaps =
-          !compactor.allowOverlap &&
-          getAllCollisions(compacted, landed).some(
-            (other) => other.i !== landed.i,
-          );
+        // Reject any candidate whose resulting layout contains an overlapping
+        // pair. Checking only the moved widget is not enough: in the legacy
+        // (`compact={null}`) and `preventCollision` modes the compactor does not
+        // resolve overlaps, so a *pushed neighbour* can land on top of another
+        // widget even when the moved widget itself is clear. The stricter
+        // whole-layout check keeps arrow moves from ever creating a stack (the
+        // pointer path is unaffected). `allowOverlap` opts out entirely.
+        const overlaps = !compactor.allowOverlap && hasCollision(compacted);
         if (!advanced || overlaps) continue;
 
         entry.applyLayout(compacted, false);

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -51,6 +51,33 @@ function hasCollision(layout: LayoutItem[]): boolean {
 }
 
 /**
+ * First position at or below the preferred cell where `item` fits without
+ * overlapping any of `others` (assumed overlap-free), scanning left-to-right
+ * then top-to-bottom. Last-resort placement for a legacy (no-op compaction)
+ * cross-board drop that would otherwise stack widgets - there is always a free
+ * slot below every existing item, so the scan terminates.
+ */
+function placeInFreeSlot(
+  others: LayoutItem[],
+  item: LayoutItem,
+  cols: number,
+): LayoutItem {
+  const w = Math.min(item.w, cols);
+  const fits = (x: number, y: number) =>
+    !others.some((o) => collides(o, { ...item, x, y, w }));
+  const preferX = Math.min(Math.max(0, item.x), cols - w);
+  const startY = Math.max(0, item.y);
+  if (fits(preferX, startY)) return { ...item, x: preferX, y: startY, w };
+  const limit = others.reduce((m, o) => Math.max(m, o.y + o.h), 0) + 1;
+  for (let y = startY; y <= startY + limit; y++) {
+    for (let x = 0; x <= cols - w; x++) {
+      if (fits(x, y)) return { ...item, x, y, w };
+    }
+  }
+  return { ...item, x: preferX, y: startY, w };
+}
+
+/**
  * Cross-board drag orchestration.
  *
  * Owns the shared widget-content store, the drag overlay ref, and the registry
@@ -350,7 +377,14 @@ export function useBoardRegistry(
       const compactor = entry.getCompactor();
       const layout = entry.getLayout();
       const live = getLayoutItem(layout, item.i);
-      const working = live ? [...layout] : [...layout, { ...item, x, y }];
+      // Deep-clone so `moveElement` (which mutates item objects in place) never
+      // touches the live layout's items. A shallow copy shares those objects, so
+      // rejecting a frame below would still leave the live layout mutated into
+      // the overlapping arrangement (committed on drop). `moveWithKeyboard`
+      // clones for the same reason.
+      const working = live
+        ? cloneLayout(layout)
+        : [...cloneLayout(layout), { ...item, x, y }];
       const target = getLayoutItem(working, item.i);
       if (!target) return;
 
@@ -366,6 +400,14 @@ export function useBoardRegistry(
         compactor.allowOverlap,
       );
       const compacted = [...compactor.compact(moved, pp.cols)];
+      // Never commit a frame that stacks widgets. In the legacy
+      // (`compact={null}`) mode `moveElement` pushes colliding neighbours but the
+      // no-op compactor leaves any residual overlap in place, so a push can drop
+      // a neighbour on top of another widget. Skipping such frames keeps the
+      // dragged widget at its last valid arrangement until the pointer reaches a
+      // slot where the move (and any push) resolves cleanly - matching the
+      // keyboard path. `allowOverlap` opts out entirely.
+      if (!compactor.allowOverlap && hasCollision(compacted)) return;
       entry.applyLayout(compacted, false);
       entry.setPlaceholder(getLayoutItem(compacted, item.i) ?? null);
     },
@@ -467,8 +509,10 @@ export function useBoardRegistry(
         // (`compact={null}`) and `preventCollision` modes the compactor does not
         // resolve overlaps, so a *pushed neighbour* can land on top of another
         // widget even when the moved widget itself is clear. The stricter
-        // whole-layout check keeps arrow moves from ever creating a stack (the
-        // pointer path is unaffected). `allowOverlap` opts out entirely.
+        // whole-layout check keeps arrow moves from ever creating a stack. The
+        // pointer path enforces the same invariant (see `moveWithinBoard`), so
+        // both inputs push/swap when clean and block otherwise. `allowOverlap`
+        // opts out entirely.
         const overlaps = !compactor.allowOverlap && hasCollision(compacted);
         if (!advanced || overlaps) continue;
 
@@ -504,11 +548,13 @@ export function useBoardRegistry(
         previewRef.current?.boardId === target.id
           ? previewRef.current.working
           : null;
-      const base = (
+      // Deep-clone the base: `moveElement` mutates item objects in place, and a
+      // rejected frame (see the overlap guard below) must not leave the carried
+      // preview or the target's live layout mutated into an overlapping state.
+      const base = cloneLayout(
         carried ??
-        cloneLayout(
-          targetSnapshotsRef.current.get(target.id) ?? target.getLayout(),
-        )
+          targetSnapshotsRef.current.get(target.id) ??
+          target.getLayout(),
       ).filter((l) => l.i !== item.i);
 
       // Reuse the item's carried position as the move origin (continuity). On
@@ -535,6 +581,10 @@ export function useBoardRegistry(
         compactor.allowOverlap,
       );
       const compacted = [...compactor.compact(moved, pp.cols)];
+      // Skip a frame that would stack widgets on the target (see the same guard
+      // in `moveWithinBoard`): keep the last valid preview instead of committing
+      // an overlap that the no-op compactor cannot resolve. `allowOverlap` off.
+      if (!compactor.allowOverlap && hasCollision(compacted)) return;
       previewRef.current = { boardId: target.id, working: compacted };
 
       const landed = getLayoutItem(compacted, item.i) ?? { ...item, x, y };
@@ -735,6 +785,26 @@ export function useBoardRegistry(
           tc.allowOverlap,
         );
         finalLayout = [...tc.compact(moved, tp.cols)];
+      }
+      // Never commit a stacked drop. When the compactor cannot resolve overlaps
+      // (`compact={null}` / `preventCollision`) a teleport drop into an occupied
+      // region would otherwise land the item on top of another widget; place it
+      // in the first free slot instead so the pointer path matches the keyboard
+      // path (never overlaps unless `allowOverlap`).
+      if (!tc.allowOverlap && hasCollision(finalLayout)) {
+        const others = cloneLayout(
+          (
+            targetSnapshotsRef.current.get(target!.id) ?? target!.getLayout()
+          ).filter((l) => l.i !== ds.itemId),
+        );
+        finalLayout = [
+          ...others,
+          placeInFreeSlot(
+            others,
+            { ...ds.item, x: landing.x, y: landing.y },
+            tp.cols,
+          ),
+        ];
       }
       target!.applyLayout(finalLayout, true);
 

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -40,12 +40,37 @@ function rectCenter(rect: ViewportRect): { x: number; y: number } {
   return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
 }
 
-/** Whether any two items in the layout overlap. */
-function hasCollision(layout: LayoutItem[]): boolean {
+/**
+ * Keys (`"<i1>|<i2>"`, ids sorted) of every overlapping pair in the layout, so
+ * two layouts' overlap sets can be compared to tell which overlaps a move
+ * *introduced* versus which already existed.
+ */
+function overlappingPairs(layout: LayoutItem[]): Set<string> {
+  const pairs = new Set<string>();
   for (let i = 0; i < layout.length; i++) {
     for (let j = i + 1; j < layout.length; j++) {
-      if (collides(layout[i], layout[j])) return true;
+      const a = layout[i];
+      const b = layout[j];
+      if (collides(a, b)) {
+        pairs.add(a.i < b.i ? `${a.i}|${b.i}` : `${b.i}|${a.i}`);
+      }
     }
+  }
+  return pairs;
+}
+
+/**
+ * Whether `after` contains an overlapping pair that `before` did not. Used to
+ * reject only moves that *create* a new stack. A board may already hold
+ * overlapping widgets - a `compact={null}` layout is never gap-compacted, and an
+ * app can supply overlapping items directly (or toggle `allowOverlap` off after
+ * stacking) - and those pre-existing overlaps must not freeze every subsequent
+ * move by making a whole-layout collision check always true.
+ */
+function hasNewOverlap(before: Set<string>, after: LayoutItem[]): boolean {
+  const afterPairs = overlappingPairs(after);
+  for (const key of afterPairs) {
+    if (!before.has(key)) return true;
   }
   return false;
 }
@@ -400,14 +425,21 @@ export function useBoardRegistry(
         compactor.allowOverlap,
       );
       const compacted = [...compactor.compact(moved, pp.cols)];
-      // Never commit a frame that stacks widgets. In the legacy
+      // Never commit a frame that *creates* a stack. In the legacy
       // (`compact={null}`) mode `moveElement` pushes colliding neighbours but the
       // no-op compactor leaves any residual overlap in place, so a push can drop
       // a neighbour on top of another widget. Skipping such frames keeps the
       // dragged widget at its last valid arrangement until the pointer reaches a
       // slot where the move (and any push) resolves cleanly - matching the
-      // keyboard path. `allowOverlap` opts out entirely.
-      if (!compactor.allowOverlap && hasCollision(compacted)) return;
+      // keyboard path. Only *newly introduced* overlaps block: pre-existing ones
+      // (an app-supplied stacked layout) must not freeze the drag. `allowOverlap`
+      // opts out entirely.
+      if (
+        !compactor.allowOverlap &&
+        hasNewOverlap(overlappingPairs(layout), compacted)
+      ) {
+        return;
+      }
       entry.applyLayout(compacted, false);
       entry.setPlaceholder(getLayoutItem(compacted, item.i) ?? null);
     },
@@ -444,6 +476,11 @@ export function useBoardRegistry(
                 ? Math.max(0, maxRows - live.h - live.y)
                 : Math.max(1, bottom(layout) - live.y);
       const seen = new Set<string>();
+      // Overlaps already present before the move: a candidate is only rejected
+      // for a *new* pair, never for one the board already had (see
+      // `hasNewOverlap`). Computed once - the baseline is constant across the
+      // directional scan.
+      const beforePairs = overlappingPairs(layout);
 
       for (let distance = 1; distance <= attempts; distance++) {
         const rawX = live.x + directionX * distance;
@@ -504,16 +541,18 @@ export function useBoardRegistry(
             ? Math.sign(landed.x - live.x) === directionX && landed.y === live.y
             : Math.sign(landed.y - live.y) === directionY &&
               landed.x === live.x;
-        // Reject any candidate whose resulting layout contains an overlapping
-        // pair. Checking only the moved widget is not enough: in the legacy
-        // (`compact={null}`) and `preventCollision` modes the compactor does not
-        // resolve overlaps, so a *pushed neighbour* can land on top of another
-        // widget even when the moved widget itself is clear. The stricter
-        // whole-layout check keeps arrow moves from ever creating a stack. The
-        // pointer path enforces the same invariant (see `moveWithinBoard`), so
-        // both inputs push/swap when clean and block otherwise. `allowOverlap`
+        // Reject a candidate that *introduces* an overlapping pair. Checking
+        // only the moved widget is not enough: in the legacy (`compact={null}`)
+        // and `preventCollision` modes the compactor does not resolve overlaps,
+        // so a *pushed neighbour* can land on top of another widget even when the
+        // moved widget itself is clear. Comparing the whole layout's overlap set
+        // against the pre-move baseline keeps arrow moves from creating a stack
+        // while still allowing movement around overlaps the board already had.
+        // The pointer path enforces the same invariant (see `moveWithinBoard`),
+        // so both inputs push/swap when clean and block otherwise. `allowOverlap`
         // opts out entirely.
-        const overlaps = !compactor.allowOverlap && hasCollision(compacted);
+        const overlaps =
+          !compactor.allowOverlap && hasNewOverlap(beforePairs, compacted);
         if (!advanced || overlaps) continue;
 
         entry.applyLayout(compacted, false);
@@ -581,10 +620,17 @@ export function useBoardRegistry(
         compactor.allowOverlap,
       );
       const compacted = [...compactor.compact(moved, pp.cols)];
-      // Skip a frame that would stack widgets on the target (see the same guard
-      // in `moveWithinBoard`): keep the last valid preview instead of committing
-      // an overlap that the no-op compactor cannot resolve. `allowOverlap` off.
-      if (!compactor.allowOverlap && hasCollision(compacted)) return;
+      // Skip a frame that would *newly* stack widgets on the target (see the same
+      // guard in `moveWithinBoard`): keep the last valid preview instead of
+      // committing an overlap the no-op compactor cannot resolve. The baseline is
+      // the target's own widgets (`base`), so overlaps the target already had do
+      // not block the incoming widget. `allowOverlap` opts out.
+      if (
+        !compactor.allowOverlap &&
+        hasNewOverlap(overlappingPairs(base), compacted)
+      ) {
+        return;
+      }
       previewRef.current = { boardId: target.id, working: compacted };
 
       const landed = getLayoutItem(compacted, item.i) ?? { ...item, x, y };
@@ -786,21 +832,25 @@ export function useBoardRegistry(
         );
         finalLayout = [...tc.compact(moved, tp.cols)];
       }
-      // Never commit a stacked drop. When the compactor cannot resolve overlaps
-      // (`compact={null}` / `preventCollision`) a teleport drop into an occupied
-      // region would otherwise land the item on top of another widget; place it
-      // in the first free slot instead so the pointer path matches the keyboard
-      // path (never overlaps unless `allowOverlap`).
-      if (!tc.allowOverlap && hasCollision(finalLayout)) {
-        const others = cloneLayout(
-          (
-            targetSnapshotsRef.current.get(target!.id) ?? target!.getLayout()
-          ).filter((l) => l.i !== ds.itemId),
-        );
+      // Never commit a drop that *creates* a stack. When the compactor cannot
+      // resolve overlaps (`compact={null}` / `preventCollision`) a teleport drop
+      // into an occupied region would otherwise land the item on top of another
+      // widget; place it in the first free slot instead so the pointer path
+      // matches the keyboard path. Overlaps the target already had do not trigger
+      // the reshuffle (they are preserved as-is). `allowOverlap` opts out.
+      const targetOthers = cloneLayout(
+        (
+          targetSnapshotsRef.current.get(target!.id) ?? target!.getLayout()
+        ).filter((l) => l.i !== ds.itemId),
+      );
+      if (
+        !tc.allowOverlap &&
+        hasNewOverlap(overlappingPairs(targetOthers), finalLayout)
+      ) {
         finalLayout = [
-          ...others,
+          ...targetOthers,
           placeInFreeSlot(
-            others,
+            targetOthers,
             { ...ds.item, x: landing.x, y: landing.y },
             tp.cols,
           ),

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -78,23 +78,44 @@ function hasNewOverlap(before: Set<string>, after: LayoutItem[]): boolean {
 /**
  * First position at or below the preferred cell where `item` fits without
  * overlapping any of `others` (assumed overlap-free), scanning left-to-right
- * then top-to-bottom. Last-resort placement for a legacy (no-op compaction)
- * cross-board drop that would otherwise stack widgets - there is always a free
- * slot below every existing item, so the scan terminates.
+ * then top-to-bottom, never past `maxRows`. Last-resort placement for a legacy
+ * (no-op compaction) cross-board drop that would otherwise stack widgets.
+ *
+ * A finite `maxRows` mirrors the `gridBounds` constraint the normal landing path
+ * applies (`clamp(y, 0, maxRows - h)`): the widget's bottom edge (`y + h`) stays
+ * within the row limit even when the landing cell is blocked, so the downward
+ * scan can't push it off the board. Rows are searched from the (clamped) landing
+ * row down to the limit first, then upward toward the top; if the whole valid
+ * band is full the widget is clamped to the limit (bounds win over overlap, as
+ * `gridBounds` does). With an unbounded `maxRows` there is always a free slot
+ * below every existing item, so the downward scan terminates on its own.
  */
 function placeInFreeSlot(
   others: LayoutItem[],
   item: LayoutItem,
   cols: number,
+  maxRows = Infinity,
 ): LayoutItem {
   const w = Math.min(item.w, cols);
+  const maxY = Number.isFinite(maxRows)
+    ? Math.max(0, maxRows - item.h)
+    : Infinity;
   const fits = (x: number, y: number) =>
     !others.some((o) => collides(o, { ...item, x, y, w }));
   const preferX = Math.min(Math.max(0, item.x), cols - w);
-  const startY = Math.max(0, item.y);
+  const startY = Math.min(Math.max(0, item.y), maxY);
   if (fits(preferX, startY)) return { ...item, x: preferX, y: startY, w };
-  const limit = others.reduce((m, o) => Math.max(m, o.y + o.h), 0) + 1;
-  for (let y = startY; y <= startY + limit; y++) {
+  const scanBottom = Number.isFinite(maxRows)
+    ? maxY
+    : startY + others.reduce((m, o) => Math.max(m, o.y + o.h), 0) + 1;
+  for (let y = startY; y <= scanBottom; y++) {
+    for (let x = 0; x <= cols - w; x++) {
+      if (fits(x, y)) return { ...item, x, y, w };
+    }
+  }
+  // The landing row (clamped to the limit) and everything below it were full;
+  // look upward for a free slot still inside the board before giving up.
+  for (let y = startY - 1; y >= 0; y--) {
     for (let x = 0; x <= cols - w; x++) {
       if (fits(x, y)) return { ...item, x, y, w };
     }
@@ -853,6 +874,7 @@ export function useBoardRegistry(
             targetOthers,
             { ...ds.item, x: landing.x, y: landing.y },
             tp.cols,
+            tp.maxRows,
           ),
         ];
       }

--- a/src/components/layout/Board/use-board-registry.ts
+++ b/src/components/layout/Board/use-board-registry.ts
@@ -41,9 +41,20 @@ function rectCenter(rect: ViewportRect): { x: number; y: number } {
 }
 
 /**
- * Keys (`"<i1>|<i2>"`, ids sorted) of every overlapping pair in the layout, so
- * two layouts' overlap sets can be compared to tell which overlaps a move
- * *introduced* versus which already existed.
+ * Canonical key for the unordered pair `{id1, id2}`. Widget ids are unrestricted
+ * strings, so a naive `` `${id1}|${id2}` `` join is ambiguous - an id containing
+ * the delimiter lets two different pairs collide (e.g. `{"a|b","c"}` and
+ * `{"a","b|c"}` both yield `"a|b|c"`). `JSON.stringify` of the sorted tuple
+ * quotes and escapes each id, so distinct pairs always produce distinct keys.
+ */
+function pairKey(id1: string, id2: string): string {
+  return id1 < id2 ? JSON.stringify([id1, id2]) : JSON.stringify([id2, id1]);
+}
+
+/**
+ * Keys of every overlapping pair in the layout (see `pairKey`), so two layouts'
+ * overlap sets can be compared to tell which overlaps a move *introduced* versus
+ * which already existed.
  */
 function overlappingPairs(layout: LayoutItem[]): Set<string> {
   const pairs = new Set<string>();
@@ -52,7 +63,7 @@ function overlappingPairs(layout: LayoutItem[]): Set<string> {
       const a = layout[i];
       const b = layout[j];
       if (collides(a, b)) {
-        pairs.add(a.i < b.i ? `${a.i}|${b.i}` : `${b.i}|${a.i}`);
+        pairs.add(pairKey(a.i, b.i));
       }
     }
   }


### PR DESCRIPTION
…compacting mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core drag/keyboard/cross-board layout paths in `use-board-registry`; behavior changes for legacy compaction modes but is gated by overlap detection and covered by new regression tests.
> 
> **Overview**
> Fixes a regression in **`Board`** when **`compact={null}`** or **`preventCollision`** is used: pushing a neighbour during a move could stack that widget on top of another.
> 
> Moves now compare **overlap pairs before vs after** (`hasNewOverlap`) so only **newly introduced** stacks are blocked—layouts that already overlap (e.g. app-supplied) still allow unrelated widgets to move. **`allowOverlap`** skips the guard.
> 
> **Keyboard** scans for the next valid slot; **pointer** drags skip frames that would create overlap and keep the last valid layout. **Cross-board drops** that would stack fall back to **`placeInFreeSlot`**. Working layouts are **deep-cloned** before `moveElement` so rejected frames do not mutate the live grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a74eda0847f720c58eba4087f9c01e8d40bf41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->