### PR TITLE
fix(Board): prevent keyboard moves when focus is inside nested controls

### DIFF
--- a/.changeset/board-keyboard-focus-gate.md
+++ b/.changeset/board-keyboard-focus-gate.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+`Board`: stop arrow keys from moving a widget when focus is inside nested controls (e.g. `input` / `textarea`). Keyboard moves only run when the widget host itself is focused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,16 @@ Project-specific working rules for AI agents. Not published with the package.
 - [tests.md](docs/rules/tests.md) — Vitest + React Testing Library patterns
 - [commit-changes.md](docs/rules/commit-changes.md) — commit message convention
 
+## Changesets
+
+When making code changes that affect end users or the public API, **always add a new changeset or update an existing one** in [`.changeset/`](.changeset/) as part of the same task. Do not wait to be asked.
+
+- Prefer updating an existing open changeset that already covers the same work/PR; otherwise add a new `.md` file.
+- Use `patch` for bug fixes and small changes; `minor` for new features and noticeable breaking changes.
+- Keep the summary concise and user-focused (`"@cube-dev/ui-kit": patch|minor` frontmatter).
+- Skip changesets for docs-only, test-only, Storybook-only, or internal tooling that does not affect package consumers. Also skip fixes for issues introduced and resolved within the same PR.
+- Add changeset manually (no CLI) — full guidelines: [`.cursor/commands/add-changeset.md`](.cursor/commands/add-changeset.md).
+
 ## Project Structure
 
 ```

--- a/src/components/layout/Board/Board.docs.mdx
+++ b/src/components/layout/Board/Board.docs.mdx
@@ -62,7 +62,7 @@ clipped by an ancestor's `overflow: hidden`.
 - **`isResizable`** `boolean` (default: `true`) — Enable resizing for all widgets.
 - **`isDroppable`** `boolean` (default: `true`) — Whether the board accepts widgets dropped from other boards.
 - **`resizeHandles`** `ResizeHandleAxis[]` (default: `['se']`) — Which resize handles to show. Corner handles (`ne`/`nw`/`se`/`sw`) show an angle grip; edge handles (`n`/`s`/`e`/`w`) show a dotted grip. Both are revealed on hover/focus/resize. A single edge (e.g. `['e']` or `['s']`) gives a horizontally- or vertically-only resizable widget.
-- **`dragCancel`** `string` — CSS selector for elements that must not start a pointer drag (e.g. form controls inside a widget: `"input,textarea,button,a,.no-drag"`). Keyboard moves are unaffected. Can be overridden per widget.
+- **`dragCancel`** `string` — CSS selector for elements that must not start a pointer drag (e.g. form controls inside a widget: `"input,textarea,button,a,.no-drag"`). Does not affect keyboard moves — those only run when the widget host itself is focused. Can be overridden per widget.
 - **`dragHandle`** `string` — CSS selector for the only elements from which a pointer drag may start. Can be overridden per widget.
 - **`showGridLines`** `boolean | 'drag'` (default: `false`) — Show grid lines behind the widgets. `true` always, `'drag'` only while a widget is being dragged or resized. A nested board that does not set this inherits an enabled ancestor's grid lines, showing its own while a drag is in progress.
 - **`isAligned`** `boolean` (default: `false`) — Align a nested board with its ancestor `Board`'s layout. Only takes effect when the board is nested inside another `Board`'s widget. When set, every cell matches the parent's cell size exactly: the board inherits the parent's column pitch (deriving its own column count from its measured width so cells stay parent-sized as the container is resized) and uses the parent's row height verbatim. It never shrinks rows to fit — pair it with an `isAutoHeight` container so the widget grows to fit its rows at that height. `cols`/`rowHeight` then act as fallbacks used only until the parent metrics resolve.
@@ -260,7 +260,9 @@ touch drags capture the pointer, so they do not trigger it.
 ## Accessibility
 
 - Widgets are focusable when draggable. Press <kbd>Tab</kbd> to focus a widget,
-  then use the arrow keys to move it one cell at a time.
+  then use the arrow keys to move it one cell at a time. Arrow keys only move
+  the widget when the widget host itself is focused — not when focus is inside
+  a nested control (e.g. an <kbd>input</kbd> or <kbd>textarea</kbd>).
 - Dragging, resizing, and keyboard movement are all handled by React Aria's
   `useMove`, which normalizes mouse, touch, and keyboard interactions.
 

--- a/src/components/layout/Board/Board.stories.tsx
+++ b/src/components/layout/Board/Board.stories.tsx
@@ -327,7 +327,7 @@ DragCancel.parameters = {
   docs: {
     description: {
       story:
-        'A pointer press on an element matching `dragCancel` (inputs, buttons, links, `.no-drag`) never starts a drag, so form controls inside a widget stay interactive. Keyboard moves are unaffected.',
+        'A pointer press on an element matching `dragCancel` (inputs, buttons, links, `.no-drag`) never starts a drag, so form controls inside a widget stay interactive. Keyboard moves only run when the widget host itself is focused, not when focus is inside a nested control.',
     },
   },
 };

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -1234,6 +1234,42 @@ describe('Board', () => {
       expect(info.item.x).toBe(1);
     });
 
+    it('does not move a widget with arrow keys when focus is inside a nested input', () => {
+      // Regression: useMove's onKeyDown sits on the host, so arrow keys from a
+      // focused <input>/<textarea> bubble there. They must not start a keyboard
+      // drag — only when the widget host itself is focused.
+      const onDragStart = vi.fn();
+      const onLayoutChange = vi.fn();
+
+      render(
+        <Board
+          width={1200}
+          cols={12}
+          onDragStart={onDragStart}
+          onLayoutChange={onLayoutChange}
+          defaultLayout={[{ i: 'a', x: 0, y: 0, w: 2, h: 2 }]}
+        >
+          <Board.Widget id="a" qa="WidgetA">
+            <input data-qa="Inp" defaultValue="hello" />
+          </Board.Widget>
+        </Board>,
+      );
+
+      const input = screen.getByTestId('Inp');
+      input.focus();
+      fireEvent.keyDown(input, { key: 'ArrowRight' });
+
+      expect(onDragStart).not.toHaveBeenCalled();
+      expect(onLayoutChange).not.toHaveBeenCalled();
+
+      // Focus on the host itself still moves the widget.
+      const widget = screen.getByTestId('WidgetA');
+      widget.focus();
+      fireEvent.keyDown(widget, { key: 'ArrowRight' });
+      expect(onDragStart).toHaveBeenCalled();
+      expect(onLayoutChange).toHaveBeenCalled();
+    });
+
     it('fires resize lifecycle callbacks during a pointer resize', () => {
       const onResizeStart = vi.fn();
       const onResize = vi.fn();

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -204,8 +204,9 @@ export interface CubeBoardProps
   resizeHandles?: ResizeHandleAxis[];
   /**
    * CSS selector for elements that must not start a pointer drag (e.g. form
-   * controls inside a widget: `"input,textarea,button,a,.no-drag"`). Keyboard
-   * moves are unaffected. Can be overridden per widget on `Board.Widget`.
+   * controls inside a widget: `"input,textarea,button,a,.no-drag"`). Does not
+   * affect keyboard moves — those only run when the widget host itself is
+   * focused. Can be overridden per widget on `Board.Widget`.
    */
   dragCancel?: string;
   /**

--- a/src/components/layout/Board/WidgetHost.tsx
+++ b/src/components/layout/Board/WidgetHost.tsx
@@ -561,8 +561,12 @@ export function WidgetHost(props: WidgetHostProps) {
   // `preventDefault()` on pointer-down cancels a native `<input>`'s focus, and a
   // capture-phase `stopPropagation()` swallows a `<button>`'s own press events.
   // Skipping `useMove` entirely leaves the target's default behavior and its own
-  // handlers fully intact. Keyboard moves go through `onKeyDown` and are never
-  // gated.
+  // handlers fully intact.
+  //
+  // Keyboard moves also go through `useMove` (`onKeyDown`). Arrow keys must only
+  // move the widget when the host itself is focused — not when focus is inside a
+  // nested input, textarea, or other descendant (those events bubble to the host
+  // and would otherwise steal caret / list navigation).
   //
   // A non-draggable widget must not carry `moveProps` at all: `useMove`'s
   // pointer-down handler calls `preventDefault()`, which cancels native text
@@ -591,6 +595,12 @@ export function WidgetHost(props: WidgetHostProps) {
           onTouchStart: (e: React.TouchEvent<HTMLDivElement>) => {
             if (shouldGateDrag(e.target)) return;
             moveProps.onTouchStart!(e);
+          },
+        }),
+        ...(moveProps.onKeyDown && {
+          onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (e.target !== e.currentTarget) return;
+            moveProps.onKeyDown!(e);
           },
         }),
       };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized interaction fix in `WidgetHost` with a regression test; no API or layout-engine changes.
> 
> **Overview**
> Fixes a regression where **arrow keys inside nested controls** (e.g. `input` / `textarea`) bubbled to the widget host and triggered React Aria `useMove` keyboard drags, breaking caret and field navigation.
> 
> **`WidgetHost`** now gates `onKeyDown` so keyboard moves run only when **`e.target === e.currentTarget`** (the widget host is focused). Pointer `dragCancel` behavior is unchanged.
> 
> Docs and Storybook copy clarify that **`dragCancel` does not affect keyboard moves**—those follow the focus rule above. A Vitest regression covers arrow keys from a focused input vs. from the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc49a6dce3ef66734917c76edf6c43088d08c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->