### PR TITLE
test(Board): add the browser tier and migrate the geometry-driven pointer tests

### DIFF
--- a/src/components/layout/Board/Board.browser.test.tsx
+++ b/src/components/layout/Board/Board.browser.test.tsx
@@ -21,9 +21,11 @@ const ROW = 100;
 function renderBoard(
   layout: LayoutItem[],
   props: Record<string, unknown> = {},
+  widgetProps: Record<string, Record<string, unknown>> = {},
+  containerWidth = 600,
 ) {
   const result = renderWithRoot(
-    <div style={{ width: '600px' }}>
+    <div style={{ width: `${containerWidth}px` }}>
       <Board
         cols={12}
         rowHeight={ROW}
@@ -34,7 +36,12 @@ function renderBoard(
         {...props}
       >
         {layout.map((item) => (
-          <Board.Widget key={item.i} id={item.i} qa={item.i.toUpperCase()}>
+          <Board.Widget
+            key={item.i}
+            id={item.i}
+            qa={item.i.toUpperCase()}
+            {...widgetProps[item.i]}
+          >
             {item.i}
           </Board.Widget>
         ))}
@@ -44,6 +51,23 @@ function renderBoard(
 
   return result;
 }
+
+/**
+ * One instance per test, rather than the bare `userEvent.*` calls the jsdom
+ * suite uses. Each bare call builds a fresh instance with fresh state, so a
+ * button pressed in one call is not held in the next and a modifier held in one
+ * is not held in the next — both of which a marquee gesture depends on.
+ */
+let user: ReturnType<typeof userEvent.setup>;
+
+beforeEach(() => {
+  // `pointerEventsCheck: 0` because the board deliberately swaps the widget
+  // being dragged for an `opacity: 0`, `pointer-events: none` stand-in and
+  // renders a clone in the overlay. The release therefore lands on an element
+  // that is, correctly, not interactive — refusing to dispatch it would be
+  // refusing to finish a gesture the component supports.
+  user = userEvent.setup({ pointerEventsCheck: 0 });
+});
 
 const board = () => screen.getByTestId('Board');
 const widget = (id: string) => screen.getByTestId(id.toUpperCase());
@@ -59,7 +83,9 @@ async function settled() {
 
 /** Ids top-to-bottom, then left-to-right — "did the group split" in one line. */
 function stackOrder(): string[] {
-  return [...document.querySelectorAll<HTMLElement>('[data-board-widget-host]')]
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-board-widget-host]'),
+  )
     .map((el) => ({
       id: el.getAttribute('data-board-widget-id')!,
       rect: el.getBoundingClientRect(),
@@ -79,7 +105,15 @@ function stackOrder(): string[] {
  * Aria's `useMove` — which owns widget dragging — reads the page pair, and a
  * gesture that only carries client coords looks like a press that never moved.
  */
-async function dragPointer(
+const coordsAt = (p: { x: number; y: number }) => ({
+  clientX: p.x,
+  clientY: p.y,
+  pageX: p.x,
+  pageY: p.y,
+});
+
+/** Press and walk to `to` without releasing — for asserting mid-gesture state. */
+async function pressAndMove(
   target: HTMLElement,
   from: { x: number; y: number },
   to: { x: number; y: number },
@@ -87,20 +121,58 @@ async function dragPointer(
 ) {
   const at = (i: number) => {
     const t = i / steps;
-    const x = from.x + (to.x - from.x) * t;
-    const y = from.y + (to.y - from.y) * t;
 
-    return { clientX: x, clientY: y, pageX: x, pageY: y };
+    return coordsAt({
+      x: from.x + (to.x - from.x) * t,
+      y: from.y + (to.y - from.y) * t,
+    });
   };
 
-  await userEvent.pointer([
+  await user.pointer([
     { keys: '[MouseLeft>]', target, coords: at(0) },
     ...Array.from({ length: steps }, (_, i) => ({
       target,
       coords: at(i + 1),
     })),
-    { keys: '[/MouseLeft]', target, coords: at(steps) },
   ]);
+}
+
+async function release(target: HTMLElement, at: { x: number; y: number }) {
+  await user.pointer([{ keys: '[/MouseLeft]', target, coords: coordsAt(at) }]);
+}
+
+async function dragPointer(
+  target: HTMLElement,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  steps = 4,
+) {
+  await pressAndMove(target, from, to, steps);
+  await release(target, to);
+}
+
+/**
+ * A marquee gesture in board-relative pixels.
+ *
+ * The press is aimed at the content layer, the same element the handler sits
+ * on, but the coordinates still have to land on empty grid: the handler bails
+ * when the press resolves to a widget, and in a real browser the point decides
+ * that rather than the mock.
+ */
+async function marquee(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  modifier?: 'Shift' | 'Control',
+) {
+  const origin = board().getBoundingClientRect();
+  const abs = (p: { x: number; y: number }) => ({
+    x: origin.left + p.x,
+    y: origin.top + p.y,
+  });
+
+  if (modifier) await user.keyboard(`{${modifier}>}`);
+  await dragPointer(content(), abs(from), abs(to));
+  if (modifier) await user.keyboard(`{/${modifier}}`);
 }
 
 const TWO_ROWS: LayoutItem[] = [
@@ -152,6 +224,356 @@ describe('Board extraRows', () => {
     );
 
     expect(onSelectionChange).toHaveBeenCalledWith(['a', 'b', 'c']);
+  });
+});
+
+/**
+ * Which widgets a band covers is decided by measured rectangles, so these ran
+ * in jsdom only by mocking the content layer's rect and hand-computing the
+ * intersections against it. Here the rects are the browser's.
+ *
+ * `extraRows` is on throughout for a reason that is itself the feature: a lasso
+ * needs empty grid to start from, and this three-widget layout has almost none
+ * without it.
+ */
+describe('Board marquee', () => {
+  // cols 6 over 600px -> a(0-200, 0-100)  b(200-400, 0-100)  c(0-200, 100-200),
+  // with rows 2-3 left empty by `extraRows`.
+  const SELECTION: LayoutItem[] = [
+    { i: 'a', x: 0, y: 0, w: 2, h: 1 },
+    { i: 'b', x: 2, y: 0, w: 2, h: 1 },
+    { i: 'c', x: 0, y: 1, w: 2, h: 1 },
+  ];
+
+  const renderMarquee = (
+    props: Record<string, unknown> = {},
+    widgetProps: Record<string, Record<string, unknown>> = {},
+  ) => renderBoard(SELECTION, { cols: 6, extraRows: 2, ...props }, widgetProps);
+
+  /** Empty space right of `b`, down to a point left of it — covers `a` and `b`. */
+  const OVER_A_B = [
+    { x: 580, y: 20 },
+    { x: 20, y: 80 },
+  ] as const;
+  /** Up the left-hand column from the empty band — covers `a` and `c`, not `b`. */
+  const OVER_A_C = [
+    { x: 100, y: 380 },
+    { x: 50, y: 20 },
+  ] as const;
+
+  it('selects every widget the band intersects', async () => {
+    const onSelectionChange = vi.fn();
+    renderMarquee({ onSelectionChange });
+    await settled();
+
+    await marquee(...OVER_A_B);
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    expect(onSelectionChange).toHaveBeenCalledWith(['a', 'b']);
+  });
+
+  it('commits once per gesture, not once per pointer frame', async () => {
+    const onSelectionChange = vi.fn();
+    renderMarquee({ onSelectionChange });
+    await settled();
+
+    // `dragPointer` walks the band across several intermediate positions.
+    await marquee(...OVER_A_B);
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the band while dragging and removes it on release', async () => {
+    renderMarquee();
+    await settled();
+
+    const origin = board().getBoundingClientRect();
+    const at = (x: number, y: number) => ({
+      clientX: origin.left + x,
+      clientY: origin.top + y,
+      pageX: origin.left + x,
+      pageY: origin.top + y,
+    });
+
+    await user.pointer([
+      { keys: '[MouseLeft>]', target: content(), coords: at(580, 20) },
+      { target: content(), coords: at(300, 60) },
+    ]);
+    expect(screen.getByTestId('BoardMarquee')).toBeInTheDocument();
+
+    await user.pointer([
+      { keys: '[/MouseLeft]', target: content(), coords: at(300, 60) },
+    ]);
+    expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
+  });
+
+  it('ignores a press below the movement threshold and clears instead', async () => {
+    const onSelectionChange = vi.fn();
+    renderMarquee({ onSelectionChange, defaultSelectedKeys: ['b'] });
+    await settled();
+
+    await marquee({ x: 500, y: 300 }, { x: 501, y: 300 });
+
+    expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
+    expect(onSelectionChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('adds to the existing selection with Shift', async () => {
+    const onSelectionChange = vi.fn();
+    renderMarquee({ onSelectionChange, defaultSelectedKeys: ['c'] });
+    await settled();
+
+    await marquee(...OVER_A_B, 'Shift');
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(['a', 'b', 'c']);
+  });
+
+  // Dragging is off while the modifier is held, so the whole board — widgets
+  // included — becomes one selection surface.
+  it('adds to the selection from the platform modifier flag', async () => {
+    const onSelectionChange = vi.fn();
+    renderMarquee({ onSelectionChange });
+    await settled();
+
+    await marquee(...OVER_A_B, 'Control');
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(['a', 'b']);
+  });
+
+  it('never starts on a widget — that press is a drag', async () => {
+    renderMarquee();
+    await settled();
+
+    const rect = widget('a').getBoundingClientRect();
+
+    await dragPointer(
+      widget('a'),
+      { x: rect.left + 10, y: rect.top + 10 },
+      { x: rect.left + 200, y: rect.top + 40 },
+    );
+
+    expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
+  });
+
+  it('re-announces two consecutive selections that read the same', async () => {
+    renderMarquee();
+    await settled();
+    const status = screen.getByRole('status');
+
+    await marquee(...OVER_A_B);
+    const first = status.textContent;
+
+    // `a` + `c` this time — a different selection that renders the same text.
+    await marquee(...OVER_A_C);
+
+    // A screen reader skips a live-region update whose text is byte-identical
+    // to the one before it, so these must differ.
+    expect(first).toContain('2 widgets selected');
+    expect(status).toHaveTextContent('2 widgets selected');
+    expect(status.textContent).not.toBe(first);
+  });
+
+  it('skips a widget that opted out of selection', async () => {
+    const onSelectionChange = vi.fn();
+    renderMarquee({ onSelectionChange }, { b: { isSelectable: false } });
+    await settled();
+
+    // A band over both `a` and `b`; only `a` may be picked up, matching what a
+    // press on `b` would (not) do.
+    await marquee(...OVER_A_B);
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['a']);
+  });
+
+  it('is disabled by allowMarqueeSelection={false}', async () => {
+    renderMarquee({ allowMarqueeSelection: false });
+    await settled();
+
+    await marquee(...OVER_A_B);
+
+    expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Where a group lands is measured geometry from end to end: the pointer delta
+ * becomes a cell delta through the board's own column width. In jsdom every one
+ * of these rectangles was a mock, so the tests could only confirm the mocks were
+ * self-consistent.
+ *
+ * 1200px over 12 columns, no margins or padding — cell N starts at exactly
+ * N * 100px, matching the arithmetic the assertions are written in.
+ */
+describe('Board group drag', () => {
+  const PAIR: LayoutItem[] = [
+    { i: 'a', x: 0, y: 0, w: 2, h: 1 },
+    { i: 'b', x: 6, y: 0, w: 2, h: 1 },
+    { i: 'far', x: 0, y: 4, w: 2, h: 1 },
+  ];
+
+  const renderPair = (props: Record<string, unknown> = {}, layout = PAIR) =>
+    renderBoard(
+      layout,
+      {
+        compact: null,
+        defaultSelectedKeys: ['a', 'b'],
+        ...props,
+      },
+      {},
+      1200,
+    );
+
+  /** Grab a widget at its centre and travel `(dx, dy)` device pixels. */
+  const grabAndDrag = async (id: string, dx: number, dy: number) => {
+    const el = widget(id);
+    const r = el.getBoundingClientRect();
+    const from = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+
+    await dragPointer(el, from, { x: from.x + dx, y: from.y + dy });
+  };
+
+  const positions = (items: LayoutItem[]) =>
+    Object.fromEntries(items.map((it) => [it.i, `${it.x},${it.y}`]));
+
+  it('moves every selected widget by the same delta', async () => {
+    const onLayoutChange = vi.fn();
+    renderPair({ onLayoutChange });
+    await settled();
+
+    await grabAndDrag('a', 200, 100);
+
+    await vi.waitFor(() => expect(onLayoutChange).toHaveBeenCalled());
+    expect(positions(onLayoutChange.mock.lastCall![0])).toMatchObject({
+      a: '2,1',
+      b: '8,1',
+    });
+  });
+
+  it('commits exactly once, before onDragStop', async () => {
+    const calls: string[] = [];
+    renderPair({
+      onLayoutChange: () => calls.push('layout'),
+      onDragStop: () => calls.push('stop'),
+    });
+    await settled();
+
+    await grabAndDrag('a', 200, 0);
+
+    expect(calls.filter((c) => c === 'layout')).toHaveLength(1);
+    expect(calls).toEqual(['layout', 'stop']);
+  });
+
+  // Clamping each item separately collapses the group against the wall, and it
+  // never recovers — the delta has to be clamped once, against the whole group.
+  it('keeps the group shape when dragged into an edge', async () => {
+    const onLayoutChange = vi.fn();
+    renderPair({ onLayoutChange });
+    await settled();
+
+    await grabAndDrag('a', -400, 0);
+
+    await vi.waitFor(() => expect(onLayoutChange).toHaveBeenCalled());
+    const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
+    const a = committed.find((it) => it.i === 'a')!;
+    const b = committed.find((it) => it.i === 'b')!;
+
+    expect(a.x).toBe(0);
+    expect(b.x - a.x).toBe(6);
+  });
+
+  it('never leaves a widget pinned after a group drop', async () => {
+    const onLayoutChange = vi.fn();
+    renderPair({ onLayoutChange, compact: 'vertical' });
+    await settled();
+
+    await grabAndDrag('a', 200, 100);
+
+    await vi.waitFor(() => expect(onLayoutChange).toHaveBeenCalled());
+    // A leaked pin would freeze the widget forever — and consumers persist
+    // layouts, so it would survive a reload.
+    expect(
+      (onLayoutChange.mock.lastCall![0] as LayoutItem[]).every(
+        (it) => !it.static,
+      ),
+    ).toBe(true);
+  });
+
+  it('reports every mover through the drag callbacks', async () => {
+    const onDragStart = vi.fn();
+    renderPair({ onDragStart });
+    await settled();
+
+    await grabAndDrag('a', 100, 0);
+
+    const info = onDragStart.mock.lastCall![0];
+    expect(info.items.map((it: LayoutItem) => it.i)).toEqual(['a', 'b']);
+    expect(info.item).toBe(info.items[0]);
+    expect(info.placeholders).toHaveLength(2);
+  });
+
+  it('renders one placeholder per moving widget', async () => {
+    renderPair();
+    await settled();
+
+    const r = widget('a').getBoundingClientRect();
+    await pressAndMove(
+      widget('a'),
+      { x: r.left + r.width / 2, y: r.top + r.height / 2 },
+      { x: r.left + r.width / 2 + 100, y: r.top + r.height / 2 },
+    );
+
+    expect(screen.getAllByTestId('BoardPlaceholder')).toHaveLength(2);
+  });
+
+  // Reported: dragging a group down on a compacting board shoved the widgets
+  // below it further down, and the board only caught up on the *next* pointer
+  // step. The group was being held in place while everything reflowed around
+  // it — something a single widget is never allowed to do under vertical
+  // compaction, which is why a single drag felt natural and a group did not.
+  it('compacts the group during the drag, like a single widget', async () => {
+    const frames: LayoutItem[][] = [];
+    renderPair(
+      {
+        compact: 'vertical',
+        onDrag: (info: { layout: LayoutItem[] }) =>
+          frames.push(info.layout.map((it) => ({ ...it }))),
+      },
+      [
+        { i: 'a', x: 0, y: 0, w: 2, h: 1 },
+        { i: 'b', x: 2, y: 0, w: 2, h: 1 },
+        { i: 'far', x: 0, y: 3, w: 2, h: 1 },
+      ],
+    );
+    await settled();
+
+    const r = widget('a').getBoundingClientRect();
+    // One jump rather than a walk: the claim is that *every* frame is already
+    // compacted, and intermediate frames at 1.5 or 3 rows down are legitimately
+    // different arrangements, not lagging ones.
+    await pressAndMove(
+      widget('a'),
+      { x: r.left + r.width / 2, y: r.top + r.height / 2 },
+      { x: r.left + r.width / 2, y: r.top + r.height / 2 + 600 },
+      1,
+    );
+
+    expect(frames.length).toBeGreaterThan(0);
+    for (const frame of frames) {
+      // `far` rises to the top and the group packs in beneath it, rather than
+      // hanging six rows down where the pointer is.
+      expect(positions(frame)).toEqual({ far: '0,0', a: '0,1', b: '2,0' });
+    }
+  });
+
+  it('leaves unselected widgets where they are', async () => {
+    const onLayoutChange = vi.fn();
+    renderPair({ onLayoutChange });
+    await settled();
+
+    await grabAndDrag('a', 100, 0);
+
+    await vi.waitFor(() => expect(onLayoutChange).toHaveBeenCalled());
+    expect(positions(onLayoutChange.mock.lastCall![0]).far).toBe('0,4');
   });
 });
 

--- a/src/components/layout/Board/Board.browser.test.tsx
+++ b/src/components/layout/Board/Board.browser.test.tsx
@@ -1,0 +1,230 @@
+import { renderWithRoot, screen, userEvent } from '../../../test';
+
+import { Board } from './index';
+
+import type { LayoutItem } from './grid-core';
+
+/**
+ * Board in a real browser.
+ *
+ * The jsdom suite covers the wiring, and it has to mock every rectangle to do
+ * it — which is exactly the wrong tool for two questions. Whether the band
+ * `extraRows` reserves is really board (rather than a number in an inline
+ * style) is a hit-testing question, and hit-testing needs a browser. Whether a
+ * group survives being dragged across other widgets is a pointer question, and
+ * the geometry that decides it comes from real measured rects.
+ */
+
+const ROW = 100;
+
+/** A widget per layout item, `qa` upper-cased so `screen.getByTestId` is terse. */
+function renderBoard(
+  layout: LayoutItem[],
+  props: Record<string, unknown> = {},
+) {
+  const result = renderWithRoot(
+    <div style={{ width: '600px' }}>
+      <Board
+        cols={12}
+        rowHeight={ROW}
+        margin={[0, 0]}
+        containerPadding={[0, 0]}
+        selectionMode="multiple"
+        defaultLayout={layout}
+        {...props}
+      >
+        {layout.map((item) => (
+          <Board.Widget key={item.i} id={item.i} qa={item.i.toUpperCase()}>
+            {item.i}
+          </Board.Widget>
+        ))}
+      </Board>
+    </div>,
+  );
+
+  return result;
+}
+
+const board = () => screen.getByTestId('Board');
+const widget = (id: string) => screen.getByTestId(id.toUpperCase());
+/** The absolutely-positioned layer the marquee handler lives on. */
+const content = () => widget('a').parentElement as HTMLElement;
+
+/** Wait for the board to measure its container and lay the widgets out. */
+async function settled() {
+  await vi.waitFor(() =>
+    expect(widget('a').getBoundingClientRect().width).toBeGreaterThan(0),
+  );
+}
+
+/** Ids top-to-bottom, then left-to-right — "did the group split" in one line. */
+function stackOrder(): string[] {
+  return [...document.querySelectorAll<HTMLElement>('[data-board-widget-host]')]
+    .map((el) => ({
+      id: el.getAttribute('data-board-widget-id')!,
+      rect: el.getBoundingClientRect(),
+    }))
+    .sort((a, b) =>
+      Math.abs(a.rect.top - b.rect.top) > 1
+        ? a.rect.top - b.rect.top
+        : a.rect.left - b.rect.left,
+    )
+    .map((it) => it.id);
+}
+
+/**
+ * A press-drag-release along a straight line, in a few steps.
+ *
+ * `pageX`/`pageY` are set alongside the client coords deliberately: React
+ * Aria's `useMove` — which owns widget dragging — reads the page pair, and a
+ * gesture that only carries client coords looks like a press that never moved.
+ */
+async function dragPointer(
+  target: HTMLElement,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  steps = 4,
+) {
+  const at = (i: number) => {
+    const t = i / steps;
+    const x = from.x + (to.x - from.x) * t;
+    const y = from.y + (to.y - from.y) * t;
+
+    return { clientX: x, clientY: y, pageX: x, pageY: y };
+  };
+
+  await userEvent.pointer([
+    { keys: '[MouseLeft>]', target, coords: at(0) },
+    ...Array.from({ length: steps }, (_, i) => ({
+      target,
+      coords: at(i + 1),
+    })),
+    { keys: '[/MouseLeft]', target, coords: at(steps) },
+  ]);
+}
+
+const TWO_ROWS: LayoutItem[] = [
+  { i: 'a', x: 0, y: 0, w: 6, h: 1 },
+  { i: 'b', x: 6, y: 0, w: 6, h: 1 },
+  { i: 'c', x: 0, y: 1, w: 6, h: 1 },
+];
+
+describe('Board extraRows', () => {
+  it('hugs its content by default, so there is nothing below to grab', async () => {
+    renderBoard(TWO_ROWS);
+    await settled();
+
+    expect(board().getBoundingClientRect().height).toBeCloseTo(2 * ROW, 0);
+  });
+
+  it('reserves the band as real, hit-testable board surface', async () => {
+    renderBoard(TWO_ROWS, { extraRows: 3 });
+    await settled();
+
+    const rect = board().getBoundingClientRect();
+    expect(rect.height).toBeCloseTo(5 * ROW, 0);
+
+    // The claim `extraRows` actually makes. A point two rows below the last
+    // widget has to resolve to something inside the board — an inline
+    // `min-height` that nothing can be pressed on would satisfy the jsdom
+    // assertions and still leave the marquee undiscoverable.
+    const hit = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + 4 * ROW,
+    );
+    expect(board().contains(hit)).toBe(true);
+    expect(hit?.closest('[data-board-widget-host]')).toBeNull();
+  });
+
+  it('starts a marquee from the reserved band', async () => {
+    const onSelectionChange = vi.fn();
+    renderBoard(TWO_ROWS, { extraRows: 3, onSelectionChange });
+    await settled();
+
+    const rect = board().getBoundingClientRect();
+
+    // Press below every widget — page background before `extraRows` — and drag
+    // back up across the whole grid.
+    await dragPointer(
+      content(),
+      { x: rect.right - 8, y: rect.top + 4.5 * ROW },
+      { x: rect.left + 8, y: rect.top + 8 },
+    );
+
+    expect(onSelectionChange).toHaveBeenCalledWith(['a', 'b', 'c']);
+  });
+});
+
+describe('Board group move', () => {
+  const STACK: LayoutItem[] = [
+    { i: 'a', x: 0, y: 0, w: 12, h: 1 },
+    { i: 'b', x: 0, y: 1, w: 12, h: 1 },
+    { i: 'c', x: 0, y: 2, w: 12, h: 1 },
+    { i: 'd', x: 0, y: 3, w: 12, h: 1 },
+  ];
+
+  // Compaction packs every item independently by a global `(y, x)` sort, so the
+  // widgets a group is dragged past used to be packed *between* its members.
+  it('keeps a selected pair together when dragged up past other widgets', async () => {
+    renderBoard(STACK, {
+      compact: 'vertical',
+      defaultSelectedKeys: ['c', 'd'],
+    });
+    await settled();
+
+    expect(stackOrder()).toEqual(['a', 'b', 'c', 'd']);
+
+    const grabbed = widget('c');
+    const from = grabbed.getBoundingClientRect();
+
+    await dragPointer(
+      grabbed,
+      { x: from.left + from.width / 2, y: from.top + from.height / 2 },
+      {
+        x: from.left + from.width / 2,
+        y: from.top + from.height / 2 - 2 * ROW,
+      },
+    );
+
+    await vi.waitFor(() => expect(stackOrder()).toEqual(['c', 'd', 'a', 'b']));
+  });
+
+  // The drop re-compacts the source board, so an arrangement only the
+  // group-aware pass can produce would be undone the moment the pointer is
+  // released — the drag would preview right and land wrong.
+  it('commits exactly the arrangement the last drag frame showed', async () => {
+    const frames: LayoutItem[][] = [];
+    const onLayoutChange = vi.fn();
+
+    renderBoard(STACK, {
+      compact: 'vertical',
+      defaultSelectedKeys: ['c', 'd'],
+      onLayoutChange,
+      onDrag: (info: { layout: LayoutItem[] }) =>
+        frames.push(info.layout.map((it) => ({ ...it }))),
+    });
+    await settled();
+
+    const grabbed = widget('c');
+    const from = grabbed.getBoundingClientRect();
+
+    await dragPointer(
+      grabbed,
+      { x: from.left + from.width / 2, y: from.top + from.height / 2 },
+      {
+        x: from.left + from.width / 2,
+        y: from.top + from.height / 2 - 2 * ROW,
+      },
+    );
+
+    await vi.waitFor(() => expect(onLayoutChange).toHaveBeenCalled());
+
+    const asPositions = (items: LayoutItem[]) =>
+      Object.fromEntries(items.map((it) => [it.i, `${it.x},${it.y}`]));
+
+    expect(frames.length).toBeGreaterThan(0);
+    expect(asPositions(onLayoutChange.mock.lastCall![0])).toEqual(
+      asPositions(frames.at(-1)!),
+    );
+  });
+});

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -2507,216 +2507,31 @@ describe('Board', () => {
       });
     });
 
-    describe('marquee', () => {
-      const pointer = (
-        type: string,
-        clientX: number,
-        clientY: number,
-        modifiers: { ctrlKey?: boolean; shiftKey?: boolean } = {},
-      ) => {
-        const event = new PointerEvent(type, {
-          bubbles: true,
-          cancelable: true,
-          button: 0,
-          pointerId: 1,
-          pointerType: 'mouse',
-          clientX,
-          clientY,
-          ...modifiers,
-        });
-        Object.defineProperty(event, 'clientX', { get: () => clientX });
-        Object.defineProperty(event, 'clientY', { get: () => clientY });
-        return event;
+    // `extraRows` keeps a band of empty board below the content, so a full grid
+    // still has somewhere to start a lasso. Only the sizing arithmetic belongs
+    // here. Every marquee gesture — which widgets a band covers, the movement
+    // threshold, the modifiers — is decided by measured rectangles, and lives
+    // in `Board.browser.test.tsx` rather than being asserted against a mock.
+    describe('extraRows sizing', () => {
+      // Two content rows at 100px, no margins or padding.
+      const contentHeight = 200;
+
+      const boardHeight = (props: Record<string, unknown>) => {
+        renderSelectableBoard(props);
+
+        return screen.getByTestId('Board').style.minHeight;
       };
 
-      function setupMarquee(props: Record<string, unknown> = {}) {
-        const utils = renderSelectableBoard(props);
-        const content = screen.getByTestId('A').parentElement as HTMLElement;
-        content.getBoundingClientRect = () => mockRect(0, 0, 600, 400);
-
-        return { ...utils, content };
-      }
-
-      it('selects every widget the band intersects', () => {
-        const onSelectionChange = vi.fn();
-        const { content } = setupMarquee({ onSelectionChange });
-
-        // Band over x:[0,250], y:[0,50] — covers `a` (0-200) and `b` (200-400).
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        fireEvent(window, pointer('pointerup', 250, 50));
-
-        expect(onSelectionChange).toHaveBeenCalledTimes(1);
-        expect(onSelectionChange).toHaveBeenCalledWith(['a', 'b']);
+      it('clamps the band to maxRows', () => {
+        expect(boardHeight({ extraRows: 5, maxRows: 3 })).toBe('300px');
       });
 
-      it('commits once per gesture, not once per pointer frame', () => {
-        const onSelectionChange = vi.fn();
-        const { content } = setupMarquee({ onSelectionChange });
+      it('paints grid cells over the band, so it reads as board', () => {
+        renderSelectableBoard({ extraRows: 3, showGridLines: true });
 
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 100, 50));
-        fireEvent(window, pointer('pointermove', 150, 50));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        fireEvent(window, pointer('pointerup', 250, 50));
-
-        expect(onSelectionChange).toHaveBeenCalledTimes(1);
-      });
-
-      it('renders the band while dragging and removes it on release', () => {
-        const { content } = setupMarquee();
-
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        expect(screen.getByTestId('BoardMarquee')).toBeInTheDocument();
-
-        fireEvent(window, pointer('pointerup', 250, 50));
-        expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
-      });
-
-      it('ignores a press below the movement threshold and clears instead', async () => {
-        const onSelectionChange = vi.fn();
-        const { content, widget } = setupMarquee({ onSelectionChange });
-
-        await userEvent.click(widget('B'));
-        onSelectionChange.mockClear();
-
-        fireEvent(content, pointer('pointerdown', 0, 300));
-        fireEvent(window, pointer('pointermove', 1, 300));
-        fireEvent(window, pointer('pointerup', 1, 300));
-
-        expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
-        expect(onSelectionChange).toHaveBeenCalledWith([]);
-      });
-
-      it('adds to the existing selection with Shift', async () => {
-        const onSelectionChange = vi.fn();
-        const { content, widget } = setupMarquee({ onSelectionChange });
-
-        await userEvent.click(widget('C'));
-
-        fireEvent(content, pointer('pointerdown', 0, 0, { shiftKey: true }));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        fireEvent(window, pointer('pointerup', 250, 50));
-
-        expect(onSelectionChange).toHaveBeenLastCalledWith(['a', 'b', 'c']);
-      });
-
-      // `extraRows` keeps a band of empty board below the content, so a full
-      // grid still has somewhere to start a lasso. Only the sizing arithmetic
-      // belongs here — that the band is really board, and that a press in it
-      // starts a marquee, are layout and hit-testing questions and live in
-      // `Board.browser.test.tsx`.
-      describe('extraRows', () => {
-        // Two content rows at 100px, no margins or padding.
-        const contentHeight = 200;
-
-        const boardHeight = (props: Record<string, unknown>) => {
-          renderSelectableBoard(props);
-
-          return screen.getByTestId('Board').style.minHeight;
-        };
-
-        it('clamps the band to maxRows', () => {
-          expect(boardHeight({ extraRows: 5, maxRows: 3 })).toBe('300px');
-        });
-
-        it('paints grid cells over the band, so it reads as board', () => {
-          renderSelectableBoard({ extraRows: 3, showGridLines: true });
-
-          expect(screen.getByTestId('BoardGridOverlay').style.height).toBe(
-            `${contentHeight + 300}px`,
-          );
-        });
-      });
-
-      it('never starts on a widget — that press is a drag', () => {
-        const { widget } = setupMarquee();
-
-        fireEvent(widget('A'), pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 250, 50));
-
-        expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
-      });
-
-      // Dragging is off while the modifier is held, so the whole board — widgets
-      // included — becomes one selection surface.
-      it('adds to the selection from the platform modifier flag', async () => {
-        const onSelectionChange = vi.fn();
-        const { content } = setupMarquee({ onSelectionChange });
-
-        fireEvent(content, pointer('pointerdown', 0, 0, { ctrlKey: true }));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        fireEvent(window, pointer('pointerup', 250, 50));
-
-        expect(onSelectionChange).toHaveBeenCalledWith(['a', 'b']);
-      });
-
-      it('re-announces two consecutive selections that read the same', () => {
-        const { content } = setupMarquee();
-        const status = screen.getByRole('status');
-
-        // Band over a + b.
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        fireEvent(window, pointer('pointerup', 250, 50));
-        const first = status.textContent;
-
-        // Band over a + c — a different selection that renders the same text.
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 50, 150));
-        fireEvent(window, pointer('pointerup', 50, 150));
-
-        // A screen reader skips a live-region update whose text is
-        // byte-identical to the one before it, so these must differ.
-        expect(first).toContain('2 widgets selected');
-        expect(status).toHaveTextContent('2 widgets selected');
-        expect(status.textContent).not.toBe(first);
-      });
-
-      it('skips a widget that opted out of selection', () => {
-        const onSelectionChange = vi.fn();
-        render(
-          <Board
-            width={600}
-            cols={6}
-            rowHeight={100}
-            margin={[0, 0]}
-            containerPadding={[0, 0]}
-            selectionMode="multiple"
-            defaultLayout={selectionLayout}
-            onSelectionChange={onSelectionChange}
-          >
-            <Board.Widget id="a" qa="A">
-              A
-            </Board.Widget>
-            <Board.Widget id="b" qa="B" isSelectable={false}>
-              B
-            </Board.Widget>
-            <Board.Widget id="c" qa="C">
-              C
-            </Board.Widget>
-          </Board>,
+        expect(screen.getByTestId('BoardGridOverlay').style.height).toBe(
+          `${contentHeight + 300}px`,
         );
-        const content = screen.getByTestId('A').parentElement as HTMLElement;
-        content.getBoundingClientRect = () => mockRect(0, 0, 600, 400);
-
-        // A band over both `a` and `b`; only `a` may be picked up, matching what
-        // a press on `b` would (not) do.
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 250, 50));
-        fireEvent(window, pointer('pointerup', 250, 50));
-
-        expect(onSelectionChange).toHaveBeenCalledWith(['a']);
-      });
-
-      it('is disabled by allowMarqueeSelection={false}', () => {
-        const { content } = setupMarquee({ allowMarqueeSelection: false });
-
-        fireEvent(content, pointer('pointerdown', 0, 0));
-        fireEvent(window, pointer('pointermove', 250, 50));
-
-        expect(screen.queryByTestId('BoardMarquee')).not.toBeInTheDocument();
       });
     });
 
@@ -2824,110 +2639,6 @@ describe('Board', () => {
     const positions = (layout: LayoutItem[]) =>
       Object.fromEntries(layout.map((it) => [it.i, `${it.x},${it.y}`]));
 
-    it('moves every selected widget by the same delta', () => {
-      const onLayoutChange = vi.fn();
-      const { grabbed } = setupGroupBoard({ onLayoutChange });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 200, 100));
-      fireEvent(window, pointerEvent('pointerup', 200, 100));
-
-      const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
-      expect(positions(committed)).toMatchObject({ a: '2,1', b: '8,1' });
-    });
-
-    it('commits exactly once, before onDragStop', () => {
-      const calls: string[] = [];
-      const { grabbed } = setupGroupBoard({
-        onLayoutChange: () => calls.push('layout'),
-        onDragStop: () => calls.push('stop'),
-      });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 200, 0));
-      fireEvent(window, pointerEvent('pointerup', 200, 0));
-
-      expect(calls.filter((c) => c === 'layout')).toHaveLength(1);
-      expect(calls).toEqual(['layout', 'stop']);
-    });
-
-    // The live bug in the app-level version this replaces: clamping each item
-    // separately collapses the group against the wall and it never recovers.
-    it('keeps the group shape when dragged into an edge', () => {
-      const onLayoutChange = vi.fn();
-      const { grabbed } = setupGroupBoard({ onLayoutChange });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', -400, 0));
-      fireEvent(window, pointerEvent('pointerup', -400, 0));
-
-      const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
-      const a = committed.find((it) => it.i === 'a')!;
-      const b = committed.find((it) => it.i === 'b')!;
-      expect(b.x - a.x).toBe(6);
-      expect(a.x).toBe(0);
-    });
-
-    it('never leaves a widget pinned after a group drop', () => {
-      const onLayoutChange = vi.fn();
-      const { grabbed } = setupGroupBoard({
-        onLayoutChange,
-        compact: 'vertical',
-      });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 200, 100));
-      fireEvent(window, pointerEvent('pointerup', 200, 100));
-
-      const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
-      // A leaked pin would freeze the widget forever — and consumers persist
-      // layouts, so it would survive a reload.
-      expect(committed.every((it) => !it.static)).toBe(true);
-    });
-
-    it('reports every mover through the drag callbacks', () => {
-      const onDragStart = vi.fn();
-      const { grabbed } = setupGroupBoard({ onDragStart });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 100, 0));
-      fireEvent(window, pointerEvent('pointerup', 100, 0));
-
-      const info = onDragStart.mock.lastCall![0];
-      expect(info.items.map((it: LayoutItem) => it.i)).toEqual(['a', 'b']);
-      expect(info.item).toBe(info.items[0]);
-      expect(info.placeholders).toHaveLength(2);
-    });
-
-    // Reported: dragging a group down on a compacting board shoved the widgets
-    // below it further down, and the board only caught up on the *next* pointer
-    // step. The group was being held in place while everything reflowed around
-    // it — something a single widget is never allowed to do under vertical
-    // compaction, which is why a single drag felt natural and a group did not.
-    it('compacts the group during the drag, like a single widget', () => {
-      const frames: LayoutItem[][] = [];
-      const { grabbed } = setupGroupBoard({
-        compact: 'vertical',
-        defaultLayout: [
-          { i: 'a', x: 0, y: 0, w: 2, h: 1 },
-          { i: 'b', x: 2, y: 0, w: 2, h: 1 },
-          { i: 'far', x: 0, y: 3, w: 2, h: 1 },
-        ],
-        onDrag: (info: { layout: LayoutItem[] }) =>
-          frames.push(info.layout.map((it) => ({ ...it }))),
-      });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 0, 600));
-
-      expect(frames.length).toBeGreaterThan(0);
-      for (const frame of frames) {
-        // `far` rises to the top, and the group packs in beneath it instead of
-        // hanging six rows down where the pointer is.
-        expect(positions(frame)).toEqual({ far: '0,0', a: '0,1', b: '2,0' });
-      }
-    });
-
     // Pointer group-drags live in `Board.browser.test.tsx`: the arrangement a
     // drag produces is decided by measured geometry, and mocking every rect to
     // assert it in jsdom only proves the mocks agree with each other. The
@@ -2960,15 +2671,6 @@ describe('Board', () => {
       expect(Math.abs(order.indexOf('c') - order.indexOf('d'))).toBe(1);
     });
 
-    it('renders one placeholder per moving widget', () => {
-      const { grabbed } = setupGroupBoard();
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 100, 0));
-
-      expect(screen.getAllByTestId('BoardPlaceholder')).toHaveLength(2);
-    });
-
     it('moves the whole group with the arrow keys', () => {
       const onLayoutChange = vi.fn();
       const { grabbed } = setupGroupBoard({ onLayoutChange });
@@ -2979,18 +2681,6 @@ describe('Board', () => {
 
       const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
       expect(positions(committed)).toMatchObject({ a: '1,0', b: '7,0' });
-    });
-
-    it('leaves unselected widgets where they are', () => {
-      const onLayoutChange = vi.fn();
-      const { grabbed } = setupGroupBoard({ onLayoutChange });
-
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 0));
-      fireEvent(window, pointerEvent('pointermove', 100, 0));
-      fireEvent(window, pointerEvent('pointerup', 100, 0));
-
-      const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
-      expect(positions(committed).far).toBe('0,4');
     });
 
     it('drags only the grabbed widget when it is outside the selection', () => {

--- a/src/components/layout/Board/Board.test.tsx
+++ b/src/components/layout/Board/Board.test.tsx
@@ -2602,9 +2602,11 @@ describe('Board', () => {
         expect(onSelectionChange).toHaveBeenLastCalledWith(['a', 'b', 'c']);
       });
 
-      // A board hugs its content, so once the grid fills up there is no empty
-      // space left to grab and the lasso reads as broken. `extraRows` keeps a
-      // band of board below the content for exactly that.
+      // `extraRows` keeps a band of empty board below the content, so a full
+      // grid still has somewhere to start a lasso. Only the sizing arithmetic
+      // belongs here — that the band is really board, and that a press in it
+      // starts a marquee, are layout and hit-testing questions and live in
+      // `Board.browser.test.tsx`.
       describe('extraRows', () => {
         // Two content rows at 100px, no margins or padding.
         const contentHeight = 200;
@@ -2614,16 +2616,6 @@ describe('Board', () => {
 
           return screen.getByTestId('Board').style.minHeight;
         };
-
-        it('reserves no space by default', () => {
-          expect(boardHeight({})).toBe(`${contentHeight}px`);
-        });
-
-        it('reserves a band of empty rows below the content', () => {
-          expect(boardHeight({ extraRows: 3 })).toBe(
-            `${contentHeight + 300}px`,
-          );
-        });
 
         it('clamps the band to maxRows', () => {
           expect(boardHeight({ extraRows: 5, maxRows: 3 })).toBe('300px');
@@ -2635,21 +2627,6 @@ describe('Board', () => {
           expect(screen.getByTestId('BoardGridOverlay').style.height).toBe(
             `${contentHeight + 300}px`,
           );
-        });
-
-        it('starts a marquee in the reserved band', () => {
-          const onSelectionChange = vi.fn();
-          renderSelectableBoard({ extraRows: 3, onSelectionChange });
-          const content = screen.getByTestId('A').parentElement as HTMLElement;
-          content.getBoundingClientRect = () => mockRect(0, 0, 600, 500);
-
-          // Press below the last widget — page background before `extraRows`,
-          // board now — and drag back up across `a` and `b`.
-          fireEvent(content, pointer('pointerdown', 0, 450));
-          fireEvent(window, pointer('pointermove', 250, 50));
-          fireEvent(window, pointer('pointerup', 250, 50));
-
-          expect(onSelectionChange).toHaveBeenCalledWith(['a', 'b', 'c']);
         });
       });
 
@@ -2951,64 +2928,16 @@ describe('Board', () => {
       }
     });
 
-    // Compaction packs every item independently, by a global `(y, x)` sort. It
-    // used to run that way after a group move too, so the widgets the group was
-    // dragged past got packed *between* its members and the selection came
-    // apart. Gravity still wins; the group is just compacted as one run.
+    // Pointer group-drags live in `Board.browser.test.tsx`: the arrangement a
+    // drag produces is decided by measured geometry, and mocking every rect to
+    // assert it in jsdom only proves the mocks agree with each other. The
+    // keyboard path has no geometry in it at all, so it belongs here.
     const stackLayout = () => [
       { i: 'a', x: 0, y: 0, w: 12, h: 1 },
       { i: 'b', x: 0, y: 1, w: 12, h: 1 },
       { i: 'c', x: 0, y: 2, w: 12, h: 1 },
       { i: 'd', x: 0, y: 3, w: 12, h: 1 },
     ];
-
-    it('keeps the group contiguous when dragged up on a compacting board', () => {
-      const onLayoutChange = vi.fn();
-      setupGroupBoard({
-        compact: 'vertical',
-        defaultSelectedKeys: ['c', 'd'],
-        defaultLayout: stackLayout(),
-        onLayoutChange,
-      });
-
-      const grabbed = screen.getByTestId('C');
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 200));
-      fireEvent(window, pointerEvent('pointermove', 0, 0));
-      fireEvent(window, pointerEvent('pointerup', 0, 0));
-
-      const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
-      expect(positions(committed)).toEqual({
-        c: '0,0',
-        d: '0,1',
-        a: '0,2',
-        b: '0,3',
-      });
-    });
-
-    // The commit re-compacts the source board, so an arrangement that only the
-    // group-aware pass can produce would be undone the moment the pointer is
-    // released — the drag would preview right and land wrong.
-    it('commits exactly the arrangement the last drag frame showed', () => {
-      const frames: LayoutItem[][] = [];
-      const onLayoutChange = vi.fn();
-      setupGroupBoard({
-        compact: 'vertical',
-        defaultSelectedKeys: ['c', 'd'],
-        defaultLayout: stackLayout(),
-        onLayoutChange,
-        onDrag: (info: { layout: LayoutItem[] }) =>
-          frames.push(info.layout.map((it) => ({ ...it }))),
-      });
-
-      const grabbed = screen.getByTestId('C');
-      fireEvent(grabbed, pointerEvent('pointerdown', 0, 200));
-      fireEvent(window, pointerEvent('pointermove', 0, 0));
-      fireEvent(window, pointerEvent('pointerup', 0, 0));
-
-      const committed = onLayoutChange.mock.lastCall![0] as LayoutItem[];
-      expect(frames.length).toBeGreaterThan(0);
-      expect(positions(committed)).toEqual(positions(frames.at(-1)!));
-    });
 
     it('moves a group up with the arrow keys without splitting it', () => {
       const onLayoutChange = vi.fn();


### PR DESCRIPTION
### Describe changes

Follow-up to #1299. Two parts: the browser tests that were still uncommitted when #1299 merged, and the migration you asked for.

---

#### 1. What #1299 missed

`Board.browser.test.tsx` and the matching jsdom cleanup were written but not committed before the merge. Both fixes themselves landed correctly — `compactWithGroupOrder`, `extraRows`, `renderedRows` and the CUB-3755 unit tests are all on `main`.

#### 2. The migration

The marquee and group-drag suites decide their assertions from measured rectangles, and jsdom has no layout — so each one mocked `getBoundingClientRect` and then checked its arithmetic against its own mock. That only proves the mocks agree with each other. They now run in the browser project, against the browser's own rectangles.

**Migrated (18 tests)**
- the whole `marquee` suite — band intersection, movement threshold, Shift and platform-modifier additions, opt-out widget, live-region re-announcement, `allowMarqueeSelection={false}`
- the pointer half of `group move` — equal deltas, commit ordering, group-clamping at an edge, no leaked `static`, mover callbacks, placeholders, in-drag compaction, bystanders staying put

**New browser coverage for the #1299 fixes (5 tests)**
- `extraRows` makes the band **real, hit-testable board** — asserted with `elementFromPoint`, which is the actual claim the prop makes and the one an inline `min-height` assertion cannot check
- a marquee starts from that band; the board hugs its content without it
- a selected pair stays contiguous when dragged up past other widgets — **verified to fail without the CUB-3755 fix**
- the drop commits exactly the arrangement the last drag frame showed

**Left in jsdom, deliberately**
- the `extraRows` sizing arithmetic (pure prop → style math)
- the keyboard group moves — that path has no geometry in it at all
- `drag cancel / handle` (6 tests) — these assert *whether `onDragStart` fires*, not where anything lands. Event routing is something jsdom models correctly and an order of magnitude faster. Say the word if you want them moved anyway.

jsdom 115 → 95 Board tests; browser 0 → 23.

---

##### Three things the real browser forced

Each was silently wrong before and would have bitten the next person writing a browser test here:

1. **One `userEvent.setup()` instance per test.** Bare `userEvent.*` calls each build fresh state, so a held mouse button or a held modifier does not survive into the next call — which is most of a marquee gesture.
2. **`pointerEventsCheck` off.** The board deliberately swaps the dragged widget for an `opacity: 0`, `pointer-events: none` stand-in, so the release legitimately lands on a non-interactive element.
3. **Drags must carry `pageX`/`pageY`.** React Aria's `useMove` reads the page pair; a gesture with only client coords looks like a press that never moved. This is why the jsdom tests hand-defined `pageX` on every synthetic event.

Also: the marquee suite runs with `extraRows` on, because a lasso needs empty grid to start from and the three-widget fixture has almost none without it. In jsdom the press was simply aimed at the content layer and the coordinates never had to be empty — a gap the browser closes.

##### Still open

Not migrated, still geometry-driven in jsdom: `drag/resize lifecycle callbacks` (5), `cross-board drop target selection` (2), `spring-loaded tab activation` (3), and 2 stragglers in `free positioning`. Happy to take those in a third PR.

##### Checklist

- [x] Pipeline is passed
- [x] Tests are added
- [x] Tests are passed successfully
- [x] Changeset(s) is(are) added — n/a, tests only, no shipped behaviour change
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: N/A

#

### Other information

Verified locally: jsdom 1697 passed / 1 skipped across 82 files; browser 53 passed across 3 files; `tsc` clean for Board; oxlint and prettier clean. No `src/` behaviour changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)