### PR TITLE
feat(ColorSwatchGroup): add a palette of selectable swatches

### DIFF
--- a/.changeset/color-swatch-group.md
+++ b/.changeset/color-swatch-group.md
@@ -1,0 +1,23 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `ColorSwatchGroup` — a grid of color swatches, one of which can be selected. It is the palette half of choosing a color, where `ColorPicker` is the freeform half.
+
+Colors go in as data rather than as children, so the API reads like `Picker` rather than `RadioGroup`, though a radio group is what it is underneath: one tab stop, arrow keys between swatches.
+
+```jsx
+<ColorSwatchGroup
+  label="Brand color"
+  colors={['#7a4dbf', '#26fcb2', { color: '#ff0000', label: 'Danger' }]}
+  columns={4}
+  value={color}
+  onChange={setColor}
+/>
+```
+
+Swatches are keyed by their canonical hex, so the same color written two ways collapses into one entry — equivalent colors would otherwise make selection ambiguous. That same matching decides which swatch a value selects, so `value` need not use the notation the swatch was written in.
+
+`allowCustom` appends a `ColorPicker` for colors outside the set, showing the current color whenever it is not one of the swatches.
+
+`ColorPicker` gains `swatches` and `swatchColumns`, which put a palette under the editor in its popover. The group drops `allowCustom` there — the escape hatch is itself a `ColorPicker`, so offering it inside one would nest popovers without end. That is enforced through context rather than documented, so the recursion cannot be written by hand either.

--- a/src/components/fields/ColorPicker/ColorPicker.docs.mdx
+++ b/src/components/fields/ColorPicker/ColorPicker.docs.mdx
@@ -42,6 +42,8 @@ readable and pasteable as text.
 - **`theme`** `CubeItemProps['theme']` (default: `default`) — Theme of the trigger
 - **`size`** `CubeItemProps['size']` — Size of the trigger
 - **`triggerTooltip`** `CubeItemProps['tooltip']` — Tooltip for the trigger, separate from the field tooltip
+- **`swatches`** `Array<string | { color: string; label?: string }>` — Colors to offer under the editor, as a [ColorSwatchGroup](/docs/forms-colorswatchgroup--docs)
+- **`swatchColumns`** `number` — How many swatches per row. Defaults to a single row
 - **`isOpen`** `boolean` — Whether the popover is open (controlled)
 - **`defaultOpen`** `boolean` (default: `false`) — Whether the popover is open initially
 - **`onOpenChange`** `(isOpen: boolean) => void` — Fired when the popover opens or closes
@@ -91,6 +93,18 @@ The `mods` property accepts the following modifiers you can override:
 | `placeholder` | `boolean` | No color is selected yet             |
 
 The swatch carries its own `empty` modifier while there is no color to show.
+
+### A palette under the editor
+
+Pass `swatches` and a [ColorSwatchGroup](/docs/forms-colorswatchgroup--docs)
+appears below the channels, so a common color is one press away.
+
+```jsx
+<ColorPicker label="Brand color" swatches={palette} swatchColumns={4} />
+```
+
+That group never offers its own custom-color escape hatch, since the escape
+hatch is a `ColorPicker` and would nest popovers without end.
 
 ## Examples
 

--- a/src/components/fields/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/fields/ColorPicker/ColorPicker.stories.tsx
@@ -70,6 +70,14 @@ export default {
       control: { type: null },
       description: 'Tooltip for the trigger, separate from the field tooltip',
     },
+    swatches: {
+      control: { type: 'object' },
+      description: 'Colors to offer under the editor, as a ColorSwatchGroup',
+    },
+    swatchColumns: {
+      control: { type: 'number' },
+      description: 'How many swatches per row. Defaults to a single row',
+    },
 
     /* State */
     isOpen: {
@@ -177,6 +185,31 @@ export const Validation: StoryFn<CubeColorPickerProps> = (args) => (
     <ColorPicker {...args} label="Invalid" isInvalid defaultValue="#ff0000" />
   </Space>
 );
+
+export const WithSwatches = Template.bind({});
+WithSwatches.args = {
+  defaultValue: '#7a4dbf',
+  defaultOpen: true,
+  swatchColumns: 4,
+  swatches: [
+    '#7a4dbf',
+    '#26fcb2',
+    '#ff0000',
+    '#ff8800',
+    '#ffd400',
+    '#00a3ff',
+    '#0044cc',
+    '#111111',
+  ],
+};
+WithSwatches.parameters = {
+  docs: {
+    description: {
+      story:
+        'A palette under the editor, so a common color is one press away. It never offers a custom-color escape hatch here — that hatch is a picker, and would nest popovers without end.',
+    },
+  },
+};
 
 export const Open = Template.bind({});
 Open.args = { defaultValue: '#7a4dbf', defaultOpen: true };

--- a/src/components/fields/ColorPicker/ColorPicker.test.tsx
+++ b/src/components/fields/ColorPicker/ColorPicker.test.tsx
@@ -140,6 +140,30 @@ describe('<ColorPicker />', () => {
     );
   });
 
+  it('leaves an open panel uneditable while read-only', async () => {
+    // Disabling the trigger only stops it being opened; a controlled or
+    // default-open popover would otherwise stay fully editable.
+    const { getByRole, getAllByRole } = renderWithRoot(
+      <ColorPicker
+        aria-label="Brand"
+        defaultValue="#ff0000"
+        swatches={['#7a4dbf', '#26fcb2']}
+        defaultOpen
+        isReadOnly
+      />,
+    );
+
+    await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+
+    for (const slider of getAllByRole('slider')) {
+      expect(slider).toBeDisabled();
+    }
+
+    for (const swatch of getAllByRole('radio')) {
+      expect(swatch).toBeDisabled();
+    }
+  }, 10000);
+
   it('does not open while disabled', async () => {
     const { getByRole, queryByRole } = renderWithRoot(
       <ColorPicker aria-label="Brand" defaultValue="#ff0000" isDisabled />,

--- a/src/components/fields/ColorPicker/ColorPicker.tsx
+++ b/src/components/fields/ColorPicker/ColorPicker.tsx
@@ -36,6 +36,8 @@ import {
 } from '../color/color';
 import { ColorPanel } from '../color/ColorPanel';
 import { ColorSwatch } from '../color/ColorSwatch';
+import { ColorPopoverContext } from '../color/context';
+import { ColorSwatchGroup, CubeColorSwatchItem } from '../ColorSwatchGroup';
 
 /** What the popover starts from when there is no color to edit yet. */
 const FALLBACK_COLOR: ColorValue = { h: 264, s: 0.8, l: 0.6 };
@@ -84,6 +86,10 @@ export interface CubeColorPickerProps
   theme?: CubeItemProps['theme'];
   /** Tooltip for the trigger, separate from the field tooltip. */
   triggerTooltip?: CubeItemProps['tooltip'];
+  /** Colors to offer under the editor, for picking without dialing one in. */
+  swatches?: CubeColorSwatchItem[];
+  /** How many swatches per row. Defaults to a single row. */
+  swatchColumns?: number;
   styles?: Styles;
   /** Styles of the trigger button. */
   triggerStyles?: Styles;
@@ -127,6 +133,8 @@ export const ColorPicker = forwardRef(function ColorPicker(
     type = 'outline',
     theme = 'default',
     triggerTooltip,
+    swatches,
+    swatchColumns,
     triggerStyles,
     swatchStyles,
     isDisabled,
@@ -163,6 +171,14 @@ export const ColorPicker = forwardRef(function ColorPicker(
     emitted.current = text;
     setColor(next);
     onChange?.(text);
+  });
+
+  const colorText = color ? formatColor(color, format) : null;
+
+  const handleSwatchChange = useEvent((next: string | null) => {
+    const parsed = next ? parseColor(next) : null;
+
+    if (parsed) handleColorChange(parsed);
   });
 
   const handleOpenChange = useEvent((next: boolean) => {
@@ -214,14 +230,32 @@ export const ColorPicker = forwardRef(function ColorPicker(
           {label}
         </ItemButton>
         <Dialog aria-label="Color picker" width="max-content">
-          <ColorPanel
-            color={color ?? FALLBACK_COLOR}
-            space={space}
-            isDisabled={isDisabled}
-            previewFormat={format}
-            onChange={handleColorChange}
-            onSpaceChange={setSpace}
-          />
+          {/* Marks the subtree so a nested swatch group drops its custom-color
+              escape hatch, which is a picker and would recurse forever. */}
+          <ColorPopoverContext.Provider value={true}>
+            <ColorPanel
+              color={color ?? FALLBACK_COLOR}
+              space={space}
+              isDisabled={isDisabled}
+              previewFormat={format}
+              swatches={
+                swatches?.length ? (
+                  <ColorSwatchGroup
+                    aria-label="Palette"
+                    size="small"
+                    colors={swatches}
+                    columns={swatchColumns}
+                    format={format}
+                    value={colorText}
+                    isDisabled={isDisabled}
+                    onChange={handleSwatchChange}
+                  />
+                ) : null
+              }
+              onChange={handleColorChange}
+              onSpaceChange={setSpace}
+            />
+          </ColorPopoverContext.Provider>
         </Dialog>
       </DialogTrigger>
     </ColorPickerWrapper>

--- a/src/components/fields/ColorPicker/ColorPicker.tsx
+++ b/src/components/fields/ColorPicker/ColorPicker.tsx
@@ -138,6 +138,7 @@ export const ColorPicker = forwardRef(function ColorPicker(
     triggerStyles,
     swatchStyles,
     isDisabled,
+    isReadOnly,
     isLoading,
     isInvalid,
     isValid,
@@ -221,7 +222,7 @@ export const ColorPicker = forwardRef(function ColorPicker(
           icon={<ColorSwatch color={color} styles={swatchStyles} />}
           rightIcon={getValidationIcon({ isInvalid, isValid })}
           tooltip={triggerTooltip}
-          isDisabled={isDisabled || isLoading}
+          isDisabled={isDisabled || isLoading || isReadOnly}
           autoFocus={autoFocus}
           aria-label={ariaLabel}
           mods={{ placeholder: !color }}

--- a/src/components/fields/ColorPicker/ColorPicker.tsx
+++ b/src/components/fields/ColorPicker/ColorPicker.tsx
@@ -237,7 +237,7 @@ export const ColorPicker = forwardRef(function ColorPicker(
             <ColorPanel
               color={color ?? FALLBACK_COLOR}
               space={space}
-              isDisabled={isDisabled}
+              isDisabled={isDisabled || isReadOnly}
               previewFormat={format}
               swatches={
                 swatches?.length ? (
@@ -248,7 +248,7 @@ export const ColorPicker = forwardRef(function ColorPicker(
                     columns={swatchColumns}
                     format={format}
                     value={colorText}
-                    isDisabled={isDisabled}
+                    isDisabled={isDisabled || isReadOnly}
                     onChange={handleSwatchChange}
                   />
                 ) : null

--- a/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.docs.mdx
+++ b/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.docs.mdx
@@ -1,0 +1,202 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+
+import * as ColorSwatchGroupStories from './ColorSwatchGroup.stories.tsx';
+
+<Meta of={ColorSwatchGroupStories} />
+
+# ColorSwatchGroup
+
+A grid of color swatches, one of which can be selected. It is the palette half
+of choosing a color, where [ColorPicker](/docs/forms-colorpicker--docs) is the
+freeform half — and the two compose: pass `swatches` to a `ColorPicker` and the
+palette appears under the editor.
+
+Under the hood it is a radio group, so one tab stop and arrow keys move between
+swatches. The API is shaped after `Picker` rather than `RadioGroup`: colors go in
+as data, not as children.
+
+## When to Use
+
+- A brand or theme palette where freeform color would be wrong
+- Chart series, tag and label colors — a small approved set
+- Inside a `ColorPicker` popover, as a shortcut past the sliders
+
+## Component
+
+<Story of={ColorSwatchGroupStories.WithSelection} />
+
+---
+
+### Properties
+
+- **`colors`** `Array<string | { color: string; label?: string }>` — The colors to offer
+- **`value`** `string | null` — The selected color (controlled)
+- **`defaultValue`** `string | null` — The selected color (uncontrolled)
+- **`onChange`** `(value: string | null) => void` — Fired with the chosen color, written in `format`
+- **`format`** `'hex' | 'rgb' | 'hsl' | 'okhsl' | 'okhst' | 'oklch'` (default: `hex`) — Notation the value is written in
+- **`columns`** `number` — How many swatches per row. Defaults to a single row
+- **`allowCustom`** `boolean` (default: `false`) — Append a `ColorPicker` for colors outside the set
+- **`size`** `'small' | 'medium' | 'large'` (default: `medium`) — Size of each swatch
+
+### Base Properties
+
+Supports [Base properties](/docs/getting-started-base-properties--docs)
+
+### Field Properties
+
+Supports all [Field properties](/docs/getting-started-field-properties--docs)
+
+### Styling Properties
+
+#### styles
+
+Customizes the grid.
+
+#### swatchStyles
+
+Customizes an individual swatch.
+
+### Style Properties
+
+These properties allow direct style application without using the `styles` prop:
+
+- **Position:** `gridArea`, `order`, `gridColumn`, `gridRow`, `placeSelf`, `alignSelf`, `justifySelf`, `zIndex`, `margin`, `inset`, `position`, `scrollMargin`
+- **Dimension:** `width`, `height`, `flexBasis`, `flexGrow`, `flexShrink`, `flex`
+- **Block:** `border`, `radius`, `shadow`, `outline`
+
+### Modifiers
+
+The `mods` property accepts the following modifiers you can override:
+
+| Modifier   | Type      | Description                        |
+| ---------- | --------- | ---------------------------------- |
+| `selected` | `boolean` | The swatch is the selected color   |
+| `disabled` | `boolean` | The group is disabled              |
+
+## Swatches must be unique
+
+Equivalent colors are collapsed into one swatch, because two entries for the
+same color make selection ambiguous — there would be no way to say which one is
+selected. Matching is done on the canonical hex, so `#ff0000`, `rgb(255 0 0)`
+and `hsl(0 100% 50%)` are one swatch, not three.
+
+<Story of={ColorSwatchGroupStories.Deduplicated} />
+
+The same matching decides which swatch a value selects, so `value` need not be
+written in the same notation as the swatch it refers to.
+
+## Examples
+
+### Basic usage
+
+```jsx
+<ColorSwatchGroup
+  label="Brand color"
+  colors={['#7a4dbf', '#26fcb2', '#ff0000']}
+  value={color}
+  onChange={setColor}
+/>
+```
+
+### Wrapping onto rows
+
+Without `columns` the swatches sit on a single row.
+
+<Story of={ColorSwatchGroupStories.Columns} />
+
+```jsx
+<ColorSwatchGroup colors={palette} columns={4} />
+```
+
+### Naming the swatches
+
+A swatch announces its color by default, which is rarely the most useful thing
+to hear. Give the colors names when they have them.
+
+<Story of={ColorSwatchGroupStories.Named} />
+
+```jsx
+<ColorSwatchGroup
+  colors={[
+    { color: '#7a4dbf', label: 'Primary' },
+    { color: '#26fcb2', label: 'Success' },
+  ]}
+/>
+```
+
+### Allowing a color outside the set
+
+<Story of={ColorSwatchGroupStories.AllowCustom} />
+
+```jsx
+<ColorSwatchGroup colors={palette} allowCustom />
+```
+
+The trailing picker shows the current color whenever that color is not one of
+the swatches, so a custom choice stays visible.
+
+### Inside a ColorPicker
+
+<Story of={ColorSwatchGroupStories.InsideColorPicker} />
+
+```jsx
+<ColorPicker label="Brand color" swatches={palette} swatchColumns={4} />
+```
+
+`allowCustom` is ignored there, and deliberately so: the escape hatch is itself
+a `ColorPicker`, so offering it inside one would nest popovers without end. The
+group reads a context the popover provides, which means the recursion cannot be
+written even by hand.
+
+## Accessibility
+
+### Keyboard Navigation
+
+- `Tab` — moves focus into the group, landing on the selected swatch
+- `Left` / `Right`, `Up` / `Down` — move between swatches, selecting as they go
+- `Space` — selects the focused swatch
+
+### Screen Reader Support
+
+- The group announces as a radiogroup, named by its label or `aria-label`
+- Each swatch announces as a radio named by its `label`, or by its color
+- Give the group a name: "radiogroup" alone says nothing about what is chosen
+
+### ARIA Properties
+
+- `aria-label` — names the group when there is no visible label
+
+## Best Practices
+
+1. **Do**: name the colors when they mean something
+
+   ```jsx
+   <ColorSwatchGroup colors={[{ color: '#ff0000', label: 'Danger' }]} />
+   ```
+
+2. **Don't**: pass the same color twice expecting two swatches — one is dropped
+
+   ```jsx
+   <ColorSwatchGroup colors={['#ff0000', 'rgb(255 0 0)']} />
+   ```
+
+3. **Do**: reach for `allowCustom` only where a color outside the palette is
+   genuinely acceptable. A fixed set is the point of this component.
+
+## Integration with Forms
+
+This component supports all
+[Field properties](/docs/getting-started-field-properties--docs) when used
+within a Form. The field value is the color string.
+
+## Suggested Improvements
+
+- Sections with headings, for palettes with more than one group
+- An optional "no color" swatch that clears the value
+- Multi-selection, for palettes that build a series
+
+## Related Components
+
+- [ColorPicker](/docs/forms-colorpicker--docs) — freeform color behind a swatch button
+- [ColorInput](/docs/forms-colorinput--docs) — freeform color as editable text
+- [RadioGroup](/docs/forms-radiogroup--docs) — the selection primitive this is built on

--- a/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.stories.tsx
+++ b/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.stories.tsx
@@ -1,0 +1,194 @@
+import { StoryFn } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { VALIDATION_ARGS } from '../../../stories/FormFieldArgs';
+import { baseProps } from '../../../stories/lists/baseProps';
+import { Flow } from '../../layout/Flow';
+import { ColorPicker } from '../ColorPicker';
+
+import {
+  ColorSwatchGroup,
+  CubeColorSwatchGroupProps,
+} from './ColorSwatchGroup';
+
+const PALETTE = [
+  '#7a4dbf',
+  '#26fcb2',
+  '#ff0000',
+  '#ff8800',
+  '#ffd400',
+  '#00a3ff',
+  '#0044cc',
+  '#111111',
+];
+
+export default {
+  title: 'Forms/ColorSwatchGroup',
+  component: ColorSwatchGroup,
+  parameters: { controls: { exclude: baseProps } },
+  args: { colors: PALETTE },
+  argTypes: {
+    /* Content */
+    colors: {
+      control: { type: 'object' },
+      description:
+        'The colors to offer. Either strings, or `{ color, label }` to name them',
+    },
+    value: {
+      control: { type: 'text' },
+      description: 'The selected color in controlled mode',
+    },
+    defaultValue: {
+      control: { type: 'text' },
+      description: 'The selected color in uncontrolled mode',
+    },
+
+    /* Presentation */
+    columns: {
+      control: { type: 'number' },
+      description: 'How many swatches per row. Defaults to a single row',
+    },
+    size: {
+      options: ['small', 'medium', 'large'],
+      control: { type: 'radio' },
+      description: 'Size of each swatch',
+      table: { defaultValue: { summary: 'medium' } },
+    },
+    format: {
+      options: ['hex', 'rgb', 'hsl', 'okhsl', 'okhst', 'oklch'],
+      control: { type: 'radio' },
+      description: 'Notation the value is written in',
+      table: { defaultValue: { summary: 'hex' } },
+    },
+
+    /* Behavior */
+    allowCustom: {
+      control: { type: 'boolean' },
+      description:
+        'Append a `ColorPicker` for colors outside the set. Ignored inside a color popover',
+      table: { defaultValue: { summary: false } },
+    },
+
+    /* State */
+    isDisabled: {
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: false } },
+    },
+    isRequired: {
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: false } },
+    },
+    ...VALIDATION_ARGS,
+
+    /* Events */
+    onChange: {
+      action: 'change',
+      description: 'Callback fired when a color is chosen',
+      control: { type: null },
+    },
+
+    /* Styling */
+    swatchStyles: {
+      control: { type: null },
+      table: { type: { summary: 'Styles' } },
+    },
+  },
+};
+
+const Template: StoryFn<CubeColorSwatchGroupProps> = (props) => (
+  <ColorSwatchGroup aria-label="Palette" {...props} />
+);
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const WithSelection = Template.bind({});
+WithSelection.args = { defaultValue: '#26fcb2' };
+
+export const Columns = Template.bind({});
+Columns.args = { defaultValue: '#7a4dbf', columns: 4 };
+Columns.parameters = {
+  docs: {
+    description: {
+      story: 'Without `columns` the swatches sit on one row.',
+    },
+  },
+};
+
+export const AllowCustom = Template.bind({});
+AllowCustom.args = { defaultValue: '#26fcb2', allowCustom: true };
+AllowCustom.parameters = {
+  docs: {
+    description: {
+      story:
+        'The trailing picker covers colors outside the set. It shows the current color whenever that color is not one of the swatches.',
+    },
+  },
+};
+
+export const Named = Template.bind({});
+Named.args = {
+  colors: [
+    { color: '#7a4dbf', label: 'Primary' },
+    { color: '#26fcb2', label: 'Success' },
+    { color: '#ff0000', label: 'Danger' },
+    { color: '#ffd400', label: 'Warning' },
+  ],
+  defaultValue: '#7a4dbf',
+};
+Named.parameters = {
+  docs: {
+    description: {
+      story:
+        'A swatch announces its color by default. `label` replaces that with a name.',
+    },
+  },
+};
+
+export const Deduplicated = Template.bind({});
+Deduplicated.args = {
+  colors: ['#ff0000', 'rgb(255 0 0)', 'hsl(0 100% 50%)', '#26fcb2'],
+};
+Deduplicated.parameters = {
+  docs: {
+    description: {
+      story:
+        'The first three are the same color written three ways, so only two swatches render — equivalent colors would make selection ambiguous.',
+    },
+  },
+};
+
+export const Sizes: StoryFn<CubeColorSwatchGroupProps> = (args) => (
+  <Flow gap="2x">
+    <ColorSwatchGroup {...args} aria-label="Small" size="small" />
+    <ColorSwatchGroup {...args} aria-label="Medium" size="medium" />
+    <ColorSwatchGroup {...args} aria-label="Large" size="large" />
+  </Flow>
+);
+Sizes.args = { defaultValue: '#7a4dbf' };
+
+export const Disabled = Template.bind({});
+Disabled.args = { defaultValue: '#7a4dbf', isDisabled: true };
+
+export const InsideColorPicker: StoryFn<CubeColorSwatchGroupProps> = () => {
+  const [color, setColor] = useState<string | null>('#7a4dbf');
+
+  return (
+    <ColorPicker
+      label="Brand color"
+      value={color}
+      swatches={PALETTE}
+      swatchColumns={4}
+      defaultOpen
+      onChange={setColor}
+    />
+  );
+};
+InsideColorPicker.parameters = {
+  docs: {
+    description: {
+      story:
+        'Passing `swatches` to a `ColorPicker` puts a palette under the editor. The group drops its custom-color escape hatch there, since that escape hatch is itself a picker.',
+    },
+  },
+};

--- a/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.test.tsx
+++ b/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.test.tsx
@@ -97,6 +97,32 @@ describe('<ColorSwatchGroup />', () => {
     expect(getByRole('radio', { name: '#7a4dbf' })).not.toBeChecked();
   });
 
+  it('shows a focus ring on the focused swatch', async () => {
+    // The swatch is all a keyboard user can see, so without this there is no
+    // way to tell which one is focused.
+    const { getByRole, getAllByTestId } = renderWithRoot(
+      <ColorSwatchGroup aria-label="Palette" colors={PALETTE} />,
+    );
+
+    await userEvent.tab();
+
+    expect(getByRole('radio', { name: '#7a4dbf' })).toHaveFocus();
+    expect(getAllByTestId('ColorSwatchOption')[0]).toHaveAttribute(
+      'data-focused',
+    );
+  });
+
+  it('lets a visible label name the group', () => {
+    // A hardcoded aria-label would outrank the label React Aria wires up.
+    const { getByRole } = renderWithRoot(
+      <ColorSwatchGroup label="Brand color" colors={PALETTE} />,
+    );
+
+    expect(
+      getByRole('radiogroup', { name: 'Brand color' }),
+    ).toBeInTheDocument();
+  });
+
   it('lays the swatches out in the requested number of columns', () => {
     const { getByTestId } = renderWithRoot(
       <ColorSwatchGroup aria-label="Palette" colors={PALETTE} columns={2} />,
@@ -118,6 +144,21 @@ describe('<ColorSwatchGroup />', () => {
       );
 
       expect(queryByTestId('ColorSwatchGroupCustom')).toBeInTheDocument();
+    });
+
+    it('locks the picker when the group is read-only', () => {
+      // Read-only stops the swatches through the radio state; the picker is a
+      // separate control and would otherwise stay live.
+      const { getByTestId } = renderWithRoot(
+        <ColorSwatchGroup
+          aria-label="Palette"
+          colors={PALETTE}
+          allowCustom
+          isReadOnly
+        />,
+      );
+
+      expect(getByTestId('ColorSwatchGroupCustom')).toBeDisabled();
     });
 
     it('drops the picker inside a color popover, where it would recurse', async () => {

--- a/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.test.tsx
+++ b/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.test.tsx
@@ -1,0 +1,145 @@
+import {
+  renderWithForm,
+  renderWithRoot,
+  userEvent,
+  waitFor,
+} from '../../../test';
+import { ColorPicker } from '../ColorPicker';
+
+import { ColorSwatchGroup } from './ColorSwatchGroup';
+
+vi.mock('../../../_internal/hooks/use-warn');
+
+const PALETTE = ['#7a4dbf', '#26fcb2', '#ff0000'];
+
+describe('<ColorSwatchGroup />', () => {
+  it('renders one swatch per color', () => {
+    const { getAllByRole } = renderWithRoot(
+      <ColorSwatchGroup aria-label="Palette" colors={PALETTE} />,
+    );
+
+    expect(getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('collapses the same color written different ways', () => {
+    // Equivalent colors would make selection ambiguous, so only one survives.
+    const { getAllByRole } = renderWithRoot(
+      <ColorSwatchGroup
+        aria-label="Palette"
+        colors={['#ff0000', 'rgb(255 0 0)', 'hsl(0 100% 50%)', '#26fcb2']}
+      />,
+    );
+
+    expect(getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('announces each swatch by its color', () => {
+    const { getByRole } = renderWithRoot(
+      <ColorSwatchGroup aria-label="Palette" colors={PALETTE} />,
+    );
+
+    expect(getByRole('radio', { name: '#7a4dbf' })).toBeInTheDocument();
+  });
+
+  it('prefers a given label over the color', () => {
+    const { getByRole } = renderWithRoot(
+      <ColorSwatchGroup
+        aria-label="Palette"
+        colors={[{ color: '#7a4dbf', label: 'Primary' }]}
+      />,
+    );
+
+    expect(getByRole('radio', { name: 'Primary' })).toBeInTheDocument();
+  });
+
+  it('marks the swatch matching the value, whatever notation it is in', () => {
+    const { getByRole } = renderWithRoot(
+      <ColorSwatchGroup
+        aria-label="Palette"
+        colors={PALETTE}
+        value="rgb(38 252 178)"
+      />,
+    );
+
+    expect(getByRole('radio', { name: '#26fcb2' })).toBeChecked();
+  });
+
+  it('publishes the chosen color in the requested notation', async () => {
+    const onChange = vi.fn();
+    const { getByRole } = renderWithRoot(
+      <ColorSwatchGroup
+        aria-label="Palette"
+        colors={PALETTE}
+        format="oklch"
+        onChange={onChange}
+      />,
+    );
+
+    await userEvent.click(
+      getByRole('radio', { name: 'oklch(0.8789 0.1857 162.47)' }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith('oklch(0.8789 0.1857 162.47)');
+  });
+
+  it('tracks the selection when uncontrolled', async () => {
+    const { getByRole } = renderWithRoot(
+      <ColorSwatchGroup
+        aria-label="Palette"
+        colors={PALETTE}
+        defaultValue="#7a4dbf"
+      />,
+    );
+
+    await userEvent.click(getByRole('radio', { name: '#ff0000' }));
+
+    expect(getByRole('radio', { name: '#ff0000' })).toBeChecked();
+    expect(getByRole('radio', { name: '#7a4dbf' })).not.toBeChecked();
+  });
+
+  it('lays the swatches out in the requested number of columns', () => {
+    const { getByTestId } = renderWithRoot(
+      <ColorSwatchGroup aria-label="Palette" colors={PALETTE} columns={2} />,
+    );
+
+    expect(getByTestId('ColorSwatchGroup')).toHaveStyle({ '--columns': '2' });
+  });
+
+  describe('custom colors', () => {
+    it('appends a picker when allowed', () => {
+      const { queryByTestId, rerender } = renderWithRoot(
+        <ColorSwatchGroup aria-label="Palette" colors={PALETTE} />,
+      );
+
+      expect(queryByTestId('ColorSwatchGroupCustom')).not.toBeInTheDocument();
+
+      rerender(
+        <ColorSwatchGroup aria-label="Palette" colors={PALETTE} allowCustom />,
+      );
+
+      expect(queryByTestId('ColorSwatchGroupCustom')).toBeInTheDocument();
+    });
+
+    it('drops the picker inside a color popover, where it would recurse', async () => {
+      // The escape hatch is itself a ColorPicker, so offering it inside one
+      // would nest popovers without end.
+      const { getByRole, queryByTestId } = renderWithRoot(
+        <ColorPicker aria-label="Brand" swatches={PALETTE} defaultOpen />,
+      );
+
+      await waitFor(() => expect(getByRole('dialog')).toBeInTheDocument());
+
+      expect(queryByTestId('ColorSwatchGroupCustom')).not.toBeInTheDocument();
+    }, 10000);
+  });
+
+  it('registers with a form and publishes the chosen color', async () => {
+    const { getByRole, formInstance } = renderWithForm(
+      <ColorSwatchGroup name="accent" label="Accent" colors={PALETTE} />,
+    );
+
+    await userEvent.click(getByRole('radio', { name: '#ff0000' }));
+
+    expect(formInstance.getFieldValue('accent')).toBe('#ff0000');
+  });
+});

--- a/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.tsx
+++ b/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.tsx
@@ -13,6 +13,7 @@ import { useRadioGroupState } from 'react-stately';
 import { useEvent } from '../../../_internal';
 import { FieldBaseProps } from '../../../shared';
 import { mergeProps } from '../../../utils/react';
+import { useFocus } from '../../../utils/react/interactions';
 import { extractStyles } from '../../../utils/styles';
 import { getValidationMods, useFieldProps, wrapWithField } from '../../form';
 import { HiddenInput } from '../../HiddenInput';
@@ -144,6 +145,9 @@ function Swatch({
     state,
     inputRef,
   );
+  // `useRadio` reports selection but not focus, and the swatch is the only
+  // thing a keyboard user can see — without this the ring never appears.
+  const { isFocused, focusProps } = useFocus({ isDisabled }, true);
 
   return (
     <SwatchElement
@@ -151,13 +155,14 @@ function Swatch({
       mods={{
         selected: isSelected,
         disabled: isRadioDisabled,
+        focused: isFocused,
         ...mods,
       }}
       styles={styles}
       style={{ '--color-swatch-color': colorKey }}
     >
       <HiddenInput
-        {...inputProps}
+        {...mergeProps(inputProps, focusProps)}
         ref={inputRef}
         qa="ColorSwatchInput"
         mods={{ button: true, disabled: isRadioDisabled }}
@@ -263,10 +268,12 @@ export const ColorSwatchGroup = forwardRef(function ColorSwatchGroup(
   });
 
   const domRef = useFocusableRef(ref as any, useRef(null));
-  const { radioGroupProps } = useRadioGroup(
+  const { radioGroupProps, labelProps } = useRadioGroup(
     {
       ...props,
-      'aria-label': ariaLabel ?? 'Colors',
+      // Only name the group here when nothing else does: an `aria-label` set
+      // unconditionally would outrank the visible label React Aria wires up.
+      'aria-label': props.label ? undefined : ariaLabel ?? 'Colors',
       orientation: 'horizontal',
     },
     state,
@@ -304,6 +311,7 @@ export const ColorSwatchGroup = forwardRef(function ColorSwatchGroup(
           size="small"
           value={isCustom ? currentValue ?? null : null}
           isDisabled={isDisabled}
+          isReadOnly={props.isReadOnly}
           triggerStyles={CUSTOM_TRIGGER_STYLES}
           onChange={publish}
         >
@@ -313,7 +321,10 @@ export const ColorSwatchGroup = forwardRef(function ColorSwatchGroup(
     </GroupElement>
   );
 
-  return wrapWithField(group, domRef, props);
+  return wrapWithField(group, domRef, {
+    ...props,
+    labelProps: mergeProps(props.labelProps, labelProps),
+  });
 });
 
 (ColorSwatchGroup as any).cubeInputType = 'Picker';

--- a/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.tsx
+++ b/src/components/fields/ColorSwatchGroup/ColorSwatchGroup.tsx
@@ -1,0 +1,319 @@
+import { useFocusableRef } from '@react-spectrum/utils';
+import {
+  BaseProps,
+  OUTER_STYLES,
+  OuterStyleProps,
+  Styles,
+  tasty,
+} from '@tenphi/tasty';
+import { ForwardedRef, forwardRef, useMemo, useRef, useState } from 'react';
+import { useRadio, useRadioGroup } from 'react-aria';
+import { useRadioGroupState } from 'react-stately';
+
+import { useEvent } from '../../../_internal';
+import { FieldBaseProps } from '../../../shared';
+import { mergeProps } from '../../../utils/react';
+import { extractStyles } from '../../../utils/styles';
+import { getValidationMods, useFieldProps, wrapWithField } from '../../form';
+import { HiddenInput } from '../../HiddenInput';
+import { ColorFormat, formatColor, parseColor, toHex } from '../color/color';
+import { useIsInsideColorPopover } from '../color/context';
+import { ColorPicker } from '../ColorPicker';
+
+import type { RadioGroupState } from 'react-stately';
+
+/** A swatch: a color, and optionally a name to announce instead of the color. */
+export type CubeColorSwatchItem = string | { color: string; label?: string };
+
+/** Sized to the swatch, so the trailing picker sits level with the row. */
+const CUSTOM_TRIGGER_STYLES: Styles = {
+  width: '$swatch-size $swatch-size',
+  height: '$swatch-size $swatch-size',
+  padding: '.25x',
+  radius: '1r',
+};
+
+const GroupElement = tasty({
+  qa: 'ColorSwatchGroup',
+  styles: {
+    display: 'grid',
+    gap: '1x',
+    placeItems: 'stretch',
+    width: 'max-content',
+    gridColumns: 'repeat($columns, 1fr)',
+
+    '$swatch-size': {
+      '': '3x',
+      'size=small': '2.5x',
+      'size=large': '4x',
+    },
+  },
+});
+
+const SwatchElement = tasty({
+  as: 'label',
+  qa: 'ColorSwatchOption',
+  styles: {
+    display: 'grid',
+    placeItems: 'stretch',
+    position: 'relative',
+    radius: '1r',
+    cursor: {
+      '': 'pointer',
+      disabled: 'default',
+    },
+    width: '$swatch-size $swatch-size',
+    height: '$swatch-size $swatch-size',
+    fill: '(#color-swatch, #clear)',
+    opacity: {
+      '': 1,
+      disabled: '$disabled-opacity',
+    },
+    // A ring at one border-width's distance, so the color area stays whole —
+    // the inner ring is the surface showing through as the gap. `outline` is
+    // deliberately left to the focus ring.
+    shadow: {
+      '': 'inset 0 0 0 1bw #dark.15',
+      selected:
+        '0 0 0 1bw #surface, 0 0 0 2bw #primary, inset 0 0 0 1bw #dark.15',
+    },
+    outline: {
+      '': '1bw #primary-text.0',
+      focused: '1bw #primary-text',
+    },
+    outlineOffset: 3,
+    transition: 'theme',
+  },
+});
+
+export interface CubeColorSwatchGroupProps
+  extends BaseProps,
+    OuterStyleProps,
+    FieldBaseProps {
+  /** The colors to offer. Duplicates of the same color are dropped. */
+  colors?: CubeColorSwatchItem[];
+  /** The selected color (controlled). */
+  value?: string | null;
+  /** The selected color (uncontrolled). */
+  defaultValue?: string | null;
+  /** Called with the chosen color, written in `format`. */
+  onChange?: (value: string | null) => void;
+  /** Notation the value is written in. */
+  format?: ColorFormat;
+  /** How many swatches per row. Defaults to a single row. */
+  columns?: number;
+  /**
+   * Append a `ColorPicker` for colors outside the set. Ignored inside a color
+   * popover, which is where that picker would otherwise recurse.
+   */
+  allowCustom?: boolean;
+  /** The size of each swatch. */
+  size?: 'small' | 'medium' | 'large' | (string & {});
+  styles?: Styles;
+  /** Styles of an individual swatch. */
+  swatchStyles?: Styles;
+  'aria-label'?: string;
+}
+
+interface SwatchProps {
+  colorKey: string;
+  label: string;
+  state: RadioGroupState;
+  isDisabled?: boolean;
+  size?: string;
+  styles?: Styles;
+  mods?: Record<string, boolean | undefined>;
+}
+
+function Swatch({
+  colorKey,
+  label,
+  state,
+  isDisabled,
+  size,
+  styles,
+  mods,
+}: SwatchProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    inputProps,
+    isSelected,
+    isDisabled: isRadioDisabled,
+  } = useRadio(
+    { value: colorKey, 'aria-label': label, isDisabled },
+    state,
+    inputRef,
+  );
+
+  return (
+    <SwatchElement
+      data-size={size}
+      mods={{
+        selected: isSelected,
+        disabled: isRadioDisabled,
+        ...mods,
+      }}
+      styles={styles}
+      style={{ '--color-swatch-color': colorKey }}
+    >
+      <HiddenInput
+        {...inputProps}
+        ref={inputRef}
+        qa="ColorSwatchInput"
+        mods={{ button: true, disabled: isRadioDisabled }}
+      />
+    </SwatchElement>
+  );
+}
+
+/**
+ * A grid of color swatches, one of which can be selected — the palette half of
+ * choosing a color, where `ColorPicker` is the freeform half.
+ *
+ * Swatches are keyed by their canonical hex, so the same color written two ways
+ * collapses into one entry. Equivalent colors would otherwise make selection
+ * ambiguous.
+ */
+export const ColorSwatchGroup = forwardRef(function ColorSwatchGroup(
+  allProps: CubeColorSwatchGroupProps,
+  ref: ForwardedRef<HTMLElement>,
+) {
+  const props = useFieldProps(allProps, {
+    defaultValidationTrigger: 'onChange',
+    valuePropsMapper: ({ value, onChange }) => ({
+      value: value as string | null | undefined,
+      onChange,
+    }),
+  });
+
+  const {
+    qa,
+    colors = [],
+    value,
+    defaultValue,
+    onChange,
+    format = 'hex',
+    columns,
+    allowCustom,
+    size = 'medium',
+    isDisabled,
+    isInvalid,
+    isValid,
+    swatchStyles,
+    'aria-label': ariaLabel,
+  } = props;
+
+  const styles = extractStyles(props, OUTER_STYLES);
+  const isInsidePopover = useIsInsideColorPopover();
+  // A custom picker inside a color popover would open a popover of its own.
+  const showCustom = allowCustom && !isInsidePopover;
+
+  /** Keyed by canonical hex so the same color written two ways is one swatch. */
+  const swatches = useMemo(() => {
+    const seen = new Map<string, { key: string; label: string }>();
+
+    for (const entry of colors) {
+      const raw = typeof entry === 'string' ? entry : entry.color;
+      const parsed = parseColor(raw);
+
+      if (!parsed) continue;
+
+      const key = toHex(parsed);
+
+      if (seen.has(key)) continue;
+
+      seen.set(key, {
+        key,
+        label:
+          (typeof entry === 'string' ? undefined : entry.label) ??
+          formatColor(parsed, format),
+      });
+    }
+
+    return [...seen.values()];
+  }, [colors, format]);
+
+  const [internalValue, setInternalValue] = useState<string | null>(
+    () => defaultValue ?? null,
+  );
+  const currentValue = value !== undefined ? value : internalValue;
+
+  const selectedColor = parseColor((currentValue ?? '').toString());
+  const selectedKey = selectedColor ? toHex(selectedColor) : null;
+  const isCustom =
+    !!selectedKey && !swatches.some((s) => s.key === selectedKey);
+
+  const publish = useEvent((next: string | null) => {
+    if (value === undefined) setInternalValue(next);
+
+    onChange?.(next);
+  });
+
+  const handleChange = useEvent((nextKey: string) => {
+    const parsed = parseColor(nextKey);
+
+    publish(parsed ? formatColor(parsed, format) : null);
+  });
+
+  const state = useRadioGroupState({
+    value: selectedKey ?? null,
+    isDisabled,
+    isReadOnly: props.isReadOnly,
+    onChange: handleChange,
+  });
+
+  const domRef = useFocusableRef(ref as any, useRef(null));
+  const { radioGroupProps } = useRadioGroup(
+    {
+      ...props,
+      'aria-label': ariaLabel ?? 'Colors',
+      orientation: 'horizontal',
+    },
+    state,
+  );
+
+  const group = (
+    <GroupElement
+      ref={domRef}
+      qa={qa || 'ColorSwatchGroup'}
+      data-size={size}
+      data-input-type="colorswatchgroup"
+      styles={styles}
+      mods={getValidationMods({ isInvalid, isValid })}
+      style={{
+        '--columns': String(columns ?? swatches.length + (showCustom ? 1 : 0)),
+      }}
+      {...mergeProps(radioGroupProps, {})}
+    >
+      {swatches.map((swatch) => (
+        <Swatch
+          key={swatch.key}
+          colorKey={swatch.key}
+          label={swatch.label}
+          state={state}
+          isDisabled={isDisabled}
+          size={size}
+          styles={swatchStyles}
+        />
+      ))}
+      {showCustom ? (
+        <ColorPicker
+          aria-label="Custom color"
+          qa="ColorSwatchGroupCustom"
+          format={format}
+          size="small"
+          value={isCustom ? currentValue ?? null : null}
+          isDisabled={isDisabled}
+          triggerStyles={CUSTOM_TRIGGER_STYLES}
+          onChange={publish}
+        >
+          {null}
+        </ColorPicker>
+      ) : null}
+    </GroupElement>
+  );
+
+  return wrapWithField(group, domRef, props);
+});
+
+(ColorSwatchGroup as any).cubeInputType = 'Picker';

--- a/src/components/fields/ColorSwatchGroup/index.tsx
+++ b/src/components/fields/ColorSwatchGroup/index.tsx
@@ -1,0 +1,5 @@
+export { ColorSwatchGroup } from './ColorSwatchGroup';
+export type {
+  CubeColorSwatchGroupProps,
+  CubeColorSwatchItem,
+} from './ColorSwatchGroup';

--- a/src/components/fields/color/ColorPanel.tsx
+++ b/src/components/fields/color/ColorPanel.tsx
@@ -1,5 +1,5 @@
 import { Styles, tasty } from '@tenphi/tasty';
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 
 import { useEvent } from '../../../_internal';
 import { Radio } from '../RadioGroup';
@@ -113,6 +113,8 @@ export interface ColorPanelProps {
   isDisabled?: boolean;
   /** Notation used for the preview caption. */
   previewFormat: ColorFormat;
+  /** Optional palette rendered under the channels. */
+  swatches?: ReactNode;
   onChange: (color: ColorValue) => void;
   onSpaceChange: (space: ColorSpace) => void;
 }
@@ -167,8 +169,15 @@ function ChannelRow({ channel, color, isDisabled, onChange }: ChannelRowProps) {
  * of the active one.
  */
 export function ColorPanel(props: ColorPanelProps) {
-  const { color, space, isDisabled, previewFormat, onChange, onSpaceChange } =
-    props;
+  const {
+    color,
+    space,
+    isDisabled,
+    previewFormat,
+    swatches,
+    onChange,
+    onSpaceChange,
+  } = props;
 
   const colorTokens = useMemo(
     () => ({
@@ -215,6 +224,7 @@ export function ColorPanel(props: ColorPanelProps) {
           />
         ))}
       </ChannelsElement>
+      {swatches}
     </PanelElement>
   );
 }

--- a/src/components/fields/color/context.ts
+++ b/src/components/fields/color/context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Marks the subtree inside a color popover.
+ *
+ * A `ColorSwatchGroup` offers a custom-color escape hatch, and that escape
+ * hatch is a `ColorPicker` — which opens a popover that may itself contain a
+ * swatch group. Reading this flag lets the group drop the escape hatch when it
+ * is already inside one, so the recursion cannot be written even by accident.
+ */
+export const ColorPopoverContext = createContext(false);
+
+export function useIsInsideColorPopover(): boolean {
+  return useContext(ColorPopoverContext);
+}

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -9,6 +9,7 @@ export * from './Checkbox';
 export * from './color';
 export * from './ColorInput';
 export * from './ColorPicker';
+export * from './ColorSwatchGroup';
 export * from './DatePicker';
 export * from './RadioGroup';
 export * from './SearchInput';

--- a/tasty.config.ts
+++ b/tasty.config.ts
@@ -248,6 +248,8 @@ export default {
     // top of it. Both are set as inline custom properties per render.
     '#color-picker',
     '#color-picker-contrast',
+    // ColorSwatchGroup: the color of an individual swatch, set inline per option.
+    '#color-swatch',
 
     // Custom Property Tokens (from src/tokens/base.ts)
     '$tab-indicator-size',


### PR DESCRIPTION
Adds the palette half of choosing a color. **Stacked on #1293** — review that one first; the base will retarget to `main` once it merges.

## On the name

You floated `ColorRadioPicker`; I'd argue against it, and against `ColorSwatchPicker` too.

React Aria ships this exact component as **`ColorSwatchPicker`**, so that's the industry term. But we just spent #1293 establishing that in this kit **`Picker` means trigger + overlay** — that's the whole basis for splitting `ColorInput` out. `ColorPicker` (button) and `ColorSwatchPicker` (inline grid) sitting in one barrel meaning structurally different things would undo that immediately.

`ColorSwatchGroup` matches `RadioGroup` / `CheckboxGroup` / `ButtonGroup`, which is what it actually is, and pairs with the `ColorSwatch` internal. `ColorRadioPicker` mixes both metaphors and matches neither.

## What React Aria taught me

Their docs carry a constraint I'd have missed: **swatches must be unique.** Equivalent colors in different spaces are duplicates, and duplicates make selection undefined — there's no way to say which of two `#ff0000` entries is selected.

So swatches are keyed by canonical hex. `'#ff0000'`, `'rgb(255 0 0)'` and `'hsl(0 100% 50%)'` collapse to one. The same matching decides which swatch a `value` selects, so `value` needn't use the notation the swatch was written in — there's a test for each.

## Selection styling

I went with your option (b), the ring, drawn with `shadow` rather than `outline`:

```
'0 0 0 1bw #surface, 0 0 0 2bw #primary, inset 0 0 0 1bw #dark.15'
```

The first shadow is the gap, the second the ring — a 1bw ring at 1bw distance. Using `shadow` leaves `outline` free for the focus ring, which the kit uses everywhere; putting selection on `outline` would have collided with it. Option (a) shrinks the color area exactly when you most want to see it.

## The recursion guard is enforced, not documented

`allowCustom` appends a `ColorPicker`, and `ColorPicker` can contain a `ColorSwatchGroup` — so the naive version nests popovers forever. The popover provides a context flag; the group reads it and drops the escape hatch. It can't be written by hand either, not just discouraged.

Verified in the browser: 8 swatches inside the popover, **0** custom triggers, `columns={4}` producing a 4-column grid.

## Notes

- The API is `Picker`-shaped as you asked — `colors` as data, not children — while `useRadioGroup` does the work, so it's one tab stop with arrow-key navigation.
- `colors` takes `string` or `{ color, label }`; a swatch announces its color by default, which is rarely the useful thing to hear.
- `ColorPicker` gains `swatches` / `swatchColumns`.
- The hidden input reuses the kit's `HiddenInput` — my first pass set `pointer-events: none`, which broke clicking. Caught by a test.
- 1384 tests pass (11 new). Bundle 468.02 kB against the 469 kB budget, **no bump needed**; tree shaking unchanged at 121.8 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New form field components with tests and docs; read-only handling is a small behavior fix on ColorPicker with limited blast radius.
> 
> **Overview**
> Introduces **`ColorSwatchGroup`**, a data-driven grid of selectable color swatches (radio-group behavior, `Picker`-style API). Colors dedupe by canonical hex; optional **`allowCustom`** adds a trailing **`ColorPicker`** for values outside the palette.
> 
> **`ColorPicker`** gains **`swatches`** / **`swatchColumns`**, rendering a **`ColorSwatchGroup`** under the editor via **`ColorPanel`’s** new `swatches` slot. **`ColorPopoverContext`** suppresses `allowCustom` inside a popover so nested pickers cannot recurse. **`isReadOnly`** now disables the trigger and locks sliders and palette radios when the popover is already open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48158407a4f381d3b1997f5ad2b8654db3829933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->