### PR TITLE
fix(palette): keep `pastel` out of the code syntax tokens

### DIFF
--- a/.changeset/pastel-skips-code-tokens.md
+++ b/.changeset/pastel-skips-code-tokens.md
@@ -1,0 +1,17 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Fix `setPaletteConfig({ pastel: true })` washing out the `code-*` syntax tokens. `pastel` was threaded into every theme including the standalone code one, and it lowers the chroma ceiling hard enough to take `code-keyword` from ~0.19 to ~0.07 — every syntax hue collapsing toward the same grey, which is the difference between readable syntax highlighting and mud.
+
+The code theme is now built with `pastel` pinned off whatever the palette does, so the emitted `code-*` values are a function of `themes.code.saturation` alone — the same isolation its fixed hues and non-inheriting saturation already gave it. To soften a code block, lower that seed instead:
+
+```ts
+setPaletteConfig({ pastel: true, themes: { code: { saturation: 50 } } });
+```
+
+The mirrored `surface` the code theme anchors its `['AA','AAA']` floors to goes non-pastel with it. That costs nothing measurable: `surface` sits at saturation factor 0.12, where the pastel ceiling moves chroma only and leaves the tone the floors are actually solved against bit-identical — pinned by a new spec.
+
+Default output is unchanged; `pastel` ships off.
+
+The Theme Builder presets now re-seed the **status hues** alongside the brand, which they should have from the start: moving `hue` alone left the shipped statuses behind, and `Forest` at 150° landed 7° off the shipped `success` (156.9°) — a success banner and the brand accent resolving to the same green. Every preset now keeps ≥38° between any two of its five hues, and `Slate` demonstrates `pastel` (plus its own `themes.code.saturation`, since pastel no longer reaches the syntax palette).

--- a/src/stories/Theming.docs.mdx
+++ b/src/stories/Theming.docs.mdx
@@ -27,16 +27,16 @@ value so this stays true.
 
 ## What is tunable
 
-| Option | Scope | Default |
-| --- | --- | --- |
-| `hue` | **Accent** hue in degrees — the brand. Drives the `accent-*` family, `primary` / `purple` / `special`, and the brand-tinted `focus`, loading faces and disabled chip. | `280.3` |
-| `baseHue` | **Base** hue in degrees — the neutral chrome: `surface` and its ladder, the `surface-text*` ramp, `border`, `placeholder`. | inherits `hue` |
-| `saturation` | Seed saturation (0–100) for the `default` theme, and the fallback for every theme that sets none. | `80` |
-| `themes.<status>.hue` | Hue for `success` / `danger` / `warning` / `note`. | `156.9` / `23.1` / `84.3` / `302.3` |
-| `themes.<status>.saturation` | Saturation for that status theme. | inherits `saturation` |
-| `themes.code.saturation` | Saturation for the `code-*` syntax family. Hues are fixed, and this does **not** inherit `saturation`. | `80` |
-| `pastel` | Global. Relaxes the sRGB-safe chroma limit. | `false` |
-| `contrastLevel` | Global. `'auto'`, or a manual `0`–`100` level. | `'auto'` |
+| Option                       | Scope                                                                                                                                                                 | Default                             |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `hue`                        | **Accent** hue in degrees — the brand. Drives the `accent-*` family, `primary` / `purple` / `special`, and the brand-tinted `focus`, loading faces and disabled chip. | `280.3`                             |
+| `baseHue`                    | **Base** hue in degrees — the neutral chrome: `surface` and its ladder, the `surface-text*` ramp, `border`, `placeholder`.                                            | inherits `hue`                      |
+| `saturation`                 | Seed saturation (0–100) for the `default` theme, and the fallback for every theme that sets none.                                                                     | `80`                                |
+| `themes.<status>.hue`        | Hue for `success` / `danger` / `warning` / `note`.                                                                                                                    | `156.9` / `23.1` / `84.3` / `302.3` |
+| `themes.<status>.saturation` | Saturation for that status theme.                                                                                                                                     | inherits `saturation`               |
+| `themes.code.saturation`     | Saturation for the `code-*` syntax family. Hues are fixed, and this does **not** inherit `saturation`.                                                                | `80`                                |
+| `pastel`                     | Global. Relaxes the sRGB-safe chroma limit. Every theme except `code`.                                                                                                | `false`                             |
+| `contrastLevel`              | Global. `'auto'`, or a manual `0`–`100` level.                                                                                                                        | `'auto'`                            |
 
 ### The setter replaces
 
@@ -87,15 +87,15 @@ setPaletteConfig({ hue: 235, baseHue: 60 });
 ```
 
 Only the `default` theme is affected. A colored theme's tinted `surface`
-deliberately follows *its own* hue, because a danger banner should read as red.
+deliberately follows _its own_ hue, because a danger banner should read as red.
 
 ### One saturation scale per theme
 
-Saturation is *not* split, deliberately: `saturation` is the theme's **seed**, and
+Saturation is _not_ split, deliberately: `saturation` is the theme's **seed**, and
 every color's own `saturation` is a 0–1 factor of it. `surface` sits at `0.12`,
 `border` at `0.175`, the text ramp at `0.2`, the accent family at ~`1.0`.
 
-So the palette has one saturation *scale*, and everything on it keeps its
+So the palette has one saturation _scale_, and everything on it keeps its
 proportions: turning `saturation` down mutes the brand fills and the neutral tint
 together, in the ratios the palette was designed around. That is the point — the
 relationship between a subtle surface tint and a saturated accent is part of the
@@ -107,13 +107,17 @@ Syntax colors are their own theme with their own seed, so neither the brand hue 
 the palette saturation reaches them. Hues are absolute literals — a brand re-seeded
 toward green would otherwise collide `code-string` with `code-number` (156°) — and
 the saturation is fixed at `80` rather than inheriting, so muting the app cannot
-wash out a code block. Tune it on its own:
+wash out a code block. `pastel` skips them for the same reason: it lowers the chroma
+ceiling far enough to take `code-keyword` from ~0.19 to ~0.07, collapsing the spread
+that keeps the syntax hues apart.
+
+So `themes.code.saturation` is the only thing that moves them. Tune it on its own:
 
 ```ts
 setPaletteConfig({ themes: { code: { saturation: 60 } } });
 ```
 
-They are still *adaptive*: each one is anchored to the real `surface` with an
+They are still _adaptive_: each one is anchored to the real `surface` with an
 `['AA','AAA']` floor, so they re-solve for light, dark and high contrast. Only hue
 and saturation are pinned.
 
@@ -153,7 +157,7 @@ const pinned = getPaletteConfigInput().baseHue !== undefined;
 
 Pinning a field to the value it already inherited resolves to the same colors but
 still counts as a change, so a UI reading the sparse config re-renders. Re-applying
-an *already pinned* value is a true no-op and costs nothing.
+an _already pinned_ value is a true no-op and costs nothing.
 
 ## Palette playground
 
@@ -206,8 +210,8 @@ result into a single region: pick **Light / Dark**, then either a contrast **mod
 variant while the page around it stays as it is.
 
 There is no `Auto` for scheme or contrast mode, on purpose. `Auto` means "follow
-the OS" — a *preference*, and a flat token value cannot express one. A preview
-renders one concrete variant, so it has to name which. The contrast *level* keeps
+the OS" — a _preference_, and a flat token value cannot express one. A preview
+renders one concrete variant, so it has to name which. The contrast _level_ keeps
 its `Auto`, because there the choice is between the two-tier model and a hand-set
 number rather than between following and not following the system.
 
@@ -241,11 +245,11 @@ The reason this needs its own API: the document palette emits **state maps**
 time — that is what `@dark` means. Collapsing the palette to a chosen scheme
 removes the conditionality, so several themes can coexist.
 
-| Option | Meaning |
-| --- | --- |
+| Option                      | Meaning                                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------------------- |
 | every `PaletteConfig` field | merged over the **current** config, so `{ scheme: 'dark' }` previews the active theme in dark |
-| `scheme` | `'light'` (default) or `'dark'` |
-| `highContrast` | resolve that scheme's high-contrast variant. Default `false` |
+| `scheme`                    | `'light'` (default) or `'dark'`                                                               |
+| `highContrast`              | resolve that scheme's high-contrast variant. Default `false`                                  |
 
 Nothing is applied globally — the live palette and the stored config are
 untouched, so previews are safe to render anywhere.
@@ -273,7 +277,7 @@ Notes:
   reproduces the normal tier and `100` the high-contrast tier exactly, in both
   schemes. Because a manual level leaves no separate high-contrast tier,
   `highContrast: true` correctly returns the same colors as the normal variant.
-  Note that tokens carrying a contrast *floor* (most text) can sit still over part
+  Note that tokens carrying a contrast _floor_ (most text) can sit still over part
   of the ramp — the floor is solved, not approximated, so the value only moves once
   the interpolated target does. Tokens positioned by a plain tone pair, like
   `#border`, step at every level.
@@ -329,7 +333,7 @@ Because the setter replaces, the prop describes the **whole** palette: drop a
 field from the object and that customization goes away on the next render, which
 is what you want from a declarative prop.
 
-Removing the prop entirely is the one thing that does *not* reset the palette —
+Removing the prop entirely is the one thing that does _not_ reset the palette —
 `<Root>` with no `palette` leaves whatever is configured alone, so that the common
 case cannot clobber a host's imperative `setPaletteConfig()` call. Pass
 `palette={{}}` if you do want the default.
@@ -347,11 +351,11 @@ and not per request:
 
 ## Caveats
 
-**`pastel: true` is a redesign, not a filter.** It changes every resolved color.
-The per-color saturation factors in this palette were tuned for the non-pastel
-space — pastel equalizes chroma across hues, so a pastel palette on the shipped
-seeds resolves more saturated than you may expect. Re-tune the seeds alongside
-it.
+**`pastel: true` is a redesign, not a filter.** It changes every resolved color
+outside the `code-*` family. The per-color saturation factors in this palette were
+tuned for the non-pastel space — pastel equalizes chroma across hues, so a pastel
+palette on the shipped seeds resolves more saturated than you may expect. Re-tune
+the seeds alongside it.
 
 **Re-seeding costs about 10 ms.** Rebuilding the eight themes and re-solving
 ~156 tokens across four scheme variants is not free, though it is inside a frame.
@@ -380,7 +384,7 @@ it.
 **Some things are not tunable at all.** Tasty locks its configuration on the
 first style injection, so the `@dark` / `@hc` state definitions and the
 `colorSpace` (both set in `Root`) are fixed for the lifetime of the page. Only
-token *values* stay mutable — which is all re-seeding needs.
+token _values_ stay mutable — which is all re-seeding needs.
 
 ## See also
 

--- a/src/stories/Theming.stories.tsx
+++ b/src/stories/Theming.stories.tsx
@@ -666,13 +666,87 @@ const GroupLabel = tasty({
   styles: { preset: 't4m', color: '#surface-text-soft' },
 });
 
-/** Quick-apply seeds, so the builder opens on something other than a blank slate. */
+/**
+ * Quick-apply seeds, so the builder opens on something other than a blank slate.
+ *
+ * Each one re-seeds the **status hues** as well as the brand, because moving `hue`
+ * alone leaves the shipped statuses behind it and they collide: a `Forest` brand at
+ * 150° lands 7° off the shipped `success` (156.9°), so a success banner and the brand
+ * accent resolve to the same green. The bar here is ~35° between any two of the five
+ * hues, roughly where two tinted surfaces stop reading as one color.
+ *
+ * Statuses still have to stay semantically legible — danger red, warning amber,
+ * success green — so `note` does most of the moving, and the brand yields a little
+ * where it has to (`Forest` sits at moss rather than mid-green to leave room for an
+ * emerald success; `Ember` at amber rather than orange to leave room for a crimson
+ * danger).
+ */
 const THEME_PRESETS: { label: string; config: PaletteConfig }[] = [
-  { label: 'Cube', config: { hue: 280.3, saturation: 80, pastel: false } },
-  { label: 'Ocean', config: { hue: 235, saturation: 70, pastel: false } },
-  { label: 'Forest', config: { hue: 150, saturation: 65, pastel: false } },
-  { label: 'Ember', config: { hue: 35, saturation: 85, pastel: false } },
-  { label: 'Slate', config: { hue: 250, baseHue: 250, saturation: 30 } },
+  // Empty on purpose: the setter replaces, so this *is* the shipped palette — the
+  // reference the other four depart from, and the way back from any of them.
+  { label: 'Cube', config: {} },
+  {
+    label: 'Ocean',
+    config: {
+      hue: 235,
+      saturation: 70,
+      themes: {
+        success: { hue: 165 },
+        danger: { hue: 25 },
+        warning: { hue: 80 },
+        // Off purple and into magenta: at the shipped 302° a note sits 67° from a
+        // blue brand and reads as a second accent rather than an aside.
+        note: { hue: 315 },
+      },
+    },
+  },
+  {
+    label: 'Forest',
+    config: {
+      hue: 128,
+      saturation: 65,
+      themes: {
+        success: { hue: 172 },
+        danger: { hue: 25 },
+        warning: { hue: 75 },
+        note: { hue: 300 },
+      },
+    },
+  },
+  {
+    label: 'Ember',
+    config: {
+      hue: 48,
+      saturation: 85,
+      themes: {
+        success: { hue: 155 },
+        danger: { hue: 6 },
+        warning: { hue: 100 },
+        note: { hue: 300 },
+      },
+    },
+  },
+  {
+    label: 'Slate',
+    config: {
+      hue: 250,
+      // Pastel is what mutes this one: it swaps the per-hue chroma ceiling for a
+      // flat one, so the saturation seed can stay high and still land soft — 60
+      // here resolves to the same accent chroma a non-pastel 30 does, but even
+      // across hues rather than letting the warm statuses run ahead.
+      saturation: 60,
+      pastel: true,
+      themes: {
+        success: { hue: 160 },
+        danger: { hue: 20 },
+        warning: { hue: 85 },
+        note: { hue: 312 },
+        // Pastel does not reach the syntax palette, by design. Softening a code
+        // block to match the rest of a muted theme goes through its own seed.
+        code: { saturation: 55 },
+      },
+    },
+  },
 ];
 
 function ThemeBuilderControls({

--- a/src/tokens/palette-config.ts
+++ b/src/tokens/palette-config.ts
@@ -39,13 +39,15 @@ export interface PaletteThemeSeed {
 }
 
 /**
- * The `code-*` syntax family takes a saturation and nothing else.
+ * The `code-*` syntax family takes a saturation and nothing else — and answers to
+ * nothing else either. This is the one knob that moves it.
  *
  * Its hues are absolute literals by design, so syntax colors never rotate with the
- * brand — strings would collide with numbers the moment the brand went green. And
- * unlike every other theme, its saturation does **not** inherit the palette-level
- * one: the code palette is calibrated once and stays there, so re-seeding the app
- * cannot quietly wash out a code block.
+ * brand — strings would collide with numbers the moment the brand went green. Unlike
+ * every other theme, its saturation does **not** inherit the palette-level one: the
+ * code palette is calibrated once and stays there, so re-seeding the app cannot
+ * quietly wash out a code block. {@link PaletteConfig.pastel} skips it for the same
+ * reason.
  */
 export interface PaletteCodeSeed {
   /** Saturation (0–100). Defaults to {@link DEFAULT_SATURATION}, not to `saturation`. */
@@ -101,6 +103,11 @@ export interface PaletteConfig {
    * Global. Widens the usable chroma range by relaxing the sRGB-safe limit,
    * producing a softer, more even palette across hues. Glaze treats `pastel` as
    * instance-level, so it is threaded into every theme.
+   *
+   * Every theme except `code`. The syntax family is calibrated on its own
+   * saturation and is deliberately left out — softening it collapses the chroma
+   * spread the syntax hues rely on to stay apart. To soften a code block, lower
+   * {@link PaletteCodeSeed.saturation} instead.
    */
   pastel?: boolean;
   /**

--- a/src/tokens/palette.test.ts
+++ b/src/tokens/palette.test.ts
@@ -356,10 +356,36 @@ describe('setPaletteConfig', () => {
     for (const name of palette.list()) {
       expect(palette.theme(name)?.getConfig().pastel, name).toBe(true);
     }
+  });
 
-    // The code theme lives outside the palette, so it is the other easy one to
-    // miss.
-    expect(getCodeTheme().getConfig().pastel).toBe(true);
+  it('keeps pastel out of the syntax palette', () => {
+    // The code theme is seeded off `themes.code.saturation` alone. `pastel`
+    // lowers the chroma ceiling far enough to take `code-keyword` from ~0.19 to
+    // ~0.07 — every syntax hue collapsing toward the same washed-out grey — so
+    // it stops at the code theme's door.
+    const before = CODE_TOKENS.map((name) => baseline[name]);
+
+    setPaletteConfig({ pastel: true });
+
+    const tuned = dumpTokens(getPaletteTokens());
+
+    // Bit-identical, in all four scheme variants: nothing but the code
+    // saturation reaches these.
+    expect(CODE_TOKENS.map((name) => tuned[name])).toEqual(before);
+    expect(getCodeTheme().getConfig().pastel).toBe(false);
+
+    // Not a no-op config — the rest of the palette did soften.
+    expect(tuned['#surface']).not.toBe(baseline['#surface']);
+  });
+
+  it('still answers to the code saturation while pastel is on', () => {
+    setPaletteConfig({ pastel: true, themes: { code: { saturation: 30 } } });
+
+    const tuned = dumpTokens(getPaletteTokens());
+
+    expect(CODE_TOKENS.map((name) => tuned[name])).not.toEqual(
+      CODE_TOKENS.map((name) => baseline[name]),
+    );
   });
 
   it('replaces the whole config rather than accumulating', () => {
@@ -551,6 +577,28 @@ describe('code syntax tokens', () => {
 
     expect(mirrored.light.surface).toBe(live['']);
     expect(mirrored.dark?.surface).toBe(live['@dark']);
+  });
+
+  it('keeps the mirror on the real surface tone under pastel', () => {
+    setPaletteConfig({ pastel: true });
+
+    const mirrored = getCodeTheme().tokens({
+      modes: { dark: true, highContrast: true },
+    });
+    const live = getPaletteTokens()['#surface'] as TokenStates;
+
+    // The mirror goes non-pastel along with the rest of the code theme, so its
+    // chroma no longer tracks the softened page. That is the whole cost of
+    // holding pastel off here, and it is a cheap one: `surface` sits at
+    // saturation factor 0.12, where the pastel ceiling moves chroma only — the
+    // lightness the AA/AAA floors are actually solved against stays exact.
+    const lightnessOf = (value: string) =>
+      value.trim().split(/\s+/)[0].replace('oklch(', '');
+
+    expect(lightnessOf(mirrored.light.surface)).toBe(lightnessOf(live['']));
+    expect(lightnessOf(mirrored.dark!.surface)).toBe(
+      lightnessOf(live['@dark']),
+    );
   });
 
   it('warns instead of silently clamping an unreachable mirror', () => {

--- a/src/tokens/palette.ts
+++ b/src/tokens/palette.ts
@@ -86,11 +86,15 @@ const TINTED_SURFACE_TONE_OFFSET = 2;
  * and selectors, while HTML/XML tag names reuse `code-keyword`. Diff insertion and
  * deletion reuse the `success-*` / `danger-*` ramps instead.
  *
- * Two things are deliberately static here. Every hue is an absolute literal, so a
+ * Three things are deliberately static here. Every hue is an absolute literal, so a
  * re-seeded brand cannot rotate the syntax palette — a green brand would otherwise
- * collide `code-string` with `code-number` (156°). And these factors are relative to
+ * collide `code-string` with `code-number` (156°). These factors are relative to
  * the *code* theme's own seed (`themes.code.saturation`), not the palette-level one,
- * so tuning the app's saturation cannot wash out a code block.
+ * so tuning the app's saturation cannot wash out a code block. And `pastel` is held
+ * off here whatever the palette does, for the same reason: it lowers the chroma
+ * ceiling hard enough to take `code-keyword` from ~0.19 to ~0.07, which is the
+ * difference between distinguishable syntax and mud. Between them, these mean the
+ * emitted `code-*` values are a function of the code saturation alone.
  *
  * That separate seed is the only reason these live outside the default theme: a
  * theme colour can never exceed its own seed, and four of these sit at factor `1.0`,
@@ -155,6 +159,11 @@ const CODE_COLORS: ColorMap = {
  * verbatim and resolves identically at any palette saturation. The mirrored `surface`
  * is an implementation detail — it exists only as the contrast base, and is filtered
  * out of the emitted tokens by {@link pickCodeTokens}.
+ *
+ * `instanceConfig` arrives with `pastel` pinned off, so the mirror is non-pastel too
+ * even when the app is. Harmless: at saturation factor 0.12 the pastel ceiling moves
+ * the mirror's chroma and leaves its tone — the axis every `code-*` contrast floor is
+ * solved against — bit-identical.
  */
 function buildCodeTheme(
   config: ResolvedPaletteConfig,
@@ -295,19 +304,33 @@ function buildPalette(
 ): BuiltPalette {
   const { hue, baseHue, saturation, pastel, themes, contrastLevel } = config;
 
+  // The one override the code theme shares with the rest of the palette.
+  const sharedOverrides: GlazeConfigOverride = options.isolateContrastLevel
+    ? { contrastLevel }
+    : {};
+
   // `pastel` is instance-level in Glaze (not settable via `glaze.configure`).
   // Setting it on the two root themes is enough: `extend({ config })` merges
   // with the parent's override, so the derived themes inherit it. When it is
   // off we omit the field entirely rather than pass `false` — the two are
   // equivalent, and omitting keeps the default output provably untouched.
   const overrides: GlazeConfigOverride = {
+    ...sharedOverrides,
     ...(pastel ? { pastel: true } : null),
-    ...(options.isolateContrastLevel ? { contrastLevel } : null),
   };
   const instanceConfig: GlazeConfigOverride | undefined = Object.keys(overrides)
     .length
     ? overrides
     : undefined;
+
+  // `pastel` deliberately does *not* reach the code theme: syntax colors answer
+  // to `themes.code.saturation` and nothing else. Pinned to `false` rather than
+  // omitted — the same value Glaze defaults to, but here it is the point of the
+  // override, not an absence. See {@link buildCodeTheme}.
+  const codeInstanceConfig: GlazeConfigOverride = {
+    ...sharedOverrides,
+    pastel: false,
+  };
 
   // --------------------------------------------------------------------------
   // Default theme (neutral, primary in palette → exported unprefixed)
@@ -784,7 +807,7 @@ function buildPalette(
     }),
     // Kept out of the palette on purpose: it has to emit `code-*` unprefixed, and
     // its mirrored `surface` would collide with the default theme's.
-    codeTheme: buildCodeTheme(config, instanceConfig),
+    codeTheme: buildCodeTheme(config, codeInstanceConfig),
   };
 }
 


### PR DESCRIPTION
## The bug

`setPaletteConfig({ pastel: true })` threaded `pastel` into every theme, the standalone code one included. `pastel` swaps Glaze's per-hue chroma ceiling for a flat, hue-independent one — which is the point everywhere else, and ruinous for syntax highlighting:

| token | default | with `pastel: true` (before) |
| --- | --- | --- |
| `code-keyword` | `oklch(0.5347 0.1938 348)` | `oklch(0.5347 0.0727 348)` |
| `code-string` | `oklch(0.5637 0.1884 280.3)` | `oklch(0.5637 0.0767 280.3)` |
| `code-number` | `oklch(0.5541 0.0988 156)` | `oklch(0.5576 0.0683 156)` |

Every syntax hue collapsing toward the same washed-out grey — the difference between distinguishable syntax and mud.

## The fix

The code theme is built with `pastel` pinned off whatever the palette does, so the emitted `code-*` values are a function of `themes.code.saturation` alone. That is the same isolation its absolute hues and non-inheriting saturation already gave it — `pastel` was the one seed still leaking in.

`pastel: false` is pinned rather than omitted: it is the same value Glaze defaults to, but here it is the point of the override, not an absence.

To soften a code block, lower its own seed:

```ts
setPaletteConfig({ pastel: true, themes: { code: { saturation: 50 } } });
```

### The one cost

The mirrored `surface` the code theme anchors its `['AA','AAA']` floors to goes non-pastel with it, so its chroma no longer tracks the softened page. Measured, not assumed: `surface` sits at saturation factor 0.12, where the pastel ceiling moves chroma only and leaves the **tone** — the axis the contrast floors are actually solved against — bit-identical in all four scheme variants. A new spec pins that.

The alternative was keeping the instance pastel and setting per-color `pastel: false` on all seven syntax colors. It lands within 0.0002 L of this, and trades an exactly-testable invariant ("code output is a pure function of the code seed") for a fuzzy one. Not worth it.

## Theme Builder presets

Second commit's worth of the same theme, spotted while verifying: presets moved `hue` alone and left the shipped status hues behind them, so they collided. `Forest` at 150° landed **7°** off the shipped `success` (156.9°) — a success banner and the brand accent resolving to the same green; `Ember` at 35° landed 12° off `danger` (23.1°).

Each preset now carries its own status hues, with ≥38° between any two of its five:

| preset | brand | success | danger | warning | note | min sep |
| --- | --- | --- | --- | --- | --- | --- |
| Cube | 280.3 | *shipped* | | | | — (`{}`, the reference) |
| Ocean | 235 | 165 | 25 | 80 | 315 | 55° |
| Forest | 128 | 172 | 25 | 75 | 300 | 44° |
| Ember | 48 | 155 | 6 | 100 | 300 | 42° |
| Slate | 250 | 160 | 20 | 85 | 312 | 62° |

Statuses stay semantically legible (danger red, warning amber, success green), so `note` does most of the moving and the brand yields where it must — `Forest` sits at moss rather than mid-green to leave room for an emerald success, `Ember` at amber rather than orange to leave room for a crimson danger.

`Slate` demonstrates `pastel: true`. Its saturation goes 30 → 60 because pastel is now what mutes it: 60 under pastel resolves to the same accent chroma a non-pastel 30 does, but even across hues instead of letting the warm statuses run ahead. It also sets `themes.code.saturation: 55`, which is the escape hatch a reader would otherwise expect `pastel` to provide.

## Verification

- 1203 tests pass. Three new specs: `code-*` bit-identical across all four variants under `pastel`; still responsive to its own seed while pastel is on; the mirror's tone still exact.
- The existing snapshot is untouched — `pastel` ships off, so default output does not move.
- Checked all five presets in the running Theme Builder. Resolved dark-scheme accents, e.g. `Forest`: brand `rgb(149,187,98)` (moss) vs success `rgb(99,197,169)` (emerald) — yellow-green vs blue-green, clearly apart. `code-keyword` reads `rgb(226,77,165)` under Cube, Ocean, Forest and Ember alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)