### PR TITLE
fix(stories): freeze the spinner in the Icons Default story

### DIFF
--- a/src/icons/Icons.stories.tsx
+++ b/src/icons/Icons.stories.tsx
@@ -82,6 +82,32 @@ const TemplateDirectionIcon: StoryFn<CubeIconProps> = (args) => {
 export const Default = Template.bind({});
 Default.args = {};
 
+/**
+ * This story renders every exported icon, which includes `LoadingIcon` — and that
+ * carries `.cube-animation-spin`, an infinite 1s rotation (see `GlobalStyles`).
+ * A snapshot therefore catches it at whatever angle it happened to reach, and the
+ * story diffs against itself on runs where nothing changed.
+ *
+ * Freeze the rotation for THIS story only. The override is scoped to the wrapper
+ * rather than injected globally, so any other story that legitimately shows a
+ * spinner in motion — and the docs page, where several stories share a document —
+ * is unaffected. `[data-static-spin] .cube-animation-spin` is specificity (0,2,0)
+ * against the global rule's (0,1,0), so it wins without `!important`.
+ *
+ * `animation: none` drops the element back to its untransformed state, i.e. a
+ * deterministic 0deg, instead of pausing at an arbitrary frame.
+ */
+Default.decorators = [
+  (Story: StoryFn) => (
+    <div data-static-spin="">
+      <style>
+        {'[data-static-spin] .cube-animation-spin { animation: none; }'}
+      </style>
+      <Story />
+    </div>
+  ),
+];
+
 export const WithSize = TemplateWithSize.bind({});
 WithSize.args = {
   size: '8x',


### PR DESCRIPTION
`Content/Icons` → **Default** renders every exported icon, which includes `LoadingIcon`. That carries `.cube-animation-spin` — `animation: cube-animation-spin 1s linear infinite`, from `GlobalStyles` — so a snapshot captures it at whatever angle it happened to reach, and the story diffs against itself on runs where nothing changed.

## The fix

A decorator on **that one story** freezes the rotation. Two details keep it from touching anything else:

- The override is **scoped to the decorator's own wrapper** (`[data-static-spin] .cube-animation-spin`) rather than injected globally, so any other story that legitimately shows a spinner *in motion* is unaffected — including on a docs page, where several stories share one document.
- `[data-static-spin] .cube-animation-spin` is specificity **(0,2,0)** against the global rule's **(0,1,0)**, so it wins without `!important`.

`animation: none` returns the element to its untransformed state — a deterministic 0deg — rather than pausing on an arbitrary frame. That makes the snapshot *stable*, not merely less jittery.

## Verification

I checked the cascade in a **real browser** rather than reasoning about it, because jsdom does not resolve the `animation` shorthand into `animationName` — a unit test reports `none` for both the scoped and unscoped case and therefore proves nothing:

```
inside  [data-static-spin]  ->  animation-name: none
outside                     ->  animation-name: cube-animation-spin, 1s, infinite
```

Also confirmed `LoadingIcon` is the only animated icon — `DirectionIcon` and `PlayCircleIcon` use static rotations and are untouched.

Story-only change: no `src` component or token is modified, so nothing ships to consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook-only change in `Icons.stories.tsx`; no production components or styles shipped to consumers.
> 
> **Overview**
> Fixes flaky **Content/Icons → Default** visual/snapshot tests caused by `LoadingIcon`’s infinite `.cube-animation-spin` rotation.
> 
> Adds a **story-only decorator** that wraps `Default` in `[data-static-spin]` and injects scoped CSS (`animation: none` on `.cube-animation-spin`) so the spinner renders at a fixed 0° without changing global styles or other stories/docs that show animated spinners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5151d85e982aaccb577947c708f2feac1c9227f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->