### PR TITLE
feat: export IconSwitch from the package root

### DIFF
--- a/.changeset/tender-mice-invite.md
+++ b/.changeset/tender-mice-invite.md
@@ -1,0 +1,18 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Export `IconSwitch` (and its `CubeIconSwitchProps` type) from the package root.
+
+`IconSwitch` cross-fades between icons when its children change — the animated
+icon swap used inside buttons and items. It already had a stories file and a
+published docs page under `Helpers/IconSwitch`, and `src/components/helpers/index.ts`
+exported it, but that barrel is not re-exported from `src/index.ts` — only
+`DisplayTransition` was pulled through. So the component was publicly documented
+while being impossible to import.
+
+```tsx
+import { IconSwitch } from '@cube-dev/ui-kit';
+
+<IconSwitch>{isLoading ? <LoaderIcon /> : <CheckIcon />}</IconSwitch>;
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,8 @@ export { Root } from './components/Root';
 export type { CubeRootProps } from './components/Root';
 export { DisplayTransition } from './components/helpers/DisplayTransition/DisplayTransition';
 export type { DisplayTransitionProps } from './components/helpers/DisplayTransition/DisplayTransition';
+export { IconSwitch } from './components/helpers/IconSwitch/IconSwitch';
+export type { CubeIconSwitchProps } from './components/helpers/IconSwitch/IconSwitch';
 
 // Navigation types and helpers
 export type {


### PR DESCRIPTION
## What

Exports `IconSwitch` and its `CubeIconSwitchProps` type from `src/index.ts`.

## Why

`IconSwitch` cross-fades between icons when its children change — the animated icon swap used inside buttons and items. It already had:

- a stories file (`IconSwitch.stories.tsx`)
- a published docs page at **Helpers/IconSwitch**
- an export in `src/components/helpers/index.ts`

…but that barrel is **not** re-exported from `src/index.ts`, which pulls `DisplayTransition` through by hand and nothing else. So the component was publicly documented while being impossible to import. Found while auditing docs pages against the built `dist/index.d.ts` — it was the only page documenting something not in the public API.

Added next to the existing `DisplayTransition` export, matching that pattern.

```tsx
import { IconSwitch } from '@cube-dev/ui-kit';

<IconSwitch>{isLoading ? <LoaderIcon /> : <CheckIcon />}</IconSwitch>;
```

## Verification

- `pnpm build` — passes; `IconSwitch` and `CubeIconSwitchProps` now present in `dist/index.d.ts`
- Type-level smoke test against the built `dist/`: `import { IconSwitch } from '@cube-dev/ui-kit'` and `const p: CubeIconSwitchProps = { children: null }` both resolve
- `pnpm test` — **1362 passed**, 1 skipped, 62 files
- `pnpm lint` — clean

## Note

I exported `CubeIconSwitchProps`, the module's canonical interface name, matching `CubeRootProps` / `CubeCardProps` elsewhere. The module also declares an `IconSwitchProps` alias for it; I left that unexported to avoid two public names for one type. Easy to add if you'd rather ship both.

The component has no ESLint-plugin defaults fixture. That registry is partial by design (`covered <= total`), so nothing fails — but now that it is public, adding a fixture would let the plugin know its style defaults. Happy to do that here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API surface only; no runtime behavior changes to IconSwitch itself.
> 
> **Overview**
> **Adds `IconSwitch` and `CubeIconSwitchProps` to the public package API** so consumers can `import { IconSwitch } from '@cube-dev/ui-kit'`, matching how docs and stories already describe usage.
> 
> The helper was only reachable via internal paths because `src/index.ts` re-exported `DisplayTransition` directly but never pulled `IconSwitch` through from the helpers barrel. The change mirrors the existing `DisplayTransition` export pattern in `src/index.ts`.
> 
> A **minor** changeset documents the new public export for `@cube-dev/ui-kit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a663d96736c5e5294eec307d60c1fcf0734cff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->