### PR TITLE
feat(PrismCode): HTML syntax highlighting

### DIFF
--- a/.changeset/prismcode-html-support.md
+++ b/.changeset/prismcode-html-support.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Ensure HTML syntax highlighting works in `PrismCode` and `CopySnippet`, including JavaScript inside `<script>` tags. Differentiate tag names, attributes, values, and punctuation so markup is not a single color wash.

--- a/src/components/GlobalStyles.tsx
+++ b/src/components/GlobalStyles.tsx
@@ -231,8 +231,12 @@ const STATIC_CSS = `
     color: var(--code-function-color);
   }
 
-  /* Attributes / properties / tags / selectors / built-ins — cyan */
-  .token.tag,
+  /* HTML/XML tag names — same hue as keywords (see Colors / CodeSyntax) */
+  .token.tag {
+    color: var(--code-keyword-color);
+  }
+
+  /* Attributes / properties / selectors / built-ins — cyan */
   .token.attr-name,
   .token.property,
   .token.symbol,
@@ -240,6 +244,23 @@ const STATIC_CSS = `
   .token.builtin,
   .token.selector {
     color: var(--code-attribute-color);
+  }
+
+  /*
+   * prism-react-renderer flattens nested markup tokens and prefixes parent
+   * types onto each leaf (e.g. \`token tag attr-value\`). Re-assert leaf
+   * colors so the bare \`.token.tag\` rule does not wash the whole tag.
+   */
+  .token.tag.attr-name {
+    color: var(--code-attribute-color);
+  }
+
+  .token.tag.attr-value {
+    color: var(--code-string-color);
+  }
+
+  .token.tag.punctuation {
+    color: var(--code-punctuation-color);
   }
 
   .token.important,

--- a/src/components/content/CopySnippet/CopySnippet.docs.mdx
+++ b/src/components/content/CopySnippet/CopySnippet.docs.mdx
@@ -54,4 +54,9 @@ These properties allow direct style application without using the `styles` prop:
   language="json"
   multiline
 />
+
+<CopySnippet
+  code={'<button type="button" class="primary">Save</button>'}
+  language="html"
+/>
 ```

--- a/src/components/content/CopySnippet/CopySnippet.stories.tsx
+++ b/src/components/content/CopySnippet/CopySnippet.stories.tsx
@@ -116,6 +116,70 @@ JavascriptSyntax.args = {
 });`,
 };
 
+export const HtmlSyntax = Template.bind({});
+HtmlSyntax.args = {
+  language: 'html',
+  code: `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cube Dashboard</title>
+    <link rel="stylesheet" href="/assets/dashboard.css" />
+  </head>
+  <body>
+    <header class="topbar" data-qa="topbar">
+      <a href="/" class="logo">Cube</a>
+      <nav aria-label="Primary">
+        <a href="/queries">Queries</a>
+        <a href="/semantic-layer">Semantic Layer</a>
+      </nav>
+    </header>
+
+    <main class="app" data-theme="light">
+      <section class="card" id="welcome">
+        <h1>Welcome</h1>
+        <p>Explore your metrics and run ad-hoc queries.</p>
+        <!-- Host-rendered content -->
+        <button type="button" id="run-query" disabled>Loading…</button>
+      </section>
+
+      <section class="card" id="results" hidden>
+        <h2>Results</h2>
+        <pre id="output"></pre>
+      </section>
+    </main>
+
+    <script>
+      const button = document.getElementById('run-query');
+      const results = document.getElementById('results');
+      const output = document.getElementById('output');
+
+      button.disabled = false;
+      button.textContent = 'Run query';
+
+      button.addEventListener('click', async () => {
+        button.disabled = true;
+        results.hidden = false;
+        output.textContent = 'Loading…';
+
+        const response = await fetch('/api/v1/load', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query: { measures: ['Orders.count'] },
+          }),
+        });
+
+        const data = await response.json();
+        output.textContent = JSON.stringify(data, null, 2);
+        button.disabled = false;
+      });
+    </script>
+  </body>
+</html>`,
+};
+
 export const DAX = Template.bind({});
 DAX.args = {
   language: 'javascript',

--- a/src/components/content/PrismCode/PrismCode.docs.mdx
+++ b/src/components/content/PrismCode/PrismCode.docs.mdx
@@ -35,11 +35,11 @@ against `#surface` in light, dark, and high-contrast schemes (AAA in HC).
 | -------------------- | -------------- | -------------------------------------------------------------- |
 | `#code-comment`      | gray           | comments, prolog, doctype, cdata                               |
 | `#code-punctuation`  | muted pink     | operators, punctuation                                         |
-| `#code-keyword`      | pink           | keywords, booleans, constants, atrules (`font-weight: 500`)    |
+| `#code-keyword`      | pink           | keywords, booleans, constants, atrules, HTML/XML tag names (`font-weight: 500` on language keywords) |
 | `#code-string`       | primary purple | strings, characters, attribute values, URLs                    |
 | `#code-number`       | green          | numbers, numeric entities                                      |
 | `#code-function`     | pink           | functions, class names, regex, variables                       |
-| `#code-attribute`    | cyan           | tags, attribute names, properties, selectors, built-ins, keys  |
+| `#code-attribute`    | cyan           | attribute names, properties, selectors, built-ins, keys        |
 
 Diff insertion (`+`) and deletion (`-`) intentionally re-use the existing
 `#success-*` / `#danger-*` ramps — both the line background tint and the

--- a/src/components/content/PrismCode/PrismCode.stories.tsx
+++ b/src/components/content/PrismCode/PrismCode.stories.tsx
@@ -208,6 +208,72 @@ ORDER BY fo.GeneratedDate, fo.UserID;`,
   },
 };
 
+export const HtmlSyntax = {
+  render: Template,
+  args: {
+    language: 'html',
+    code: `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cube Dashboard</title>
+    <link rel="stylesheet" href="/assets/dashboard.css" />
+  </head>
+  <body>
+    <header class="topbar" data-qa="topbar">
+      <a href="/" class="logo">Cube</a>
+      <nav aria-label="Primary">
+        <a href="/queries">Queries</a>
+        <a href="/semantic-layer">Semantic Layer</a>
+      </nav>
+    </header>
+
+    <main class="app" data-theme="light">
+      <section class="card" id="welcome">
+        <h1>Welcome</h1>
+        <p>Explore your metrics and run ad-hoc queries.</p>
+        <!-- Host-rendered content -->
+        <button type="button" id="run-query" disabled>Loading…</button>
+      </section>
+
+      <section class="card" id="results" hidden>
+        <h2>Results</h2>
+        <pre id="output"></pre>
+      </section>
+    </main>
+
+    <script>
+      const button = document.getElementById('run-query');
+      const results = document.getElementById('results');
+      const output = document.getElementById('output');
+
+      button.disabled = false;
+      button.textContent = 'Run query';
+
+      button.addEventListener('click', async () => {
+        button.disabled = true;
+        results.hidden = false;
+        output.textContent = 'Loading…';
+
+        const response = await fetch('/api/v1/load', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            query: { measures: ['Orders.count'] },
+          }),
+        });
+
+        const data = await response.json();
+        output.textContent = JSON.stringify(data, null, 2);
+        button.disabled = false;
+      });
+    </script>
+  </body>
+</html>`,
+  },
+};
+
 export const DiffSyntax = {
   render: Template,
   args: {

--- a/src/components/content/PrismCode/PrismCode.tsx
+++ b/src/components/content/PrismCode/PrismCode.tsx
@@ -10,6 +10,7 @@ import { forwardRef } from 'react';
 
 import { ensureYamlSqlExtensions, Prism } from './prismSetup';
 
+import 'prismjs/components/prism-markup.js';
 import 'prismjs/components/prism-javascript.js';
 import 'prismjs/components/prism-yaml.js';
 import 'prismjs/components/prism-bash.js';

--- a/src/components/content/PrismCode/__tests__/PrismCode.test.tsx
+++ b/src/components/content/PrismCode/__tests__/PrismCode.test.tsx
@@ -58,4 +58,39 @@ describe('PrismCode component', () => {
     expect(codeElement).toBeInTheDocument();
     expect(codeElement?.className).toContain('diff-highlight');
   });
+
+  test('renders HTML with tag and attribute tokens', () => {
+    const code = `<button type="button" class="primary">Save</button>`;
+
+    const { container } = render(<PrismCode code={code} language="html" />);
+
+    const codeElement = container.querySelector('code');
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement?.querySelector('.token.tag')).toBeInTheDocument();
+    expect(codeElement?.querySelector('.token.attr-name')).toBeInTheDocument();
+    // prism-react-renderer flattens nested markup with a parent `tag` type
+    expect(
+      codeElement?.querySelector('.token.tag.attr-name'),
+    ).toBeInTheDocument();
+    expect(
+      codeElement?.querySelector('.token.tag.attr-value'),
+    ).toBeInTheDocument();
+    expect(
+      codeElement?.querySelector('.token.tag.punctuation'),
+    ).toBeInTheDocument();
+  });
+
+  test('highlights JavaScript inside HTML script tags', () => {
+    const code = `<script>
+  const x = 1;
+  console.log('hi');
+</script>`;
+
+    const { container } = render(<PrismCode code={code} language="html" />);
+
+    const codeElement = container.querySelector('code');
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement?.querySelector('.token.keyword')).toBeInTheDocument();
+    expect(codeElement?.querySelector('.token.string')).toBeInTheDocument();
+  });
 });

--- a/src/tokens/palette.ts
+++ b/src/tokens/palette.ts
@@ -325,8 +325,8 @@ defaultTheme.colors({
   // in light, dark, and high-contrast schemes alike. Hues mirror the
   // long-standing PrismCode reference (pink keywords / pink functions /
   // orange strings / green numbers / gray comments). `code-attribute` keeps
-  // a cyan hue for HTML attribute names / CSS properties / selectors — not
-  // exercised in the SQL reference but useful in other languages. Diff
+  // a cyan hue for HTML attribute names / CSS properties / selectors; HTML/XML
+  // tag names use `code-keyword`. Diff
   // insertion / deletion re-use the existing `success-*` / `danger-*` ramps.
   'code-comment': {
     base: 'surface',


### PR DESCRIPTION
## Summary
- Load Prism markup grammar so `language="html"` works in `PrismCode` / `CopySnippet`, including JS inside `<script>` tags
- Fix flattened markup token colors so tags, attributes, values, and punctuation are distinct
- Add HTML stories, docs example, tests, and a patch changeset

## Test plan
- [ ] Open PrismCode / CopySnippet `HtmlSyntax` stories and confirm HTML + nested script highlighting
- [ ] Spot-check JS/YAML/SQL/bash highlighting is unchanged
- [ ] `pnpm test -- PrismCode`


Made with [Cursor](https://cursor.com)