### PR TITLE
ci: open the Version Packages PR with a PAT so its required checks run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,12 @@ jobs:
           publish: pnpm release
           commit: 'chore: release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT, not the default GITHUB_TOKEN. GitHub deliberately
+          # does not fire `pull_request` events for PRs opened with
+          # GITHUB_TOKEN, so the Version Packages PR never received the checks
+          # `main` requires (Build & canary release, Tests & lint, UI Tests,
+          # UI Review) and could only ever be merged with an admin override.
+          GITHUB_TOKEN: ${{ secrets.UIKIT_GITHUB_TOKEN }}
           # NPM_TOKEN not needed - using trusted publishing (OIDC)
 
   deploy-chromatic-release:


### PR DESCRIPTION
### Describe changes

Release PRs in this repo can only be merged with an admin override. This fixes the cause.

#### What's happening

`main`'s protection requires four checks:

```
Build & canary release · Tests & lint · UI Tests · UI Review
```

All four originate from `pull-request.yml`, which triggers on `pull_request` only.

The changesets action in `publish.yml` was passed the default `GITHUB_TOKEN`. GitHub **deliberately does not fire `pull_request` events for PRs opened with that token** — it's an anti-recursion rule, so Actions can't trigger Actions indefinitely. The result is that a Version Packages PR collects only the external checks that don't depend on workflow events:

| | Version Packages PR | normal PR |
|---|---|---|
| Cursor Bugbot, Vercel, Vercel Preview Comments, snyk | ✅ | ✅ |
| **Build & canary release** | ❌ never runs | ✅ |
| **Tests & lint** | ❌ never runs | ✅ |
| **UI Tests** | ❌ never runs | ✅ |
| **UI Review** | ❌ never runs | ✅ |

So it sits at `mergeStateStatus: BLOCKED` forever. Confirmed on the currently-open [#1259](https://github.com/cube-js/cube-ui-kit/pull/1259) and on the already-merged [#1256](https://github.com/cube-js/cube-ui-kit/pull/1256), which shows the same four external checks and nothing else — meaning every release so far has been merged by overriding protection.

#### Fix

Point the action at the existing `UIKIT_GITHUB_TOKEN` PAT, so the PR is opened as a user and receives the normal PR workflows. One line, plus a comment recording why it must not be reverted to `GITHUB_TOKEN`.

The `Comment PR` step (line 99) intentionally keeps the default token — it only posts a canary comment and needs no elevated identity.

#### Why not the alternatives

- **Adding a `push` trigger for `changeset-release/**`** would also emit the four context names without any credential, but it relies on Chromatic posting `UI Tests` / `UI Review` statuses on a branch build rather than a PR build — less certain, and it makes the release PR behave unlike every other PR.
- **Removing the required checks** from protection would weaken `main` for every PR to solve a bot-PR problem.

#### Follow-up needed after merge

The already-open #1259 was created by the old token, so it will not retroactively gain checks. To clear it: close #1259 and delete its `changeset-release/main` branch — the next `Publish` run on `main` recreates it with the PAT, and it should then go green and merge without an override. I can do that once this lands.

Two things I can't verify from here, worth a glance:

1. **`UIKIT_GITHUB_TOKEN` must be unexpired with `repo` + `workflow` scope.** It was added 2024-06-13 and is currently referenced by no workflow, so I could not test it. If the next release PR is opened by `github-actions[bot]` rather than a user, the token is the reason.
2. A PAT-opened PR is attributed to that token's owner, so release PRs will show as authored by you rather than the Actions bot.

##### Checklist

- [x] Pipeline is passed
- [ ] Tests are added — n/a, CI configuration only
- [x] Tests are passed successfully
- [ ] If you're adding a new component/new props, add stories — n/a
- [ ] Changeset(s) is(are) added — none: no shipped code changes, so nothing to version
- [x] Commit message follows commit guidelines

Closes: N/A

#

### Other information

No published output changes — this touches only how the release PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI credential swap only; no runtime or package code changes, though release PR auth now depends on PAT validity and scopes.
> 
> **Overview**
> **Fixes release PRs stuck behind branch protection** by having the changesets action authenticate with `secrets.UIKIT_GITHUB_TOKEN` instead of the default `GITHUB_TOKEN` when creating or updating the Version Packages PR.
> 
> GitHub does not emit `pull_request` workflows for PRs opened by `GITHUB_TOKEN`, so those release PRs never ran the four checks `main` requires (`Build & canary release`, Tests & lint, UI Tests, UI Review) and could only merge via admin override. A PAT opens the PR as a normal user PR so existing `pull-request.yml` jobs run.
> 
> Adds an inline comment in `publish.yml` documenting why this must stay a PAT. The canary **Comment PR** step is unchanged and still uses `GITHUB_TOKEN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba94143b02b7e329721fe7c70096f7d6d7f53d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->