### PR TITLE
refactor(fields): declare isBuffered where it is implemented

### DIFF
--- a/.changeset/buffered-value-props-mixin.md
+++ b/.changeset/buffered-value-props-mixin.md
@@ -1,0 +1,14 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Declare `isBuffered` on the four fields that implement it rather than on the shared
+`CubeTextInputBaseProps`.
+
+`TextInput`, `TextArea`, `PasswordInput` and `SearchInput` buffer their value; `NumberInput` and
+`CommandTextArea` are built on the same base type but keep their own text and never read the prop.
+Declaring it on the base put it in their declared surface too. It now comes from a
+`CubeBufferedValueProps` mixin, exported alongside the base props, so a field built on that base in
+future doesn't inherit a flag it ignores.
+
+Type-level only — no runtime change, and no behaviour change for the four fields.

--- a/src/components/fields/PasswordInput/PasswordInput.tsx
+++ b/src/components/fields/PasswordInput/PasswordInput.tsx
@@ -10,10 +10,15 @@ import {
 } from '../../../utils/react/nullableValue';
 import { ItemAction } from '../../actions';
 import { useFieldProps } from '../../form';
-import { CubeTextInputBaseProps, TextInputBase } from '../TextInput';
+import {
+  CubeBufferedValueProps,
+  CubeTextInputBaseProps,
+  TextInputBase,
+} from '../TextInput';
 
 export interface CubePasswordInputProps
-  extends WithNullableValue<CubeTextInputBaseProps> {}
+  extends WithNullableValue<CubeTextInputBaseProps>,
+    CubeBufferedValueProps {}
 
 function PasswordInput(
   props: CubePasswordInputProps,

--- a/src/components/fields/SearchInput/SearchInput.tsx
+++ b/src/components/fields/SearchInput/SearchInput.tsx
@@ -12,7 +12,11 @@ import {
 } from '../../../utils/react/nullableValue';
 import { ItemAction } from '../../actions';
 import { getValidationTheme, useValidationProps } from '../../form';
-import { CubeTextInputBaseProps, TextInputBase } from '../TextInput';
+import {
+  CubeBufferedValueProps,
+  CubeTextInputBaseProps,
+  TextInputBase,
+} from '../TextInput';
 
 export { useSearchFieldState, useSearchField };
 export type { SearchFieldProps };
@@ -31,7 +35,8 @@ export interface CubeSearchInputProps
       | 'insideForm'
       | 'idPrefix'
     >,
-    SearchFieldProps {
+    SearchFieldProps,
+    CubeBufferedValueProps {
   /** Whether the search input is clearable using ESC keyboard button or clear button inside the input */
   isClearable?: boolean;
   /** Callback called when the clear button is pressed */

--- a/src/components/fields/TextArea/TextArea.tsx
+++ b/src/components/fields/TextArea/TextArea.tsx
@@ -14,9 +14,15 @@ import {
   WithNullableValue,
 } from '../../../utils/react/nullableValue';
 import { useFieldProps } from '../../form';
-import { CubeTextInputBaseProps, TextInputBase } from '../TextInput';
+import {
+  CubeBufferedValueProps,
+  CubeTextInputBaseProps,
+  TextInputBase,
+} from '../TextInput';
 
-export interface CubeTextAreaProps extends CubeTextInputBaseProps {
+export interface CubeTextAreaProps
+  extends CubeTextInputBaseProps,
+    CubeBufferedValueProps {
   /** Whether the textarea should change its size depends on the content */
   autoSize?: boolean;
   /** Max number of visible rows when autoSize is `true`. Defaults to 10  */

--- a/src/components/fields/TextInput/TextInput.tsx
+++ b/src/components/fields/TextInput/TextInput.tsx
@@ -8,9 +8,14 @@ import {
 } from '../../../utils/react/nullableValue';
 import { useFieldProps } from '../../form';
 
-import { CubeTextInputBaseProps, TextInputBase } from './TextInputBase';
+import {
+  CubeBufferedValueProps,
+  CubeTextInputBaseProps,
+  TextInputBase,
+} from './TextInputBase';
 
-export type CubeTextInputProps = WithNullableValue<CubeTextInputBaseProps>;
+export type CubeTextInputProps = WithNullableValue<CubeTextInputBaseProps> &
+  CubeBufferedValueProps;
 
 export { useTextField };
 

--- a/src/components/fields/TextInput/TextInputBase.tsx
+++ b/src/components/fields/TextInput/TextInputBase.tsx
@@ -233,6 +233,16 @@ export interface CubeTextInputBaseProps
   /** The size of the input */
   size?: 'small' | 'medium' | 'large' | (string & {});
   autocomplete?: string;
+}
+
+/**
+ * Mixed into the fields that actually buffer their value — `TextInput`, `TextArea`,
+ * `PasswordInput`, `SearchInput` — rather than declared on `CubeTextInputBaseProps`. Every field
+ * built on that base would otherwise inherit the prop, including `NumberInput` and
+ * `CommandTextArea`, which keep their own text and ignore it: a public API that accepts a flag and
+ * does nothing with it.
+ */
+export interface CubeBufferedValueProps {
   /**
    * Whether the typed text is held locally until the controlled `value` catches up. On by default,
    * which is what keeps the caret in place when the value round-trips through a store that


### PR DESCRIPTION
Follow-up to #1296.

## What

`isBuffered` was declared on `CubeTextInputBaseProps`. Four fields implement it — `TextInput`, `TextArea`, `PasswordInput`, `SearchInput` — but `NumberInput` and `CommandTextArea` are built on the same base type and keep their own text, so they never read it. The prop is now a `CubeBufferedValueProps` mixin (exported next to the base props) that only the four buffering fields extend, so a field added to that base later doesn't inherit a flag it ignores.

Type-level only. No runtime change, no behaviour change for the four fields. Full suite green: 64 files, 1396 tests.

## What this does NOT fix, measured rather than assumed

I opened this believing the prop was *accepted* by components that ignore it. That turned out to be wrong, and the correction is worth more than the refactor:

- A `@ts-expect-error` guard asserting `<NumberInput isBuffered={false} />` is an error came back **"unused directive"** — no error was raised.
- A probe showed `NumberInput`, `CommandTextArea` **and `TextInput`** all accept `totallyBogusPropXyz={1}` with no type error at all.

So excess-property checking isn't reaching these field components, and `isBuffered` on `NumberInput` was never distinguishable from any other unknown prop. This PR therefore closes no type hole — it's declaration hygiene: the prop is defined next to its implementation and stops widening the shared base.

**The bigger issue is that probe result.** Prop-name typos go uncaught across the field components, which for a design system is worth its own look — likely something in the props chain (`WithNullableValue` maps `value`/`defaultValue` to `any`, and there are index-signature types nearby) defeating the check. Not touched here; flagging it as its own investigation.

## Timing

Worth landing before #1292 (Version Packages → `0.157.0`), so the first release carrying `isBuffered` has it declared in the right place. A patch changeset is included so this is released either way, whichever order the two merge in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)