### PR TITLE
feat(fields): buffer the typed value so a late echo can't move the caret

### DIFF
--- a/.changeset/buffered-text-values.md
+++ b/.changeset/buffered-text-values.md
@@ -1,0 +1,35 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Keep the caret in place in `TextInput`, `TextArea`, `PasswordInput` and `SearchInput` when the
+controlled value comes back late.
+
+A controlled `<input>` renders whatever string its parent hands it. If the parent hands back the
+pre-keystroke string — because its state arrives through a store that publishes a render late, a
+debounce, or a deferred update — React writes that stale string into the DOM node, and a native
+`value` assignment collapses the selection. Typing in the middle of a field threw the caret to the
+end. The text still landed a render later, so it read as a caret bug rather than a data-flow one.
+
+These four fields now hold the typed text locally until the parent catches up. `onChange` still
+fires once per keystroke with the full value, so nothing downstream changes: no debouncing, no
+commit-on-blur, no coalesced calls. An incoming `value` is adopted whenever it is a genuine change
+from the parent — an undo, a reset, a transformed string, another record — and on blur the parent's
+value takes over again.
+
+Components that already own their typed text are untouched: `NumberInput`, `ComboBox`,
+`SearchComboBox`, `FilterListBox`, `CommandMenu`, `CommandTextArea`, `ColorPicker` and
+`InlineInput`.
+
+Two additions to the public API:
+
+- `useBufferedValue(value, onChange, options)` — the hook behind it, exported for controls that
+  own their own input. It is generic, and `options.getKey` lets non-string values (an array of
+  colour stops rebuilt on every emit) be matched by signature rather than identity.
+- `isBuffered` on the four fields — set it to `false` for a caller that must see the field snap
+  back to its own `value` the instant it declines a keystroke.
+
+```tsx
+// A parent whose state arrives a render late no longer fights the caret.
+<TextInput value={spec.title} onChange={(title) => updateSpec({ title })} />
+```

--- a/src/components/fields/PasswordInput/PasswordInput.tsx
+++ b/src/components/fields/PasswordInput/PasswordInput.tsx
@@ -3,7 +3,7 @@ import { useTextField } from 'react-aria';
 
 import { useI18n } from '../../../i18n';
 import { EyeIcon, EyeInvisibleIcon } from '../../../icons';
-import { mergeProps } from '../../../utils/react';
+import { chain, mergeProps, useBufferedValue } from '../../../utils/react';
 import {
   castNullableStringValue,
   WithNullableValue,
@@ -36,13 +36,25 @@ function PasswordInput(
     suffix,
     multiLine,
     inputRef: propsInputRef,
+    isBuffered,
     ...rest
   } = props;
   let localInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   let inputRef = propsInputRef ?? localInputRef;
+
+  // Hold the typed text locally until the controlled value catches up — see `useBufferedValue`.
+  let buffered = useBufferedValue(rest.value, rest.onChange, {
+    isBuffered,
+    isDisabled: rest.isDisabled,
+    isReadOnly: rest.isReadOnly,
+  });
+
   let { labelProps, inputProps } = useTextField(
     {
       ...rest,
+      value: buffered.value,
+      onChange: buffered.onChange,
+      onBlur: chain(rest.onBlur, buffered.reset),
       type,
     },
     inputRef,

--- a/src/components/fields/SearchInput/SearchInput.tsx
+++ b/src/components/fields/SearchInput/SearchInput.tsx
@@ -4,7 +4,7 @@ import { SearchFieldProps, useSearchFieldState } from 'react-stately';
 
 import { CloseIcon, SearchIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
-import { mergeProps } from '../../../utils/react';
+import { chain, mergeProps, useBufferedValue } from '../../../utils/react';
 import { ariaToCubeButtonProps } from '../../../utils/react/mapProps';
 import {
   castNullableStringValue,
@@ -53,14 +53,29 @@ export const SearchInput = forwardRef(function SearchInput(
     isValid,
     onClear,
     labelProps: userLabelProps,
+    isBuffered,
     ...restProps
   } = props;
 
   let inputRef = useRef(null);
 
-  let state = useSearchFieldState(restProps);
+  // Hold the typed text locally until the controlled value catches up — see `useBufferedValue`.
+  // Applied before the state hook, so `state.value` (and the clear button) follow the draft.
+  let buffered = useBufferedValue(restProps.value, restProps.onChange, {
+    isBuffered,
+    isDisabled: restProps.isDisabled,
+    isReadOnly: restProps.isReadOnly,
+  });
+  let fieldProps = {
+    ...restProps,
+    value: buffered.value,
+    onChange: buffered.onChange,
+    onBlur: chain(restProps.onBlur, buffered.reset),
+  };
+
+  let state = useSearchFieldState(fieldProps);
   let { labelProps, inputProps, clearButtonProps } = useSearchField(
-    restProps,
+    fieldProps,
     state,
     inputRef,
   );

--- a/src/components/fields/TextArea/TextArea.tsx
+++ b/src/components/fields/TextArea/TextArea.tsx
@@ -8,7 +8,7 @@ import {
 import { useTextField } from 'react-aria';
 
 import { useEvent } from '../../../_internal/index';
-import { chain, mergeProps } from '../../../utils/react';
+import { chain, mergeProps, useBufferedValue } from '../../../utils/react';
 import {
   castNullableStringValue,
   WithNullableValue,
@@ -49,6 +49,7 @@ function TextArea(
     labelProps: userLabelProps,
     inputRef: propsInputRef,
     value,
+    isBuffered,
     ...otherProps
   } = props;
 
@@ -96,14 +97,22 @@ function TextArea(
     textarea.style.height = `${totalHeight}px`;
   });
 
+  // Hold the typed text locally until the controlled value catches up — see `useBufferedValue`.
+  const buffered = useBufferedValue(value, onChange, {
+    isBuffered,
+    isDisabled,
+    isReadOnly,
+  });
+
   let { labelProps, inputProps } = useTextField(
     {
       ...otherProps,
-      value,
+      value: buffered.value,
       isDisabled,
       isReadOnly,
       isRequired,
-      onChange: chain(onChange, adjustHeight),
+      onChange: chain(buffered.onChange, adjustHeight),
+      onBlur: chain(otherProps.onBlur, buffered.reset),
       inputElementType: 'textarea',
     },
     inputRef,
@@ -128,12 +137,13 @@ function TextArea(
     return () => resizeObserver.disconnect();
   }, [autoSize, inputRef?.current]);
 
-  // Adjust height when value changes programmatically (controlled mode with autoSize)
+  // Adjust height when value changes programmatically (controlled mode with autoSize).
+  // Keyed on the rendered value, not the prop, so a buffered draft is measured.
   useEnvironmentalEffect(() => {
     if (autoSize && inputRef.current) {
       adjustHeight();
     }
-  }, [value]);
+  }, [buffered.value]);
 
   return (
     <TextInputBase

--- a/src/components/fields/TextInput/TextInput.tsx
+++ b/src/components/fields/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
 import { ForwardedRef, forwardRef, useRef } from 'react';
 import { useTextField } from 'react-aria';
 
-import { mergeProps } from '../../../utils/react';
+import { chain, mergeProps, useBufferedValue } from '../../../utils/react';
 import {
   castNullableStringValue,
   WithNullableValue,
@@ -31,12 +31,29 @@ export const TextInput = forwardRef(function TextInput(
     labelProps: userLabelProps,
     inputRef: propsInputRef,
     form,
+    isBuffered,
     ...restProps
   } = props;
   let localInputRef = useRef<HTMLTextAreaElement | HTMLInputElement>(null);
   let inputRef = propsInputRef ?? localInputRef;
 
-  let { labelProps, inputProps } = useTextField(restProps, inputRef);
+  // Hold the typed text locally until the controlled value catches up, so a parent that echoes it
+  // back a render late can't overwrite the DOM node and throw the caret to the end.
+  let buffered = useBufferedValue(restProps.value, restProps.onChange, {
+    isBuffered,
+    isDisabled: restProps.isDisabled,
+    isReadOnly: restProps.isReadOnly,
+  });
+
+  let { labelProps, inputProps } = useTextField(
+    {
+      ...restProps,
+      value: buffered.value,
+      onChange: buffered.onChange,
+      onBlur: chain(restProps.onBlur, buffered.reset),
+    },
+    inputRef,
+  );
 
   // Merge user-provided labelProps with aria labelProps
   const mergedLabelProps = mergeProps(labelProps, userLabelProps);

--- a/src/components/fields/TextInput/TextInputBase.tsx
+++ b/src/components/fields/TextInput/TextInputBase.tsx
@@ -233,6 +233,13 @@ export interface CubeTextInputBaseProps
   /** The size of the input */
   size?: 'small' | 'medium' | 'large' | (string & {});
   autocomplete?: string;
+  /**
+   * Whether the typed text is held locally until the controlled `value` catches up. On by default,
+   * which is what keeps the caret in place when the value round-trips through a store that
+   * re-renders a pass late. Set to `false` for a caller that must see the value snap back to its
+   * own `value` prop the instant it declines a keystroke. See `useBufferedValue`.
+   */
+  isBuffered?: boolean;
 }
 
 /**

--- a/src/components/fields/buffered-value.test.tsx
+++ b/src/components/fields/buffered-value.test.tsx
@@ -1,0 +1,191 @@
+import { ReactNode, useEffect, useState } from 'react';
+
+import { PasswordInput, SearchInput, TextArea, TextInput } from '../../index';
+import { act, renderWithForm, renderWithRoot, userEvent } from '../../test';
+
+interface FieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  isBuffered?: boolean;
+}
+
+const FIELDS = [
+  {
+    name: 'TextInput',
+    render: (props: FieldProps) => <TextInput label="field" {...props} />,
+  },
+  {
+    name: 'TextArea',
+    render: (props: FieldProps) => <TextArea label="field" {...props} />,
+  },
+  {
+    name: 'PasswordInput',
+    render: (props: FieldProps) => <PasswordInput label="field" {...props} />,
+  },
+  {
+    name: 'SearchInput',
+    render: (props: FieldProps) => <SearchInput label="field" {...props} />,
+  },
+] as const;
+
+/**
+ * A parent that applies every change one commit late — the shape of any value that reaches a
+ * component through a store publishing in a layout effect, a debounce, or a deferred update. The
+ * render immediately after a keystroke still carries the pre-keystroke string, which is exactly
+ * what used to get written back into the DOM node and collapse the selection.
+ */
+function LaggingParent(props: {
+  children: (value: string, onChange: (next: string) => void) => ReactNode;
+  initialValue?: string;
+}) {
+  const { children, initialValue = 'hello' } = props;
+  const [value, setValue] = useState(initialValue);
+  const [inFlight, setInFlight] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (inFlight !== null) {
+      setValue(inFlight);
+      setInFlight(null);
+    }
+  }, [inFlight]);
+
+  return (
+    <>
+      {children(value, setInFlight)}
+      <button data-qa="External" onClick={() => setValue('from elsewhere')}>
+        external
+      </button>
+    </>
+  );
+}
+
+async function typeInto(
+  input: HTMLInputElement,
+  text: string,
+  at: number,
+): Promise<void> {
+  await act(async () => {
+    await userEvent.type(input, text, {
+      initialSelectionStart: at,
+      initialSelectionEnd: at,
+    });
+  });
+}
+
+describe('buffered value in text fields', () => {
+  it.each(FIELDS)(
+    'keeps the caret in place while the parent lags ($name)',
+    async ({ render }) => {
+      const { getByTestId } = renderWithRoot(
+        <LaggingParent>
+          {(value, onChange) => render({ value, onChange })}
+        </LaggingParent>,
+      );
+      const input = getByTestId('Input') as HTMLInputElement;
+
+      await typeInto(input, 'X', 2);
+
+      expect(input).toHaveValue('heXllo');
+      expect(input.selectionStart).toBe(3);
+    },
+  );
+
+  it.each(FIELDS)(
+    'does not lose keystrokes typed before the echo lands ($name)',
+    async ({ render }) => {
+      const { getByTestId } = renderWithRoot(
+        <LaggingParent>
+          {(value, onChange) => render({ value, onChange })}
+        </LaggingParent>,
+      );
+      const input = getByTestId('Input') as HTMLInputElement;
+
+      await typeInto(input, 'XYZ', 2);
+
+      expect(input).toHaveValue('heXYZllo');
+      expect(input.selectionStart).toBe(5);
+    },
+  );
+
+  it.each(FIELDS)(
+    'lets an external change overwrite the draft ($name)',
+    async ({ render }) => {
+      const { getByTestId } = renderWithRoot(
+        <LaggingParent>
+          {(value, onChange) => render({ value, onChange })}
+        </LaggingParent>,
+      );
+      const input = getByTestId('Input') as HTMLInputElement;
+
+      await typeInto(input, 'X', 2);
+      await act(async () => await userEvent.click(getByTestId('External')));
+
+      expect(input).toHaveValue('from elsewhere');
+    },
+  );
+
+  it.each(FIELDS)(
+    'snaps back on blur when the parent declined the keystroke ($name)',
+    async ({ render }) => {
+      const onChange = vi.fn();
+      const { getByTestId } = renderWithRoot(
+        render({ value: 'hello', onChange }),
+      );
+      const input = getByTestId('Input') as HTMLInputElement;
+
+      await typeInto(input, 'X', 2);
+      // The parent never advanced its value, so the typed text is only ours for now.
+      expect(input).toHaveValue('heXllo');
+      expect(onChange).toHaveBeenCalledWith('heXllo');
+
+      await act(async () => await userEvent.tab());
+
+      expect(input).toHaveValue('hello');
+    },
+  );
+
+  describe('inside a Form', () => {
+    it('keeps the form value and the DOM in step', async () => {
+      const { getByTestId, formInstance } = renderWithForm(
+        <TextInput label="field" name="field" />,
+      );
+      const input = getByTestId('Input') as HTMLInputElement;
+
+      await typeInto(input, 'abc', 0);
+
+      expect(input).toHaveValue('abc');
+      expect(formInstance.getFieldValue('field')).toBe('abc');
+
+      // A programmatic write from outside has to win over the buffer.
+      await act(async () => {
+        formInstance.setFieldValue('field', 'from the form');
+      });
+
+      expect(input).toHaveValue('from the form');
+    });
+  });
+
+  // The negative control: the same harness with buffering off is the bug this all exists for. The
+  // text still lands — React writes the stale string, then the echo — but the caret is left at the
+  // end of the field instead of after the character that was just typed.
+  it('loses the caret with isBuffered={false}', async () => {
+    const { getByTestId } = renderWithRoot(
+      <LaggingParent>
+        {(value, onChange) => (
+          <TextInput
+            label="field"
+            value={value}
+            onChange={onChange}
+            isBuffered={false}
+          />
+        )}
+      </LaggingParent>,
+    );
+    const input = getByTestId('Input') as HTMLInputElement;
+
+    await typeInto(input, 'X', 2);
+
+    expect(input).toHaveValue('heXllo');
+    expect(input.selectionStart).toBe('heXllo'.length);
+  });
+});

--- a/src/utils/react/index.ts
+++ b/src/utils/react/index.ts
@@ -21,3 +21,8 @@ export { useLocalStorage } from './useLocalStorage';
 export { resolveIcon } from './resolveIcon';
 export type { DynamicIcon, IconRenderFn, ResolvedIcon } from './resolveIcon';
 export { useMergeStyles } from './useMergeStyles';
+export { useBufferedValue } from './useBufferedValue';
+export type {
+  UseBufferedValueOptions,
+  UseBufferedValueResult,
+} from './useBufferedValue';

--- a/src/utils/react/useBufferedValue.test.tsx
+++ b/src/utils/react/useBufferedValue.test.tsx
@@ -1,0 +1,205 @@
+import { act, renderHook } from '../../test';
+
+import { useBufferedValue, UseBufferedValueOptions } from './useBufferedValue';
+
+interface Props<T> {
+  value: T | undefined;
+  onChange?: (next: T) => void;
+  options?: UseBufferedValueOptions<T>;
+}
+
+function renderBuffered<T>(initial: Props<T>) {
+  return renderHook(
+    ({ value, onChange, options }: Props<T>) =>
+      useBufferedValue(value, onChange, options),
+    { initialProps: initial },
+  );
+}
+
+describe('useBufferedValue()', () => {
+  describe('while the parent keeps up', () => {
+    it('adopts a value the parent genuinely changed', () => {
+      const { result, rerender } = renderBuffered<string>({ value: 'abc' });
+
+      act(() => result.current.onChange('abxc'));
+      rerender({ value: 'abxc' });
+      expect(result.current.value).toBe('abxc');
+
+      // An undo, a reset, another record loaded into the same field.
+      rerender({ value: 'zzz' });
+      expect(result.current.value).toBe('zzz');
+    });
+
+    it('adopts a value the parent transformed', () => {
+      const onChange = vi.fn();
+      const { result, rerender } = renderBuffered<string>({
+        value: 'abc',
+        onChange,
+      });
+
+      act(() => result.current.onChange('abcd'));
+      // The parent uppercases: a different string, so it wins.
+      rerender({ value: 'ABCD', onChange });
+
+      expect(result.current.value).toBe('ABCD');
+      expect(onChange).toHaveBeenCalledExactlyOnceWith('abcd');
+    });
+  });
+
+  describe('while the parent lags', () => {
+    it('keeps the draft when the parent re-renders with the pre-keystroke value', () => {
+      const { result, rerender } = renderBuffered<string>({ value: 'abc' });
+
+      act(() => result.current.onChange('abxc'));
+
+      // The stale pass: same value as before the keystroke. Adopting it here is what used to
+      // rewrite the DOM node and throw the caret to the end.
+      rerender({ value: 'abc' });
+      expect(result.current.value).toBe('abxc');
+
+      // The echo lands a pass later and is recognised as ours.
+      rerender({ value: 'abxc' });
+      expect(result.current.value).toBe('abxc');
+    });
+
+    it('does not swallow a keystroke typed before the first echo returned', () => {
+      const { result, rerender } = renderBuffered<string>({ value: 'ab' });
+
+      act(() => result.current.onChange('abc'));
+      act(() => result.current.onChange('abcd'));
+
+      // The first echo arrives while a later emit is still in flight.
+      rerender({ value: 'abc' });
+      expect(result.current.value).toBe('abcd');
+
+      rerender({ value: 'abcd' });
+      expect(result.current.value).toBe('abcd');
+    });
+
+    it('handles a revert to the pre-keystroke string', () => {
+      const { result, rerender } = renderBuffered<string>({ value: 'abc' });
+
+      act(() => result.current.onChange('abxc'));
+      act(() => result.current.onChange('abc'));
+
+      rerender({ value: 'abxc' });
+      expect(result.current.value).toBe('abc');
+
+      rerender({ value: 'abc' });
+      expect(result.current.value).toBe('abc');
+    });
+
+    it('emits every change verbatim, once, in the same tick', () => {
+      const onChange = vi.fn();
+      const { result } = renderBuffered<string>({ value: 'a', onChange });
+
+      act(() => result.current.onChange('ab'));
+      act(() => result.current.onChange('abc'));
+
+      expect(onChange.mock.calls).toEqual([['ab'], ['abc']]);
+    });
+  });
+
+  describe('reset()', () => {
+    it('gives the parent back control', () => {
+      const { result, rerender } = renderBuffered<string>({ value: 'abc' });
+
+      // A parent that declines the keystroke: it re-renders with the value it already had.
+      act(() => result.current.onChange('abxc'));
+      rerender({ value: 'abc' });
+      expect(result.current.value).toBe('abxc');
+
+      act(() => result.current.reset());
+      expect(result.current.value).toBe('abc');
+    });
+
+    it('leaves a later external change free to land', () => {
+      const { result, rerender } = renderBuffered<string>({ value: 'abc' });
+
+      act(() => result.current.onChange('abxc'));
+      act(() => result.current.reset());
+
+      rerender({ value: 'zzz' });
+      expect(result.current.value).toBe('zzz');
+    });
+  });
+
+  describe('when there is nothing to protect', () => {
+    it('passes an uncontrolled value through', () => {
+      const onChange = vi.fn();
+      const { result } = renderBuffered<string>({ value: undefined, onChange });
+
+      act(() => result.current.onChange('abc'));
+
+      expect(result.current.value).toBeUndefined();
+      expect(onChange).toHaveBeenCalledExactlyOnceWith('abc');
+    });
+
+    it.each([
+      ['isReadOnly', { isReadOnly: true }],
+      ['isDisabled', { isDisabled: true }],
+      ['isBuffered: false', { isBuffered: false }],
+    ] as const)('stays inert with %s', (_label, options) => {
+      const onChange = vi.fn();
+      const { result } = renderBuffered<string>({
+        value: 'abc',
+        onChange,
+        options,
+      });
+
+      act(() => result.current.onChange('abxc'));
+
+      expect(result.current.value).toBe('abc');
+      expect(onChange).toHaveBeenCalledExactlyOnceWith('abxc');
+    });
+
+    it('is current again once the control becomes editable', () => {
+      const { result, rerender } = renderBuffered<string>({
+        value: 'abc',
+        options: { isReadOnly: true },
+      });
+
+      rerender({ value: 'changed elsewhere', options: { isReadOnly: true } });
+      rerender({ value: 'changed elsewhere', options: { isReadOnly: false } });
+
+      expect(result.current.value).toBe('changed elsewhere');
+
+      act(() => result.current.onChange('changed here'));
+      rerender({ value: 'changed elsewhere', options: { isReadOnly: false } });
+      expect(result.current.value).toBe('changed here');
+    });
+  });
+
+  describe('getKey', () => {
+    // The shape the chart-spec controls need: an array that is rebuilt on every emit, so identity
+    // comparison can't recognise the echo.
+    const getKey = (stops: string[]) => stops.join('|');
+
+    it('recognises an echo of an equal-but-not-identical value', () => {
+      const { result, rerender } = renderBuffered<string[]>({
+        value: ['#red', '#blue'],
+        options: { getKey },
+      });
+
+      act(() => result.current.onChange(['#red', '#green']));
+
+      rerender({ value: ['#red', '#blue'], options: { getKey } });
+      expect(result.current.value).toEqual(['#red', '#green']);
+
+      rerender({ value: ['#red', '#green'], options: { getKey } });
+      expect(result.current.value).toEqual(['#red', '#green']);
+    });
+
+    it('still adopts a genuine external change', () => {
+      const { result, rerender } = renderBuffered<string[]>({
+        value: ['#red'],
+        options: { getKey },
+      });
+
+      act(() => result.current.onChange(['#green']));
+      rerender({ value: ['#black', '#white'], options: { getKey } });
+
+      expect(result.current.value).toEqual(['#black', '#white']);
+    });
+  });
+});

--- a/src/utils/react/useBufferedValue.test.tsx
+++ b/src/utils/react/useBufferedValue.test.tsx
@@ -91,11 +91,11 @@ describe('useBufferedValue()', () => {
       expect(result.current.value).toBe('abc');
     });
 
-    // A guard on the double-invoked-render path, not a reproduction: StrictMode runs the render
-    // twice and keeps both, and the bookkeeping below is guarded by a key comparison that makes the
-    // second pass a no-op either way. An interrupted concurrent pass — where React throws a render
-    // away — is the case that argues for holding this in state rather than refs, and it cannot be
-    // provoked from jsdom. Measured: this test passes against a ref-based implementation too.
+    // A guard on the double-invoked-render path, not a reproduction. StrictMode runs the render
+    // twice and keeps both, and the hook writes nothing during render, so the second pass is a
+    // no-op by construction. The case this cannot reach is an *interrupted* pass, where React throws
+    // a render away — that one is handled by writing the bookkeeping only from event handlers and
+    // layout effects, neither of which a discarded render runs, and it cannot be provoked from jsdom.
     it('classifies correctly when every render is double-invoked', () => {
       const { result, rerender } = renderHook(
         ({ value }: { value: string }) => useBufferedValue(value),

--- a/src/utils/react/useBufferedValue.test.tsx
+++ b/src/utils/react/useBufferedValue.test.tsx
@@ -1,6 +1,6 @@
-import { StrictMode } from 'react';
+import { StrictMode, useEffect, useState } from 'react';
 
-import { act, renderHook } from '../../test';
+import { act, render, renderHook } from '../../test';
 
 import { useBufferedValue, UseBufferedValueOptions } from './useBufferedValue';
 
@@ -126,6 +126,56 @@ describe('useBufferedValue()', () => {
 
       expect(onChange.mock.calls).toEqual([['ab'], ['abc']]);
     });
+  });
+
+  // The buffer sits on every keystroke of every text field, so its render cost is part of its
+  // contract. Two per keystroke is the floor for a lagging parent — one for the typed value, one
+  // for the echo — and this pins that the bookkeeping adds nothing on top. An earlier version held
+  // the queue in state and adjusted it during render, which cost a third render per keystroke whose
+  // output was identical.
+  it('costs no render beyond the keystroke and its echo', () => {
+    let renders = 0;
+    let emit: (next: string) => void = () => {};
+
+    function Field({
+      value,
+      onChange,
+    }: {
+      value: string;
+      onChange: (n: string) => void;
+    }) {
+      renders++;
+      const buffered = useBufferedValue(value, onChange);
+
+      emit = buffered.onChange;
+
+      return <input readOnly value={buffered.value ?? ''} />;
+    }
+
+    function LaggingParent() {
+      const [value, setValue] = useState('');
+      const [inFlight, setInFlight] = useState<string | null>(null);
+
+      useEffect(() => {
+        if (inFlight !== null) {
+          setValue(inFlight);
+          setInFlight(null);
+        }
+      }, [inFlight]);
+
+      return <Field value={value} onChange={setInFlight} />;
+    }
+
+    render(<LaggingParent />);
+
+    renders = 0;
+    let text = '';
+    for (let i = 0; i < 10; i++) {
+      text += 'x';
+      act(() => emit(text));
+    }
+
+    expect(renders / 10).toBeLessThanOrEqual(2);
   });
 
   describe('reset()', () => {

--- a/src/utils/react/useBufferedValue.test.tsx
+++ b/src/utils/react/useBufferedValue.test.tsx
@@ -1,3 +1,5 @@
+import { StrictMode } from 'react';
+
 import { act, renderHook } from '../../test';
 
 import { useBufferedValue, UseBufferedValueOptions } from './useBufferedValue';
@@ -87,6 +89,32 @@ describe('useBufferedValue()', () => {
 
       rerender({ value: 'abc' });
       expect(result.current.value).toBe('abc');
+    });
+
+    // A guard on the double-invoked-render path, not a reproduction: StrictMode runs the render
+    // twice and keeps both, and the bookkeeping below is guarded by a key comparison that makes the
+    // second pass a no-op either way. An interrupted concurrent pass — where React throws a render
+    // away — is the case that argues for holding this in state rather than refs, and it cannot be
+    // provoked from jsdom. Measured: this test passes against a ref-based implementation too.
+    it('classifies correctly when every render is double-invoked', () => {
+      const { result, rerender } = renderHook(
+        ({ value }: { value: string }) => useBufferedValue(value),
+        {
+          initialProps: { value: 'abc' },
+          wrapper: ({ children }) => <StrictMode>{children}</StrictMode>,
+        },
+      );
+
+      act(() => result.current.onChange('abxc'));
+
+      rerender({ value: 'abc' }); // the stale pass
+      expect(result.current.value).toBe('abxc');
+
+      rerender({ value: 'abxc' }); // our own echo
+      expect(result.current.value).toBe('abxc');
+
+      rerender({ value: 'zzz' }); // a real external change
+      expect(result.current.value).toBe('zzz');
     });
 
     it('emits every change verbatim, once, in the same tick', () => {

--- a/src/utils/react/useBufferedValue.ts
+++ b/src/utils/react/useBufferedValue.ts
@@ -1,0 +1,135 @@
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseBufferedValueOptions<T> {
+  /**
+   * Identity of a value, for values `Object.is` doesn't compare usefully — an array of colour
+   * stops, a settings object. Defaults to the value itself, which is what strings want.
+   */
+  getKey?: (value: T) => unknown;
+  /** Nothing can be typed into a disabled control, so there is nothing to protect. */
+  isDisabled?: boolean;
+  /** Same for a read-only one. */
+  isReadOnly?: boolean;
+  /** Escape hatch: `false` makes the hook inert and passes `value`/`onChange` straight through. */
+  isBuffered?: boolean;
+}
+
+export interface UseBufferedValueResult<T> {
+  /** Render this instead of `value`. `undefined` passes through, meaning uncontrolled. */
+  value: T | undefined;
+  /** Call this instead of `onChange`. Still emits once per call, in the same tick. */
+  onChange: (next: T) => void;
+  /** Drop the buffer and let `value` win again. The text fields call it on blur. */
+  reset: () => void;
+}
+
+/**
+ * Holds a controlled value locally so a parent that echoes the new value back *late* cannot
+ * overwrite what the user is doing.
+ *
+ * **Why any of this is needed.** A controlled `<input>` renders whatever string its parent hands
+ * it. If the parent hands back the pre-keystroke string — because its state reaches the component
+ * through a store that publishes a render late, or through a debounce, or a deferred update —
+ * React writes that stale string into the DOM node, and a native `value` assignment collapses the
+ * selection to the end. Typing in the middle of a field throws the caret to the end. The value
+ * eventually lands, so it looks like a caret bug rather than a data-flow one.
+ *
+ * The buffer keeps the typed text on screen until the parent catches up, while still emitting
+ * `onChange` once per keystroke — so nothing downstream changes: no debouncing, no commit-on-blur,
+ * no swallowed calls.
+ *
+ * Generic on purpose. The same lateness affects values that aren't strings (a colour scale's array
+ * of stops emitted through a chart-spec pipeline), and `getKey` is where those pass the signature
+ * function they already have.
+ *
+ * ```tsx
+ * const buffered = useBufferedValue(value, onChange, { isReadOnly, isDisabled });
+ *
+ * <input value={buffered.value} onChange={buffered.onChange} onBlur={buffered.reset} />
+ * ```
+ *
+ * One case it cannot resolve: an external change that lands *between* an emit and its echo, and
+ * happens to equal a value still in flight, is read as our own echo. Telling those apart needs a
+ * sequence number from the store rather than value matching.
+ */
+export function useBufferedValue<T>(
+  value: T | undefined,
+  onChange?: (next: T) => void,
+  options: UseBufferedValueOptions<T> = {},
+): UseBufferedValueResult<T> {
+  const { getKey, isDisabled, isReadOnly, isBuffered = true } = options;
+
+  // An `undefined` value means the control is uncontrolled — it already owns its text.
+  const isActive =
+    isBuffered && value !== undefined && !isDisabled && !isReadOnly;
+
+  const keyOf = (next: T | undefined): unknown =>
+    getKey && next != null ? getKey(next) : next;
+  const valueKey = keyOf(value);
+
+  const [draft, setDraft] = useState(value);
+  // Keys we have emitted that the parent hasn't echoed back yet. A queue rather than one slot: the
+  // user can type again before the first echo returns, and each echo has to be recognised as ours
+  // or applying it would swallow everything typed after it.
+  const pendingRef = useRef<unknown[]>([]);
+  // The last value we accepted as the parent's opinion — not the last one we rendered.
+  const seenKeyRef = useRef<unknown>(valueKey);
+  const latestRef = useRef({ value, onChange, keyOf, isActive });
+
+  latestRef.current = { value, onChange, keyOf, isActive };
+
+  if (!isActive) {
+    // Mirror the parent, so the buffer is already current if the control becomes editable.
+    if (pendingRef.current.length) {
+      pendingRef.current = [];
+    }
+
+    seenKeyRef.current = valueKey;
+
+    if (keyOf(draft) !== valueKey) {
+      setDraft(value);
+    }
+  } else if (valueKey !== seenKeyRef.current) {
+    const pendingAt = pendingRef.current.indexOf(valueKey);
+
+    seenKeyRef.current = valueKey;
+
+    if (pendingAt >= 0) {
+      // Our own echo, a render or more late. Consume it along with any earlier emit it superseded,
+      // and keep the draft.
+      pendingRef.current = pendingRef.current.slice(pendingAt + 1);
+    } else {
+      // A real change from the parent: undo/redo, a reset, a transformed value, another record.
+      pendingRef.current = [];
+      setDraft(value);
+    }
+  }
+  // The remaining case — active, and the value is the same one we last saw — is the one this hook
+  // exists for: the parent re-rendered us with the string it held *before* the keystroke. Keeping
+  // the draft is what stops React writing that stale string back and collapsing the selection.
+
+  const handleChange = useCallback((next: T) => {
+    const {
+      onChange: latestOnChange,
+      keyOf: latestKeyOf,
+      isActive: latestIsActive,
+    } = latestRef.current;
+
+    if (latestIsActive) {
+      setDraft(next);
+      pendingRef.current = [...pendingRef.current, latestKeyOf(next)];
+    }
+
+    latestOnChange?.(next);
+  }, []);
+
+  const reset = useCallback(() => {
+    const { value: latestValue, keyOf: latestKeyOf } = latestRef.current;
+
+    pendingRef.current = [];
+    seenKeyRef.current = latestKeyOf(latestValue);
+    setDraft(latestValue);
+  }, []);
+
+  return { value: isActive ? draft : value, onChange: handleChange, reset };
+}

--- a/src/utils/react/useBufferedValue.ts
+++ b/src/utils/react/useBufferedValue.ts
@@ -71,60 +71,45 @@ export function useBufferedValue<T>(
     getKey && next != null ? getKey(next) : next;
   const valueKey = keyOf(value);
 
+  // The only state, and the only thing that can force a render: what the user typed. It is rendered
+  // *while we are ahead of the parent* and ignored otherwise — which is what makes adopting an
+  // external value free, since there is nothing to write.
   const [draft, setDraft] = useState(value);
   // Keys we have emitted that the parent hasn't echoed back yet. A queue rather than one slot: the
   // user can type again before the first echo returns, and each echo has to be recognised as ours
   // or applying it would swallow everything typed after it.
-  //
-  // State, not refs, though it is only ever read here. The decision below is taken during render,
-  // and React may discard a render — an interrupted concurrent pass, a StrictMode double-invoke.
-  // A discarded render throws away these updates together with the matching `setDraft`, whereas
-  // ref writes would survive it and leave the bookkeeping describing a render that never
-  // committed: an echo could then be read as an external change, or the reverse.
-  const [pending, setPending] = useState<unknown[]>(NOTHING_PENDING);
+  const pendingRef = useRef<unknown[]>(NOTHING_PENDING);
   // The last value we accepted as the parent's opinion — not the last one we rendered.
-  const [seenKey, setSeenKey] = useState<unknown>(valueKey);
+  const seenKeyRef = useRef<unknown>(valueKey);
   const latestRef = useRef({ value, onChange, keyOf, isActive });
 
-  // Synced after commit rather than during render, for the same reason.
+  // These three refs are read during render but written *only* in an event handler or after commit,
+  // never during a render. That is what keeps them honest under concurrent rendering: React may
+  // discard a render (an interrupted pass, a StrictMode double-invoke), and a discarded render runs
+  // no effects, so it cannot leave the bookkeeping describing a pass that never committed.
+  const pending = pendingRef.current;
+  const propMoved = valueKey !== seenKeyRef.current;
+  // Our own echo, a render or more late — possibly an earlier emit a later one superseded.
+  const echoAt = propMoved ? pending.indexOf(valueKey) : -1;
+  // A real change from the parent: undo/redo, a reset, a transformed value, another record.
+  const isExternal = propMoved && echoAt < 0;
+  const isAhead = isActive && !isExternal && pending.length > 0;
+  // Not being ahead is the whole of "the parent wins", so an external change needs no state write
+  // and costs no extra render. Being ahead — including when the value is the stale one the parent
+  // held *before* the keystroke — is what stops React writing that string back and collapsing the
+  // selection.
+  const rendered = isAhead ? draft : value;
+
   useLayoutEffect(() => {
     latestRef.current = { value, onChange, keyOf, isActive };
+    seenKeyRef.current = valueKey;
+
+    if (!isActive || isExternal) {
+      pendingRef.current = NOTHING_PENDING;
+    } else if (echoAt >= 0) {
+      pendingRef.current = pending.slice(echoAt + 1);
+    }
   });
-
-  if (!isActive) {
-    // Mirror the parent, so the buffer is already current if the control becomes editable.
-    if (pending.length) {
-      setPending(NOTHING_PENDING);
-    }
-
-    if (seenKey !== valueKey) {
-      setSeenKey(valueKey);
-    }
-
-    if (keyOf(draft) !== valueKey) {
-      setDraft(value);
-    }
-  } else if (valueKey !== seenKey) {
-    const pendingAt = pending.indexOf(valueKey);
-
-    setSeenKey(valueKey);
-
-    if (pendingAt >= 0) {
-      // Our own echo, a render or more late. Consume it along with any earlier emit it superseded,
-      // and keep the draft.
-      setPending(pending.slice(pendingAt + 1));
-    } else {
-      // A real change from the parent: undo/redo, a reset, a transformed value, another record.
-      if (pending.length) {
-        setPending(NOTHING_PENDING);
-      }
-
-      setDraft(value);
-    }
-  }
-  // The remaining case — active, and the value is the same one we last saw — is the one this hook
-  // exists for: the parent re-rendered us with the string it held *before* the keystroke. Keeping
-  // the draft is what stops React writing that stale string back and collapsing the selection.
 
   const handleChange = useCallback((next: T) => {
     const {
@@ -134,21 +119,22 @@ export function useBufferedValue<T>(
     } = latestRef.current;
 
     if (latestIsActive) {
+      // A ref write in an event handler, which runs after a commit — never mid-render.
+      pendingRef.current = [...pendingRef.current, latestKeyOf(next)];
       setDraft(next);
-      // Functional, so two keystrokes inside one event both make it onto the queue.
-      setPending((queue) => [...queue, latestKeyOf(next)]);
     }
 
     latestOnChange?.(next);
   }, []);
 
   const reset = useCallback(() => {
-    const { value: latestValue, keyOf: latestKeyOf } = latestRef.current;
+    const { value: latestValue } = latestRef.current;
 
-    setPending(NOTHING_PENDING);
-    setSeenKey(latestKeyOf(latestValue));
+    // Emptying the queue is what hands control back: with nothing in flight we are no longer ahead,
+    // so the parent's value is rendered again. `setDraft` is only here to schedule that render.
+    pendingRef.current = NOTHING_PENDING;
     setDraft(latestValue);
   }, []);
 
-  return { value: isActive ? draft : value, onChange: handleChange, reset };
+  return { value: rendered, onChange: handleChange, reset };
 }

--- a/src/utils/react/useBufferedValue.ts
+++ b/src/utils/react/useBufferedValue.ts
@@ -1,5 +1,9 @@
 import { useCallback, useRef, useState } from 'react';
 
+import { useLayoutEffect } from './useLayoutEffect';
+
+const NOTHING_PENDING: unknown[] = [];
+
 export interface UseBufferedValueOptions<T> {
   /**
    * Identity of a value, for values `Object.is` doesn't compare usefully — an array of colour
@@ -71,36 +75,50 @@ export function useBufferedValue<T>(
   // Keys we have emitted that the parent hasn't echoed back yet. A queue rather than one slot: the
   // user can type again before the first echo returns, and each echo has to be recognised as ours
   // or applying it would swallow everything typed after it.
-  const pendingRef = useRef<unknown[]>([]);
+  //
+  // State, not refs, though it is only ever read here. The decision below is taken during render,
+  // and React may discard a render — an interrupted concurrent pass, a StrictMode double-invoke.
+  // A discarded render throws away these updates together with the matching `setDraft`, whereas
+  // ref writes would survive it and leave the bookkeeping describing a render that never
+  // committed: an echo could then be read as an external change, or the reverse.
+  const [pending, setPending] = useState<unknown[]>(NOTHING_PENDING);
   // The last value we accepted as the parent's opinion — not the last one we rendered.
-  const seenKeyRef = useRef<unknown>(valueKey);
+  const [seenKey, setSeenKey] = useState<unknown>(valueKey);
   const latestRef = useRef({ value, onChange, keyOf, isActive });
 
-  latestRef.current = { value, onChange, keyOf, isActive };
+  // Synced after commit rather than during render, for the same reason.
+  useLayoutEffect(() => {
+    latestRef.current = { value, onChange, keyOf, isActive };
+  });
 
   if (!isActive) {
     // Mirror the parent, so the buffer is already current if the control becomes editable.
-    if (pendingRef.current.length) {
-      pendingRef.current = [];
+    if (pending.length) {
+      setPending(NOTHING_PENDING);
     }
 
-    seenKeyRef.current = valueKey;
+    if (seenKey !== valueKey) {
+      setSeenKey(valueKey);
+    }
 
     if (keyOf(draft) !== valueKey) {
       setDraft(value);
     }
-  } else if (valueKey !== seenKeyRef.current) {
-    const pendingAt = pendingRef.current.indexOf(valueKey);
+  } else if (valueKey !== seenKey) {
+    const pendingAt = pending.indexOf(valueKey);
 
-    seenKeyRef.current = valueKey;
+    setSeenKey(valueKey);
 
     if (pendingAt >= 0) {
       // Our own echo, a render or more late. Consume it along with any earlier emit it superseded,
       // and keep the draft.
-      pendingRef.current = pendingRef.current.slice(pendingAt + 1);
+      setPending(pending.slice(pendingAt + 1));
     } else {
       // A real change from the parent: undo/redo, a reset, a transformed value, another record.
-      pendingRef.current = [];
+      if (pending.length) {
+        setPending(NOTHING_PENDING);
+      }
+
       setDraft(value);
     }
   }
@@ -117,7 +135,8 @@ export function useBufferedValue<T>(
 
     if (latestIsActive) {
       setDraft(next);
-      pendingRef.current = [...pendingRef.current, latestKeyOf(next)];
+      // Functional, so two keystrokes inside one event both make it onto the queue.
+      setPending((queue) => [...queue, latestKeyOf(next)]);
     }
 
     latestOnChange?.(next);
@@ -126,8 +145,8 @@ export function useBufferedValue<T>(
   const reset = useCallback(() => {
     const { value: latestValue, keyOf: latestKeyOf } = latestRef.current;
 
-    pendingRef.current = [];
-    seenKeyRef.current = latestKeyOf(latestValue);
+    setPending(NOTHING_PENDING);
+    setSeenKey(latestKeyOf(latestValue));
     setDraft(latestValue);
   }, []);
 


### PR DESCRIPTION
## The bug

A controlled `<input>` renders whatever string its parent hands it. If the parent hands back the **pre-keystroke** string — because its state arrives through a store that publishes a render late, a debounce, or a deferred update — React writes that stale string into the DOM node, and a native `value` assignment collapses the selection.

Typing in the middle of a field threw the caret to the end. The text still landed a render later, so it read as a caret bug rather than a data-flow one. Cube Cloud hit it in conditional-formatting values (CUB-3737), where the chart spec reaches the field through `use-context-selector` and arrives a commit late; the visible symptom was typing `very ` into `At risk` and getting `At vriskery `.

Two ingredients, and this PR removes the one we own. The other is `@react-stately/utils@3.11.0`, whose `useControlledState` now calls `forceUpdate()` on every `setValue` **even when controlled** ([PR #9331](https://github.com/adobe/react-spectrum/pull/9331)) — that is what drags the field into the stale render. On 3.10.8 it doesn't. Worth reporting upstream separately; nobody has filed the caret case.

## What changed

`TextInput`, `TextArea`, `PasswordInput` and `SearchInput` hold the typed text locally until the parent catches up.

- `onChange` still fires **once per keystroke with the full value** — no debouncing, no commit-on-blur, no coalesced calls, so no call site changes behaviour.
- An incoming `value` is adopted whenever it is a genuine change from the parent (undo, reset, a transformed string, another record).
- Blur hands control back to the parent's `value`.

Recognising the echo needs **both** guards: matching only the pending emits would adopt a stale value the parent never changed, and matching only "the prop moved" would swallow a keystroke typed while an earlier echo was still in flight.

Untouched, because they already own their typed text: `NumberInput`, `ComboBox`, `SearchComboBox`, `FilterListBox`, `CommandMenu`, `CommandTextArea`, `ColorPicker`, `InlineInput`.

## Public API

- **`useBufferedValue(value, onChange, options)`** — exported for controls that own their own input. Generic, so non-string values (an array of colour stops rebuilt on every emit) can be matched by signature via `options.getKey`. Returns `{ value, onChange, reset }`.
- **`isBuffered`** — set `false` for a caller that must see the field snap back to its own `value` the instant it declines a keystroke.

## Compatibility

The one semantic shift: a parent that rejects a keystroke by re-sending the **identical** string now shows the rejected character until blur. A parent that transforms into a different string is unaffected — the differing echo is adopted.

Surveyed all **301** text-field call sites across Cube Cloud's four ui-kit consumers before choosing the default: **zero** are that shape. `shouldUpdate` — the only genuine reject path in ui-kit's own form — has zero usages there. All 12 `value`-without-`onChange` sites are `isReadOnly`/`isDisabled`, where the hook is inert.

## Tests

33 new tests. The component tests run a parent that echoes one commit late and pin `selectionStart` for all four fields; the `isBuffered={false}` case is kept as a **negative control** — it reproduces the bug in jsdom (value `heXllo`, caret at the end instead of after the typed character), so the file proves the mechanism rather than only asserting the fix.

Full suite: **64 files, 1394 passed**, plus lint, typecheck and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core text-field controlled-value behavior for all four inputs; default buffering changes edge cases where a parent rejects a keystroke by re-sending the same string (visible until blur), though call sites were surveyed as unaffected.
> 
> **Overview**
> Fixes caret jumping to the end when controlled text fields receive a **stale** `value` one render behind the keystroke (late store updates, debounce, etc.).
> 
> Adds **`useBufferedValue`**, which keeps a local draft while pending parent echoes are tracked in a queue, still fires **`onChange` once per keystroke**, adopts real external updates (reset, transform, undo), and **`reset` on blur** so the parent wins again. **`TextInput`**, **`TextArea`**, **`PasswordInput`**, and **`SearchInput`** wire this in by default; **`isBuffered={false}`** opts out. The hook is exported with optional **`getKey`** for non-string controlled values.
> 
> **`TextArea`** auto-size now keys off the rendered buffered value. New hook and integration tests cover lagging parents, caret position, form sync, and render cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d27c2485c96154b1c0731dd92ded008592d42c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->