### PR TITLE
docs: update component documentation

### DIFF
--- a/.changeset/clarify-component-usage.md
+++ b/.changeset/clarify-component-usage.md
@@ -1,0 +1,5 @@
+---
+"@cube-dev/ui-kit": patch
+---
+
+Clarify when to use selection, search, command, and menu components.

--- a/src/components/actions/CommandMenu/CommandMenu.docs.mdx
+++ b/src/components/actions/CommandMenu/CommandMenu.docs.mdx
@@ -6,15 +6,21 @@ import * as CommandMenuStories from './CommandMenu.stories';
 
 # CommandMenu
 
-A searchable menu interface that combines the functionality of Menu and ListBox components. It provides a command-line-like experience for users to quickly find and execute actions through a searchable interface.
+A searchable, keyboard-first surface for finding and executing application actions. CommandMenu renders the searchable menu content; wrap it in `CommandMenu.Trigger` for a button-anchored popover or place it in a `Dialog` for a global command palette.
 
 ## When to use
 
-- **Quick action access**: Enable users to quickly find and execute commands or actions
-- **Large command sets**: When you have many available actions that benefit from search filtering
-- **Keyboard-first workflows**: For power users who prefer keyboard navigation
-- **Command-line interfaces**: When building developer tools or admin interfaces
-- **Global search**: As a global command palette accessible via keyboard shortcuts
+- Users need to search a large or changing set of application commands
+- The primary result of choosing an item is executing an action
+- Keyboard-first discovery, aliases (`keywords`), and shortcut hints are important
+- A trigger-based command popover or modal global command palette is needed
+
+Choose a different component when the interaction has another outcome:
+
+- Use [Menu](/docs/actions-menu--docs) with `MenuTrigger` for a short contextual action list that does not need a search field.
+- Use [SearchComboBox](/docs/forms-searchcombobox--docs) for a focused single-line search-and-act input that may submit raw text and clears after each result.
+- Use [FilterPicker](/docs/forms-filterpicker--docs) when users are searching to keep one or more selected field values.
+- Use [CommandTextArea](/docs/forms-commandtextarea--docs) when a command or mention should be inserted into multiline text rather than executed immediately.
 
 ## Examples
 
@@ -431,10 +437,12 @@ The CommandMenu supports enhanced search capabilities:
 
 ## Related Components
 
-- [Menu](/docs/actions-menu--docs) - For static menu options without search
-- [ListBox](/docs/forms-listbox--docs) - For searchable selection lists
-- [Dialog](/docs/overlays-dialog--docs) - For modal command palette usage
-- [MenuTrigger](/docs/actions-menu--docs) - For trigger-based command palette usage
+- [Menu](/docs/actions-menu--docs) - Use with MenuTrigger for short contextual action lists without visible search
+- [SearchComboBox](/docs/forms-searchcombobox--docs) - Use for focused search-and-act inputs that clear after each result
+- [FilterPicker](/docs/forms-filterpicker--docs) - Use when searched items become persistent field values
+- [CommandTextArea](/docs/forms-commandtextarea--docs) - Use when suggestions insert text at the caret
+- [Dialog](/docs/overlays-dialog--docs) - Use as the container for a modal global command palette
+- [MenuTrigger](/docs/actions-menu--docs) - Use through CommandMenu.Trigger for a button-anchored command popover
 
 ## Technical Notes
 

--- a/src/components/actions/Menu/Menu.docs.mdx
+++ b/src/components/actions/Menu/Menu.docs.mdx
@@ -6,15 +6,22 @@ import * as MenuStories from './Menu.stories';
 
 # Menu
 
-A versatile dropdown menu component that displays a list of actions or options. Built with React Aria for accessibility and supports single/multiple selection, sections, keyboard navigation, and custom styling.
+An action-oriented menu for short, scannable sets of commands, navigation destinations, or toggles. `Menu` renders the menu content; combine it with `MenuTrigger` to open a dropdown from a button or use the trigger variants for context menus. It supports keyboard typeahead, but does not show a search field.
 
 ## When to Use
 
-- Display a list of actions that can be performed (like Cut, Copy, Paste)
-- Create context menus for right-click interactions
-- Build dropdown menus for navigation or settings
-- Implement selection lists with single or multiple selection modes
-- Group related options using sections with dividers
+- A button or context-menu gesture should reveal a short list of related actions
+- Items execute commands or navigate rather than populate a form field
+- Mutually exclusive menu options or independent toggles need menu-item selection states
+- Related actions need sections, submenus, icons, or keyboard shortcut hints
+
+Choose a different component when the interaction has another shape:
+
+- Use [CommandMenu](/docs/actions-commandmenu--docs) when users need a visible search field to discover or filter commands.
+- Use [Select](/docs/forms-select--docs) for a conventional single-value form field.
+- Use [Picker](/docs/forms-picker--docs) for persistent single or multiple field values without search.
+- Use [FilterPicker](/docs/forms-filterpicker--docs) for persistent single or multiple field values with search.
+- Use [SearchComboBox](/docs/forms-searchcombobox--docs) for a focused search-and-act input that clears after each result.
 
 ## Component
 
@@ -474,16 +481,21 @@ The Menu component is typically used with MenuTrigger for dropdown functionality
 </MenuTrigger>
 ```
 
+`Menu` is the content and selection model; `MenuTrigger` supplies the button-triggered popover behavior. Use `CommandMenu.Trigger` instead when the opened content needs a visible command-search input.
+
 ## Suggested Improvements
 
 - Enhancement 1: Implement virtual scrolling for large item lists
 - Enhancement 2: Add animation presets for menu transitions
 - Enhancement 3: Support for item templates and custom renderers
-- Enhancement 4: Built-in search/filter functionality
+- Enhancement 4: For built-in search/filter functionality, use CommandMenu
 - Enhancement 5: Add support for icons in section headers
 
 ## Related Components
 
-- [Button](/docs/actions-button--docs) - Common trigger element for menus
-- [ListBox](/docs/forms-listbox--docs) - Alternative for selection-focused interfaces
-- [ComboBox](/docs/forms-combobox--docs) - Combines input with menu selection 
+- [CommandMenu](/docs/actions-commandmenu--docs) - Use for searchable, keyboard-first command discovery
+- [Button](/docs/actions-button--docs) - Common trigger element for MenuTrigger
+- [Select](/docs/forms-select--docs) - Use for a conventional persistent single-value field
+- [Picker](/docs/forms-picker--docs) - Use for persistent single or multiple selection without search
+- [FilterPicker](/docs/forms-filterpicker--docs) - Use for persistent single or multiple selection with search
+- [ListBox](/docs/forms-listbox--docs) - Use for an always-visible selection-focused interface

--- a/src/components/fields/CommandTextArea/CommandTextArea.docs.mdx
+++ b/src/components/fields/CommandTextArea/CommandTextArea.docs.mdx
@@ -6,18 +6,23 @@ import * as CommandTextAreaStories from './CommandTextArea.stories';
 
 # CommandTextArea
 
-A multiline text input (built on `TextArea` / `TextInputBase`) that shows a
-command-autocomplete popover when the text matches a configurable trigger. The
-focus always stays in the textarea; arrow keys, Enter/Tab, and Escape drive the
-list only while it is open. Selecting an option inserts the option's literal
-value (e.g. `/clear`) into the text and fires `onCommand`.
+A multiline free-form field with inline token autocomplete. Typing a configured
+trigger such as `/` or `@` opens suggestions at the caret; choosing one inserts
+its literal value into the text and fires `onCommand`. The field value remains
+the complete textarea string rather than a selected option key.
 
 ## When to Use
 
-- Chat or prompt inputs where users type slash commands (`/clear`, `/help`).
-- Inputs that need token-based autocomplete (`@mentions`, snippets) without
-  giving up free-form, multiline editing.
-- Any textarea that should "feel like a textarea" but offer inline suggestions.
+- Chat or prompt inputs where slash commands (`/clear`, `/help`) are inserted into the message
+- Multiline editors that need inline `@mentions`, snippets, variables, or other triggered tokens
+- Cases where focus and the text caret must remain in a normal textarea while suggestions are open
+
+Choose a different component when the interaction has another outcome:
+
+- Use [SearchComboBox](/docs/forms-searchcombobox--docs) for a separate single-line search-and-act input that clears after a result is chosen.
+- Use [ComboBox](/docs/forms-combobox--docs) when the field should keep one selected option rather than a free-form text document.
+- Use [CommandMenu](/docs/actions-commandmenu--docs) when users should search for and immediately execute application commands instead of inserting text.
+- Use [TextArea](/docs/forms-textarea--docs) when no inline suggestions are needed.
 
 ## Component
 
@@ -157,5 +162,7 @@ This component supports all [Field properties](/docs/getting-started-field-prope
 ## Related Components
 
 - [TextArea](/docs/forms-textarea--docs) — The base multiline field this builds on.
-- [ComboBox](/docs/forms-combobox--docs) — Single-value select with search (different semantics: commits a `selectedKey`).
+- [SearchComboBox](/docs/forms-searchcombobox--docs) — Single-line search-and-act input that clears after each result.
+- [ComboBox](/docs/forms-combobox--docs) — Searchable field that commits one selected key instead of inserting text.
+- [CommandMenu](/docs/actions-commandmenu--docs) — Searchable command surface that executes actions instead of editing text.
 - [ListBox](/docs/forms-listbox--docs) — The virtual-focus list rendered inside the popover.

--- a/src/components/fields/FilterPicker/FilterPicker.docs.mdx
+++ b/src/components/fields/FilterPicker/FilterPicker.docs.mdx
@@ -6,16 +6,23 @@ import * as FilterPickerStories from './FilterPicker.stories';
 
 # FilterPicker
 
-A versatile selection component that combines a trigger button with a searchable dropdown. It provides a space-efficient interface for selecting one or multiple items from a filtered list, with support for sections, custom summaries, and various UI states. Built with React Aria's accessibility features and the Cube `tasty` style system.
+A button-triggered field for keeping one or more selected values from a **searchable** list. It is designed for compact filters and preference controls, with sections, checkboxes, select-all, custom summaries, and form integration.
 
 ## When to Use
 
-- Creating filter interfaces where users need to select from predefined options
-- Building advanced search and filtering systems with multiple criteria
-- Implementing tag-based selection systems with multiple categories
-- Designing compact selection interfaces where space is limited
-- Providing searchable selection without taking up permanent screen space
-- Building user preference panels with organized option groups
+- The selected value or values must persist after the popover closes
+- Users need a visible search field to find options
+- A compact button trigger is preferable to an always-visible input
+- Multiple selection, checkboxes, select-all, grouped options, or a custom trigger summary are needed
+- The selection should participate in form state and validation
+
+Choose a different component when the interaction has another shape:
+
+- Use [Picker](/docs/forms-picker--docs) for the same compact single/multiple-selection pattern when the list is manageable without search.
+- Use [Select](/docs/forms-select--docs) for a conventional single-value field with a short predefined list.
+- Use [ComboBox](/docs/forms-combobox--docs) for an always-visible text input that searches and keeps one selected value.
+- Use [SearchComboBox](/docs/forms-searchcombobox--docs) when choosing a result should fire an action and clear the input rather than persist a value.
+- Use [CommandMenu](/docs/actions-commandmenu--docs) when entries execute application commands instead of becoming field values.
 
 ## Component
 
@@ -888,8 +895,10 @@ When using the dynamic content pattern (`items` prop) without sections, FilterPi
 
 ## Related Components
 
-- [FilterListBox](/docs/forms-filterlistbox--docs) - The underlying searchable list component
-- [Select](/docs/forms-select--docs) - Use for simple selection without search functionality
-- [ComboBox](/docs/forms-combobox--docs) - Use when users need to enter custom values
+- [FilterListBox](/docs/forms-filterlistbox--docs) - Use for an always-visible searchable selection list without a trigger
+- [Picker](/docs/forms-picker--docs) - Use for button-triggered single or multiple selection without a search field
+- [Select](/docs/forms-select--docs) - Use for a conventional single-value field with a short predefined list
+- [ComboBox](/docs/forms-combobox--docs) - Use for an input-based searchable field that keeps one selected value
+- [SearchComboBox](/docs/forms-searchcombobox--docs) - Use for search-and-act flows that clear after each result
 - [ListBox](/docs/forms-listbox--docs) - Use for basic list selection without search
 - [Button](/docs/actions-button--docs) - The underlying trigger component

--- a/src/components/fields/Picker/Picker.docs.mdx
+++ b/src/components/fields/Picker/Picker.docs.mdx
@@ -6,15 +6,23 @@ import * as PickerStories from './Picker.stories';
 
 # Picker
 
-A versatile selection component that combines a trigger button with a dropdown list. It provides a space-efficient interface for selecting one or multiple items from a list, with support for sections, custom summaries, and various UI states.
+A button-triggered field for keeping one or more selected values from a predefined list **without a visible search field**. Picker is suited to compact controls that need multiple selection, checkboxes, select-all, sections, or a custom summary in the trigger.
 
 ## When to Use
 
-- Creating selection interfaces where users need to choose from predefined options
-- Implementing compact selection interfaces where space is limited
-- Building user preference panels with organized option groups
-- When you need single or multiple selection from a list
-- When you don't need search/filter functionality (use ComboBox or FilterPicker for searchable lists)
+- The selected value or values must persist after the popover closes
+- The option set is manageable through scanning or keyboard typeahead, without a search input
+- Multiple selection, checkboxes, select-all, grouped options, or a custom trigger summary are needed
+- A compact button trigger fits a toolbar, filter bar, or preference panel
+- The selection should participate in form state and validation
+
+Choose a different component when the interaction has another shape:
+
+- Use [Select](/docs/forms-select--docs) for a conventional single-value field with a short predefined list.
+- Use [FilterPicker](/docs/forms-filterpicker--docs) when users need a visible search field while keeping single or multiple selections.
+- Use [ComboBox](/docs/forms-combobox--docs) for an always-visible text input that searches and keeps one selected value.
+- Use [SearchComboBox](/docs/forms-searchcombobox--docs) when choosing a result should fire an action and clear the input.
+- Use [Menu](/docs/actions-menu--docs) with `MenuTrigger` when entries primarily execute actions rather than become field values.
 
 ## Component
 
@@ -968,8 +976,11 @@ Optimize complex item content with the `textValue` prop for better accessibility
 
 ## Related Components
 
-- [ComboBox](/docs/forms-combobox--docs) - Use when you need search/filter functionality or custom value entry
+- [Select](/docs/forms-select--docs) - Use for a conventional single-value field with a short predefined list
+- [FilterPicker](/docs/forms-filterpicker--docs) - Use for button-triggered single or multiple selection with a visible search field
+- [ComboBox](/docs/forms-combobox--docs) - Use for an input-based searchable field that keeps one selected value
+- [SearchComboBox](/docs/forms-searchcombobox--docs) - Use for search-and-act flows that clear after each result
 - [ListBox](/docs/forms-listbox--docs) - Use for always-visible list selection without a trigger
-- [Select](/docs/forms-select--docs) - Use for native select behavior
+- [Menu](/docs/actions-menu--docs) - Use with MenuTrigger for action-oriented dropdowns
 - [Button](/docs/actions-button--docs) - The underlying trigger component
 - [Dialog](/docs/overlays-dialog--docs) - The popover container component

--- a/src/components/fields/SearchComboBox/SearchComboBox.docs.mdx
+++ b/src/components/fields/SearchComboBox/SearchComboBox.docs.mdx
@@ -5,16 +5,22 @@ import * as SearchComboBoxStories from './SearchComboBox.stories';
 
 # SearchComboBox
 
-A search-styled combobox for "search and act" flows. The user types a query, picks a suggestion (or optionally submits raw text), a callback fires, and the input clears so they can search again. Unlike [ComboBox](/docs/forms-combobox--docs), it does not hold a persistent selection and cannot be connected to a form.
+A single-line input for **search-and-act** flows. The user types a query, chooses a suggestion (or optionally submits the raw text), an action fires, and the input clears for the next query. SearchComboBox does not represent a selected value and cannot be connected to a form.
 
 ## When to Use
 
-- Command palettes, "add item" inputs, or global search where each interaction is a discrete action
+- "Add item" inputs, resource launchers, or focused searches where every result choice is a discrete action
 - Server-driven suggestions where results are fetched based on the query (use `filter={false}`)
 - When you want the input to reset after every pick instead of showing the selected label
 - When you optionally want to submit a free-form query that matches no suggestion
 
-For a field that keeps a selected value (e.g. inside a form), use [ComboBox](/docs/forms-combobox--docs) instead.
+Choose a different component when the interaction has another outcome:
+
+- Use [ComboBox](/docs/forms-combobox--docs) when the input should keep one selected value and participate in a form.
+- Use [FilterPicker](/docs/forms-filterpicker--docs) when a button should open a searchable list and keep one or more selected values.
+- Use [CommandMenu](/docs/actions-commandmenu--docs) for a searchable, keyboard-first palette of application commands, usually opened from a trigger or dialog.
+- Use [CommandTextArea](/docs/forms-commandtextarea--docs) when suggestions insert tokens into multiline free-form text.
+- Use [SearchInput](/docs/forms-searchinput--docs) when users submit free text without choosing suggestions.
 
 ## Component
 
@@ -265,6 +271,9 @@ useEffect(() => {
 
 ## Related Components
 
-- [ComboBox](/docs/forms-combobox--docs) - Use when you need a persistent selection that can be bound to a form
+- [ComboBox](/docs/forms-combobox--docs) - Use for an input-based searchable field that keeps one selected value
+- [FilterPicker](/docs/forms-filterpicker--docs) - Use when searched items become persistent single or multiple field values
+- [CommandMenu](/docs/actions-commandmenu--docs) - Use for searchable, keyboard-first application commands in a popover or dialog
+- [CommandTextArea](/docs/forms-commandtextarea--docs) - Use when suggestions insert tokens into multiline free-form text
 - [SearchInput](/docs/forms-searchinput--docs) - Use for free-text search without suggestions
 - [ListBox](/docs/forms-listbox--docs) - The underlying list component used in the popover

--- a/src/components/fields/Select/Select.docs.mdx
+++ b/src/components/fields/Select/Select.docs.mdx
@@ -5,15 +5,23 @@ import * as SelectStories from './Select.stories';
 
 # Select
 
-A select allows users to choose a single option from a list of predefined choices. It provides a compact interface for selection with a dropdown menu that displays available options when activated.
+A conventional field for keeping one selected value from a predefined list. Select uses a compact button trigger and supports keyboard typeahead, but it does not show a search input or support multiple selection.
 
 ## When to Use
 
-- Allow users to select one option from a predefined list
-- Provide selection in forms where space is limited
-- Offer choices where only one selection is allowed
-- Create dropdown menus for navigation or filtering
-- Present structured options in a compact interface
+- Exactly one value should persist after the dropdown closes
+- The option set is short enough to scan or navigate with keyboard typeahead
+- A familiar compact field is preferable to an always-visible list
+- The value should participate in form state and validation
+
+Choose a different component when the interaction has another shape:
+
+- Use [Picker](/docs/forms-picker--docs) when you need multiple selection, checkboxes, select-all, or a custom trigger summary.
+- Use [FilterPicker](/docs/forms-filterpicker--docs) when users need a visible search field, especially for multiple selection.
+- Use [ComboBox](/docs/forms-combobox--docs) for an always-visible text input that searches and keeps one selected value.
+- Use [SearchComboBox](/docs/forms-searchcombobox--docs) when choosing a result should fire an action and clear the input.
+- Use [Menu](/docs/actions-menu--docs) with `MenuTrigger` for navigation or actions that do not represent a field value.
+- Use [RadioGroup](/docs/forms-radiogroup--docs) when a small set of choices should remain visible for direct comparison.
 
 ## Component
 
@@ -616,8 +624,11 @@ This component supports all [Field properties](/docs/getting-started-field-prope
 
 ## Related Components
 
-- [ComboBox](/docs/forms-combobox--docs) - For searchable selection with filtering capabilities
-- [FilterPicker](/docs/forms-filterpicker--docs) - Alternative with different interaction patterns
+- [Picker](/docs/forms-picker--docs) - For richer button-triggered selection, including multiple values
+- [FilterPicker](/docs/forms-filterpicker--docs) - For button-triggered selection with a visible search field
+- [ComboBox](/docs/forms-combobox--docs) - For an input-based searchable field that keeps one selected value
+- [SearchComboBox](/docs/forms-searchcombobox--docs) - For search-and-act flows that clear after each result
 - [ListBox](/docs/forms-listbox--docs) - The underlying list component used in Select
 - [RadioGroup](/docs/forms-radiogroup--docs) - For visible selection options with fewer choices
+- [Menu](/docs/actions-menu--docs) - For action-oriented or navigation dropdowns
 - [Item](/docs/content-item--docs) - The base component used for rendering items


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs and changeset only; no runtime or API changes.
> 
> **Overview**
> **Documentation-only** update to Storybook MDX for overlapping selection, search, command, and menu components, plus a patch changeset for `@cube-dev/ui-kit`.
> 
> Each affected page (`CommandMenu`, `Menu`, `CommandTextArea`, `FilterPicker`, `Picker`, `SearchComboBox`, `Select`) gets a tighter intro, **When to use** bullets framed around outcomes (persist field values vs execute actions vs insert text), and a **Choose a different component when…** section with cross-links. **Related components** lists are aligned to the same decision tree. `Menu` also clarifies `Menu` + `MenuTrigger` vs `CommandMenu.Trigger`, and its “built-in search” enhancement now points to `CommandMenu`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1792bb538113a23ab28a0cd58f61b37426fc45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->