### PR TITLE
fix(DisplayTransition): finish a collapse interrupted a frame before it starts

### DIFF
--- a/.changeset/witty-lamps-collapse.md
+++ b/.changeset/witty-lamps-collapse.md
@@ -1,0 +1,25 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`DisplayTransition`: finish the collapse when the flow is interrupted one frame before it starts,
+so `Disclosure` can no longer render an open panel under a collapsed header.
+
+Hiding is a two-step flow: the main effect sets the internal `exit-pending` phase, and the
+`[phase]` effect then schedules the double-rAF that advances it to `exit` and on to `unmounted`.
+Anything that re-ran the main effect while `exit-pending` was still on screen cancelled that rAF
+— and because `phase` had not changed, the `[phase]` effect never re-ran to replace it. The
+component was stranded in `exit-pending`, which reports as `entered`: the content stayed at full
+height indefinitely while `isShown` was already `false`, recovering only on the next toggle. The
+pending exit is now re-armed by whoever cancels it, mirroring how the enter flow already behaved.
+
+`Disclosure` is the one consumer that changes `transitionDuration` at runtime, so it is where this
+surfaced: a caller that disables the animation on the same event that collapses the panel — for
+example `transitionDuration={isBusy ? 0 : undefined}` — hit it whenever the two landed in separate
+renders. The trigger read as collapsed while the panel below it stayed fully expanded.
+
+Also adds a browser test tier for `DisplayTransition` and `Disclosure`. The
+`duration === undefined` path, which times the exit off the element's own `transitionend` and is
+what most consumers use, could not be tested under jsdom — with no layout, transition events never
+fire and the fallback timer always won — and `Disclosure`'s `height: 0 → max-content` animation has
+no measurable height there either.

--- a/src/components/content/Disclosure/Disclosure.browser.test.tsx
+++ b/src/components/content/Disclosure/Disclosure.browser.test.tsx
@@ -1,0 +1,95 @@
+import { act, renderWithRoot, screen, userEvent, waitFor } from '../../../test';
+
+import { Disclosure } from './Disclosure';
+
+/** Real time passing, inside act() so the resulting state updates are wrapped. */
+const settle = (ms: number) =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+
+const trigger = () => screen.getByRole('button', { name: 'Toggle' });
+const panel = () => screen.queryByTestId('DisclosureContentWrapper');
+const panelHeight = () => panel()?.getBoundingClientRect().height ?? 0;
+
+interface HarnessProps {
+  isExpanded: boolean;
+  /** Mirrors Disclosure consumers that disable the animation while streaming. */
+  transitionDuration?: number;
+}
+
+function Harness({ isExpanded, transitionDuration }: HarnessProps) {
+  return (
+    <Disclosure
+      isExpanded={isExpanded}
+      transitionDuration={transitionDuration}
+      onExpandedChange={() => {}}
+    >
+      <Disclosure.Trigger>Toggle</Disclosure.Trigger>
+      <Disclosure.Content>
+        <div style={{ height: '120px' }}>Panel content</div>
+      </Disclosure.Content>
+    </Disclosure>
+  );
+}
+
+/**
+ * Disclosure's open/closed geometry, in a real browser.
+ *
+ * The panel animates `height: 0 → max-content` via `interpolate-size:
+ * allow-keywords`, so its real height only exists where there is layout — jsdom
+ * reports 0 for both states and cannot tell an open panel from a closed one.
+ * That blind spot is why the panel collapsing to 0px shipped twice (#1209,
+ * #1249) and why the header/content desync in CUB-3793 was invisible to the
+ * suite.
+ */
+describe('Disclosure geometry', () => {
+  it('opens and closes the panel for real', async () => {
+    renderWithRoot(
+      <Disclosure>
+        <Disclosure.Trigger>Toggle</Disclosure.Trigger>
+        <Disclosure.Content>
+          <div style={{ height: '120px' }}>Panel content</div>
+        </Disclosure.Content>
+      </Disclosure>,
+    );
+
+    // Collapsed: the panel is not mounted at all.
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(panel()).not.toBeInTheDocument();
+
+    await userEvent.click(trigger());
+
+    await waitFor(() => expect(panelHeight()).toBeGreaterThan(100));
+    expect(trigger()).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(trigger());
+
+    await waitFor(() => expect(panel()).not.toBeInTheDocument(), {
+      timeout: 1000,
+    });
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('does not leave the panel open when the header says collapsed', async () => {
+    // CUB-3793. The chat passes transitionDuration={isStreaming ? 0 : undefined}
+    // and collapses when the run ends; the two land in separate renders, so the
+    // duration used to change while the collapse was still one frame from
+    // starting — cancelling it and stranding the panel at full height under a
+    // trigger that already read as collapsed.
+    const { rerender } = renderWithRoot(
+      <Harness isExpanded={true} transitionDuration={0} />,
+    );
+
+    await waitFor(() => expect(panelHeight()).toBeGreaterThan(100));
+
+    rerender(<Harness isExpanded={false} transitionDuration={0} />);
+    rerender(<Harness isExpanded={false} transitionDuration={undefined} />);
+
+    await settle(400);
+
+    // The invariant: the trigger and the panel agree.
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(panelHeight()).toBe(0);
+  });
+});

--- a/src/components/content/Disclosure/Disclosure.test.tsx
+++ b/src/components/content/Disclosure/Disclosure.test.tsx
@@ -545,9 +545,11 @@ describe('Content Preservation', () => {
       vi.advanceTimersByTime(150);
     });
 
-    // After completing the exit transition, content should have been preserved
-    // throughout the exit animation
-    // The content may no longer be visible after transition completes, but it
-    // should have been preserved during the exit phase
+    // Once the exit completes the panel unmounts, so the preserved content goes
+    // with it — it was kept only for the duration of the animation.
+    expect(container.textContent).not.toContain('original content');
+    expect(
+      container.querySelector('[data-qa="DisclosureContentWrapper"]'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/helpers/DisplayTransition/DisplayTransition.browser.test.tsx
+++ b/src/components/helpers/DisplayTransition/DisplayTransition.browser.test.tsx
@@ -1,0 +1,166 @@
+import { act, renderWithRoot, screen, waitFor } from '../../../test';
+
+import { DisplayTransition } from './DisplayTransition';
+
+import type { RefCallback } from 'react';
+
+/**
+ * Real time passing, inside act() so the state updates the rAFs and timers
+ * produce are not reported as unwrapped.
+ */
+const settle = (ms: number) =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+
+const probe = () => screen.getByTestId('probe');
+const phaseOf = () => probe().getAttribute('data-phase');
+const heightOf = () => probe().getBoundingClientRect().height;
+
+interface ProbeProps {
+  isShown: boolean;
+  /** undefined => native transition-event timing, the mode most consumers use. */
+  duration?: number;
+  onRest?: (transition: 'enter' | 'exit') => void;
+  /** Declare a real CSS height transition on the element. */
+  hasTransition?: boolean;
+  /** Skip binding the ref, leaving the hook with no element to listen on. */
+  detached?: boolean;
+}
+
+function Probe({
+  isShown,
+  duration,
+  onRest,
+  hasTransition = true,
+  detached = false,
+}: ProbeProps) {
+  return (
+    <DisplayTransition
+      exposeUnmounted
+      animateOnMount={false}
+      duration={duration}
+      isShown={isShown}
+      onRest={onRest}
+    >
+      {({ phase, isShown: shown, ref }) => (
+        <div
+          ref={detached ? undefined : (ref as RefCallback<HTMLDivElement>)}
+          data-phase={phase}
+          data-qa="probe"
+          data-shown={shown}
+          style={{
+            overflow: 'hidden',
+            height: shown ? '80px' : '0px',
+            transition: hasTransition ? 'height 120ms linear' : 'none',
+          }}
+        >
+          <div style={{ height: '80px' }}>content</div>
+        </div>
+      )}
+    </DisplayTransition>
+  );
+}
+
+/**
+ * Transition timing, in a real browser.
+ *
+ * The `duration === undefined` path — which listens for the element's own
+ * `transitionstart`/`transitionend`, and is what 8 of the 11 consumers use — is
+ * untestable under jsdom: jsdom has no layout and never fires transition
+ * events, so the 150ms "no transition started" fallback always won and the
+ * listener path never ran once.
+ */
+describe('DisplayTransition timing with real transitions', () => {
+  it('ends the exit on the real transitionend', async () => {
+    const onRest = vi.fn();
+
+    const { rerender } = renderWithRoot(
+      <Probe isShown={true} onRest={onRest} />,
+    );
+
+    expect(phaseOf()).toBe('entered');
+    expect(heightOf()).toBeCloseTo(80, 0);
+
+    rerender(<Probe isShown={false} onRest={onRest} />);
+
+    // The collapse takes a frame to arm, then the real 120ms transition runs.
+    await waitFor(() => expect(phaseOf()).toBe('exit'));
+    expect(onRest).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(phaseOf()).toBe('unmounted'), { timeout: 1000 });
+
+    expect(onRest).toHaveBeenCalledWith('exit');
+    expect(onRest).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the short timer when no transition is declared', async () => {
+    const onRest = vi.fn();
+
+    const { rerender } = renderWithRoot(
+      <Probe hasTransition={false} isShown={true} onRest={onRest} />,
+    );
+
+    rerender(<Probe hasTransition={false} isShown={false} onRest={onRest} />);
+
+    // No transitionstart ever fires, so the 150ms fallback has to complete it.
+    await waitFor(() => expect(phaseOf()).toBe('unmounted'), { timeout: 1000 });
+
+    expect(onRest).toHaveBeenCalledWith('exit');
+  });
+
+  it('falls back to the long timer when there is no element to listen on', async () => {
+    const onRest = vi.fn();
+
+    const { rerender } = renderWithRoot(
+      <Probe detached isShown={true} onRest={onRest} />,
+    );
+
+    rerender(<Probe detached isShown={false} onRest={onRest} />);
+
+    // AUTO_FALLBACK_DURATION is 500ms — comfortably longer than the 150ms one,
+    // so check it has not resolved early before waiting it out.
+    await settle(250);
+    expect(phaseOf()).not.toBe('unmounted');
+
+    await waitFor(() => expect(phaseOf()).toBe('unmounted'), { timeout: 2000 });
+
+    expect(onRest).toHaveBeenCalledWith('exit');
+  });
+
+  it('finishes the exit when the duration changes mid-collapse', async () => {
+    // CUB-3793 against real frames: the collapse and the duration change land in
+    // two separate renders inside the same frame, which used to cancel the
+    // pending exit and strand the element visible.
+    const onRest = vi.fn();
+
+    const { rerender } = renderWithRoot(
+      <Probe duration={0} isShown={true} onRest={onRest} />,
+    );
+
+    rerender(<Probe duration={0} isShown={false} onRest={onRest} />);
+    rerender(<Probe duration={undefined} isShown={false} onRest={onRest} />);
+
+    await waitFor(() => expect(phaseOf()).toBe('unmounted'), { timeout: 1000 });
+
+    expect(onRest).toHaveBeenCalledWith('exit');
+  });
+
+  it('keeps the element shown when re-shown mid-collapse', async () => {
+    const onRest = vi.fn();
+
+    const { rerender } = renderWithRoot(
+      <Probe isShown={true} onRest={onRest} />,
+    );
+
+    rerender(<Probe isShown={false} onRest={onRest} />);
+    rerender(<Probe isShown={true} onRest={onRest} />);
+
+    // Give the cancelled exit every chance to fire late.
+    await settle(400);
+
+    expect(phaseOf()).toBe('entered');
+    expect(heightOf()).toBeCloseTo(80, 0);
+    expect(onRest).not.toHaveBeenCalledWith('exit');
+  });
+});

--- a/src/components/helpers/DisplayTransition/DisplayTransition.test.tsx
+++ b/src/components/helpers/DisplayTransition/DisplayTransition.test.tsx
@@ -4,13 +4,42 @@ import { render } from '../../../test';
 
 import { DisplayTransition } from './DisplayTransition';
 
+import type { DisplayTransitionProps } from './DisplayTransition';
+
+/** Renders the transition with a probe element exposing phase/isShown as attributes. */
+function Probe(props: Omit<DisplayTransitionProps, 'children'>) {
+  return (
+    <DisplayTransition {...props}>
+      {({ phase, isShown, ref }) => (
+        <div ref={ref} data-phase={phase} data-shown={isShown}>
+          content
+        </div>
+      )}
+    </DisplayTransition>
+  );
+}
+
+const phaseOf = (container: HTMLElement) =>
+  container.querySelector('[data-phase]')?.getAttribute('data-phase');
+
+const shownOf = (container: HTMLElement) =>
+  container.querySelector('[data-shown]')?.getAttribute('data-shown');
+
 describe('DisplayTransition', () => {
+  const originalMatchMedia = window.matchMedia;
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    // Tests that stub matchMedia must not leak it into the rest of the file:
+    // the jsdom project shares one environment across a worker.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    });
   });
 
   it('should handle initial states correctly based on props', () => {
@@ -515,5 +544,297 @@ describe('DisplayTransition', () => {
 
     // Content should be gone immediately since preserveContent=false
     expect(container.textContent).not.toContain('original content');
+  });
+
+  describe('exit interrupted mid-collapse', () => {
+    // The collapse is a two-step flow: the main flow effect sets 'exit-pending',
+    // then the [phase] effect schedules the double-rAF that advances it to
+    // 'exit' → 'unmounted'. Anything that re-runs the flow effect while
+    // 'exit-pending' is still on screen cancels that rAF, so the flow effect has
+    // to re-arm it — otherwise the [phase] effect never re-runs (phase did not
+    // change) and the content is stranded visible while the driver says hidden.
+
+    it('should finish the exit when duration flips 0 → undefined mid-collapse', () => {
+      // Reproduces CUB-3793: Disclosure passes transitionDuration={isStreaming ? 0 : undefined},
+      // and in chat the collapse and the streaming flag land in separate renders.
+      const onRest = vi.fn();
+
+      const { container, rerender } = render(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={0}
+          isShown={true}
+          onRest={onRest}
+        />,
+      );
+
+      expect(phaseOf(container)).toBe('entered');
+
+      // Collapse. Do not advance time: this leaves 'exit-pending' on screen with
+      // the double-rAF still pending.
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={0}
+          isShown={false}
+          onRest={onRest}
+        />,
+      );
+
+      expect(phaseOf(container)).toBe('entered'); // 'exit-pending' reports as 'entered'
+      expect(shownOf(container)).toBe('true');
+
+      // Streaming ends one render later, so the duration changes while still pending.
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={undefined}
+          isShown={false}
+          onRest={onRest}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(phaseOf(container)).toBe('unmounted');
+      expect(shownOf(container)).toBe('false');
+      expect(onRest).toHaveBeenCalledWith('exit');
+    });
+
+    it('should finish the exit when a numeric duration changes mid-collapse', () => {
+      const onRest = vi.fn();
+
+      const { container, rerender } = render(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+          onRest={onRest}
+        />,
+      );
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={false}
+          onRest={onRest}
+        />,
+      );
+
+      expect(phaseOf(container)).toBe('entered');
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={300}
+          isShown={false}
+          onRest={onRest}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(phaseOf(container)).toBe('unmounted');
+      expect(onRest).toHaveBeenCalledWith('exit');
+      expect(onRest).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stay entered when re-shown during exit-pending', () => {
+      const onRest = vi.fn();
+
+      const { container, rerender } = render(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+          onRest={onRest}
+        />,
+      );
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={false}
+          onRest={onRest}
+        />,
+      );
+
+      // Re-shown before the exit ever started.
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+          onRest={onRest}
+        />,
+      );
+
+      expect(phaseOf(container)).toBe('entered');
+      expect(shownOf(container)).toBe('true');
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // The cancelled exit must not sneak through afterwards.
+      expect(phaseOf(container)).toBe('entered');
+      expect(shownOf(container)).toBe('true');
+      expect(onRest).not.toHaveBeenCalledWith('exit');
+    });
+
+    it('should re-enter when re-shown during the exit phase', () => {
+      const { container, rerender } = render(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+        />,
+      );
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={false}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      expect(phaseOf(container)).toBe('exit');
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      expect(phaseOf(container)).toBe('entered');
+      expect(shownOf(container)).toBe('true');
+    });
+
+    it('should not fire callbacks after unmounting mid-exit', () => {
+      const onRest = vi.fn();
+      const onPhaseChange = vi.fn();
+
+      const { rerender, unmount } = render(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+          onRest={onRest}
+          onPhaseChange={onPhaseChange}
+        />,
+      );
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={false}
+          onRest={onRest}
+          onPhaseChange={onPhaseChange}
+        />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      onRest.mockClear();
+      onPhaseChange.mockClear();
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(onRest).not.toHaveBeenCalled();
+      expect(onPhaseChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('callbacks', () => {
+    it('should report exit phases without ever exposing exit-pending', () => {
+      const onPhaseChange = vi.fn();
+      const onToggle = vi.fn();
+
+      const { rerender } = render(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={true}
+          onPhaseChange={onPhaseChange}
+          onToggle={onToggle}
+        />,
+      );
+
+      // Mounting straight into 'entered' is not a change.
+      expect(onPhaseChange).not.toHaveBeenCalled();
+      expect(onToggle).not.toHaveBeenCalled();
+
+      rerender(
+        <Probe
+          exposeUnmounted
+          animateOnMount={false}
+          duration={150}
+          isShown={false}
+          onPhaseChange={onPhaseChange}
+          onToggle={onToggle}
+        />,
+      );
+
+      // 'exit-pending' is an internal phase — it reports as 'entered', which is
+      // what we were already in, so neither callback fires yet.
+      expect(onPhaseChange).not.toHaveBeenCalled();
+      expect(onToggle).not.toHaveBeenCalled();
+
+      // Step through the double-rAF and the duration separately. Advancing past
+      // both inside one act() collapses the commits, so the intermediate 'exit'
+      // render would never be observed.
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      expect(onPhaseChange.mock.calls.flat()).toEqual(['exit']);
+      expect(onToggle.mock.calls.flat()).toEqual([false]);
+
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(onPhaseChange.mock.calls.flat()).toEqual(['exit', 'unmounted']);
+      // Visibility already changed at 'exit'; unmounting is not a second toggle.
+      expect(onToggle.mock.calls.flat()).toEqual([false]);
+    });
   });
 });

--- a/src/components/helpers/DisplayTransition/DisplayTransition.tsx
+++ b/src/components/helpers/DisplayTransition/DisplayTransition.tsx
@@ -262,6 +262,17 @@ export function DisplayTransition({
     });
   };
 
+  // frame N: "exit-pending" (still shown) → frame N+1: "exit" (hidden) → ensureExitFlow.
+  // Idempotent and re-callable, mirroring ensureEnterFlow: whoever cancels the
+  // pending rAF is responsible for re-arming it.
+  const ensureExitPendingFlow = () => {
+    nextPaint(() => {
+      if (phaseRef.current !== 'exit-pending') return;
+      setPhase('exit');
+      ensureExitFlow();
+    });
+  };
+
   useLayoutEffect(() => {
     ++flowRef.current; // invalidate any pending work
     const current = phaseRef.current;
@@ -291,8 +302,13 @@ export function DisplayTransition({
         setPhase('exit-pending');
       } else if (current === 'exit') {
         ensureExitFlow();
+      } else {
+        // Still "exit-pending": our own cleanup just cancelled the rAF the
+        // [phase] effect scheduled, and that effect will not re-run because
+        // `phase` did not change. Re-arm it here or the content stays visible
+        // forever while the driver reports hidden.
+        ensureExitPendingFlow();
       }
-      // 'exit-pending' is handled in useLayoutEffect below
     }
 
     return () => {
@@ -308,12 +324,7 @@ export function DisplayTransition({
       ensureEnterFlow();
     } else if (phaseRef.current === 'exit-pending') {
       // Schedule RAF for exit, mirroring the enter flow timing
-      nextPaint(() => {
-        if (phaseRef.current === 'exit-pending') {
-          setPhase('exit');
-          ensureExitFlow();
-        }
-      });
+      ensureExitPendingFlow();
     }
     return cancelRAF;
   }, [phase]);


### PR DESCRIPTION
Fixes an open `Disclosure` panel rendering under a collapsed header, reported in [CUB-3793](https://linear.app/cube-d3/issue/CUB-3793/chat-disclosure-renders-open-while-its-header-shows-collapsed).

## The bug

Hiding runs in two steps: the main flow effect sets the internal `exit-pending` phase, and the `[phase]` effect then schedules the double-rAF that advances it to `exit` and on to `unmounted`.

Anything that re-ran the main flow effect while `exit-pending` was still on screen fell through its `else if` chain to no branch at all, while its cleanup had already cancelled the pending rAF and `++flowRef` had invalidated that rAF's guard. Because `phase` never changed, the `[phase]` effect did not re-run to replace it. The component was stranded in `exit-pending` — which reports as `entered` — so the content stayed at full height indefinitely while `isShown` was already `false`, recovering only on the next toggle.

The enter side never had this hole: `current === 'enter'` re-calls `ensureEnterFlow()`. The pending exit is now re-armed the same way, by whoever cancels it.

## Why Disclosure

`Disclosure` is the only one of the 11 `DisplayTransition` consumers that changes `duration` at runtime (`Overlay` uses a module constant; the rest leave it `undefined` forever). A caller that disables the animation on the same event that collapses the panel — `transitionDuration={isBusy ? 0 : undefined}` — hits it whenever the collapse and the duration change land in separate renders, which is exactly what Cube Cloud's chat does when a run stops streaming.

## Tests

The regression is covered at both levels, and both cases fail on `main`:

- `DisplayTransition.test.tsx` — duration flipping `0 → undefined` and `150 → 300` mid-collapse, plus the previously uncovered interrupt branches (re-shown during `exit-pending`, re-shown during `exit`, unmount mid-exit) and the `onPhaseChange`/`onToggle` sequences, asserting `exit-pending` is never reported.
- `Disclosure.browser.test.tsx` — the reported invariant in a real browser: after the collapse the trigger reads `aria-expanded="false"` **and** the panel measures 0px. On `main` this reports `expected 120 to be +0`.

Both files also close a standing blind spot. `DisplayTransition.browser.test.tsx` is the first coverage of the `duration === undefined` path, which times the exit off the element's own `transitionend` and is what 8 of the 11 consumers use — jsdom has no layout, so transition events never fire and the 150ms fallback always won, meaning the listener path had never once executed under test. It now covers a real `transitionend`, the 150ms no-transition fallback, and the 500ms no-element fallback. `Disclosure`'s `height: 0 → max-content` animation likewise has no measurable height in jsdom, which is why the panel collapsing to 0px shipped twice (#1209, #1249).

Two hygiene fixes found while reading: the reduced-motion test replaced `window.matchMedia` and never restored it (the jsdom project shares one environment per worker), and `Disclosure.test.tsx`'s content-preservation test ended in a comment with no `expect` at all.

Full `pnpm test` (164 files / 3400 tests) and `pnpm test:browser` (60 tests) are green, along with `pnpm lint` and `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)