### PR TITLE
refactor(Disclosure): simplify interface definitions and improve cont…

### DIFF
--- a/.changeset/disclosure-content-visibility.md
+++ b/.changeset/disclosure-content-visibility.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Fix Disclosure content panel occasionally measuring to 0 height when expanding (content-visibility: auto interacted badly with the height 0 → max-content transition).

--- a/src/components/content/Disclosure/Disclosure.tsx
+++ b/src/components/content/Disclosure/Disclosure.tsx
@@ -197,10 +197,12 @@ const ContentElement = tasty({
   styles: {
     display: 'block',
     flow: 'column',
-    contentVisibility: {
-      '': 'auto',
-      shown: 'visible',
-    },
+    // Always visible: `content-visibility: auto` while height animates
+    // `0 → max-content` can leave the panel at 0px (children skipped for
+    // layout, so max-content resolves to 0). Collapsed content is already
+    // clipped via height:0 + overflow:hidden on the wrapper, and
+    // DisplayTransition unmounts when fully closed.
+    contentVisibility: 'visible',
   },
 });
 


### PR DESCRIPTION
…ent visibility handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CSS change to Disclosure expand/collapse styling with no auth, data, or API impact.
> 
> **Overview**
> Fixes an intermittent bug where **Disclosure** panels could stay at **0 height** after expanding.
> 
> `ContentElement` no longer toggles **`content-visibility`** between `auto` (collapsed) and `visible` (shown). It always uses **`visible`**, because `auto` during the wrapper’s **`0 → max-content`** height transition can skip child layout so **`max-content` resolves to 0**. Collapse behavior is unchanged: the wrapper still clips with **`height: 0`** and **`overflow: hidden`**, and **`DisplayTransition`** still unmounts when fully closed.
> 
> A patch **changeset** documents the fix for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec419146430a10820c88307a4aebec34d3cc31ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->