### PR TITLE
feat(probe): add `@cube-dev/ui-kit/probe` entry for inspecting rendered output

### DIFF
--- a/.changeset/probe-entry.md
+++ b/.changeset/probe-entry.md
@@ -1,0 +1,15 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `@cube-dev/ui-kit/probe` — DOM-pure helpers for tooling that inspects what a render produced.
+
+Answering "what HTML and CSS did this component tree actually generate?" is a recurring need for agents and dev tooling, and the pieces to do it correctly were either unreachable or easy to get subtly wrong.
+
+- `canonicalizeIds` / `canonicalizeClassNames` / `canonicalize` — normalise React and react-aria element IDs and tasty class-name hashes so two renders can be compared byte-for-byte. These already existed in `src/eslint-plugin/probe.tsx`, which is not part of the `./eslint-plugin` entry, so nothing outside this repo could import them. They now live in `src/probe/` and are re-exported from their old home.
+- `captureCss` / `splitRules` / `diffRules` — read the CSS a subtree caused, by capturing the empty harness, mounting, capturing again and subtracting. Scoping `getCSSTextForNode` to an inner wrapper is the obvious approach and is wrong: `<Root>` is the `PortalProvider` target, so Dialog / Menu / Tooltip / Select popups mount as its *siblings* and drop out of the result entirely.
+- `captureCss` also collects the rules the CSS engine refused instead of suppressing them. jsdom *discards* `@container style()` and `@property` rules rather than degrading them, so a jsdom-derived dump is incomplete — not merely unresolved — for components that use them, and a caller needs to be told.
+
+The entry is deliberately DOM-pure: it operates on an already-rendered node, so it adds no test-renderer dependency and carries no opinion about the provider stack, which is the part that genuinely differs per consumer.
+
+Also fixes the jsdom test setup's tasty warning filter, which matched `[tasty]` against tasty's `[Tasty]` and so had never suppressed anything.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "./eslint-plugin": {
       "import": "./dist/eslint-plugin/index.js",
       "types": "./dist/eslint-plugin/index.d.ts"
+    },
+    "./probe": {
+      "import": "./dist/probe/index.js",
+      "types": "./dist/probe/index.d.ts"
     }
   },
   "files": [

--- a/src/eslint-plugin/probe.tsx
+++ b/src/eslint-plugin/probe.tsx
@@ -1,6 +1,7 @@
 import { getCSSTextForNode } from '@tenphi/tasty';
 import { ReactElement } from 'react';
 
+import { canonicalize } from '../probe/canonicalize';
 import { cleanup, renderWithRoot } from '../test';
 
 import { DefaultValue, PropEntry, SkipReason } from './types';
@@ -26,77 +27,16 @@ export interface Probe {
 }
 
 /**
- * Replace generated element IDs with positional placeholders.
- *
- * React's `useId` draws from a global counter, so the same tree rendered twice
- * yields `«r0»` then `«r2»` and a byte comparison would fail for every
- * component that labels an input. Rewriting each distinct ID to `«idN»` in
- * order of first appearance keeps the `id` <-> `aria-labelledby` / `for`
- * relationships meaningful — a structural change still shows up as a
- * difference — while dropping the counter's absolute value.
+ * The canonicalisers now live in `src/probe/canonicalize.ts` so consumers can
+ * reach them — this file is not part of the `./eslint-plugin` entry, so nothing
+ * outside the repo could import from it. Re-exported here to keep this module's
+ * existing callers and tests working unchanged.
  */
-export function canonicalizeIds(text: string): string {
-  const seen = new Map<string, string>();
-
-  const replace = (match: string) => {
-    let placeholder = seen.get(match);
-
-    if (!placeholder) {
-      placeholder = `«id${seen.size}»`;
-      seen.set(match, placeholder);
-    }
-
-    return placeholder;
-  };
-
-  return (
-    text
-      .replace(/«[^»]*»/g, replace)
-      // react-aria mints its own counter-based IDs in several shapes:
-      // `react-aria1`, `react-aria-1`, and `react-aria-description-0`.
-      .replace(/\breact-aria[\w-]*?\d+\b/g, replace)
-  );
-}
-
-/**
- * Replace tasty's generated class names with positional placeholders.
- *
- * The hash is derived from the *input* style object, not the CSS it produces, so two
- * inputs that normalise to identical CSS still get different class names. `<Space>`
- * sets `gap: true` and `<Space gap="1x">` resolves to the same `gap: var(--gap)` — the
- * emitted rules are byte-identical and only the hash differs. Comparing raw output
- * therefore reported a real redundancy as "differs", and the prop never became a
- * registry candidate.
- *
- * Placeholders are assigned in order of first appearance, so this cannot hide a
- * genuine difference: an extra, missing or reordered class shifts the sequence and
- * still compares unequal. Only the arbitrary hash value is normalised away.
- *
- * The pattern requires a digit so it matches `t1iuxaru` / `tp3unhd` without touching
- * all-letter CSS keywords that happen to start with `t` (`translate`, `transform`).
- */
-export function canonicalizeClassNames(text: string): string {
-  const seen = new Map<string, string>();
-
-  return text.replace(
-    /\bt(?=[a-z0-9]{6,8}\b)(?![a-z]+\b)[a-z0-9]{6,8}\b/g,
-    (match) => {
-      let placeholder = seen.get(match);
-
-      if (!placeholder) {
-        placeholder = `tcls${seen.size}`;
-        seen.set(match, placeholder);
-      }
-
-      return placeholder;
-    },
-  );
-}
-
-/** Both normalisations, in the order the probe applies them. */
-export function canonicalize(text: string): string {
-  return canonicalizeClassNames(canonicalizeIds(text));
-}
+export {
+  canonicalize,
+  canonicalizeClassNames,
+  canonicalizeIds,
+} from '../probe/canonicalize';
 
 export function probe(ui: ReactElement): Probe {
   // `baseElement` (document.body), not `container`: overlay components render

--- a/src/probe/canonicalize.ts
+++ b/src/probe/canonicalize.ts
@@ -1,0 +1,85 @@
+/**
+ * Normalising generated identifiers out of rendered output.
+ *
+ * Moved here from `src/eslint-plugin/probe.tsx` so consumers can reach them:
+ * that file is not part of the `./eslint-plugin` entry, so nothing outside this
+ * repo could import it. `probe.tsx` re-exports them, so its own callers and the
+ * defaults registry are unaffected.
+ *
+ * Both functions exist for the same reason — comparing two renders byte-for-byte
+ * requires dropping values that are arbitrary per render but structurally
+ * meaningful in aggregate.
+ */
+
+/**
+ * Replace generated element IDs with positional placeholders.
+ *
+ * React's `useId` draws from a global counter, so the same tree rendered twice
+ * yields `«r0»` then `«r2»` and a byte comparison would fail for every
+ * component that labels an input. Rewriting each distinct ID to `«idN»` in
+ * order of first appearance keeps the `id` <-> `aria-labelledby` / `for`
+ * relationships meaningful — a structural change still shows up as a
+ * difference — while dropping the counter's absolute value.
+ */
+export function canonicalizeIds(text: string): string {
+  const seen = new Map<string, string>();
+
+  const replace = (match: string) => {
+    let placeholder = seen.get(match);
+
+    if (!placeholder) {
+      placeholder = `«id${seen.size}»`;
+      seen.set(match, placeholder);
+    }
+
+    return placeholder;
+  };
+
+  return (
+    text
+      .replace(/«[^»]*»/g, replace)
+      // react-aria mints its own counter-based IDs in several shapes:
+      // `react-aria1`, `react-aria-1`, and `react-aria-description-0`.
+      .replace(/\breact-aria[\w-]*?\d+\b/g, replace)
+  );
+}
+
+/**
+ * Replace tasty's generated class names with positional placeholders.
+ *
+ * The hash is derived from the *input* style object, not the CSS it produces, so
+ * two inputs that normalise to identical CSS still get different class names.
+ * `<Space>` sets `gap: true` and `<Space gap="1x">` resolves to the same
+ * `gap: var(--gap)` — the emitted rules are byte-identical and only the hash
+ * differs.
+ *
+ * Placeholders are assigned in order of first appearance, so this cannot hide a
+ * genuine difference: an extra, missing or reordered class shifts the sequence
+ * and still compares unequal. Only the arbitrary hash value is normalised away.
+ *
+ * The pattern requires a digit so it matches `t1iuxaru` / `tp3unhd` without
+ * touching all-letter CSS keywords that happen to start with `t` (`translate`,
+ * `transform`).
+ */
+export function canonicalizeClassNames(text: string): string {
+  const seen = new Map<string, string>();
+
+  return text.replace(
+    /\bt(?=[a-z0-9]{6,8}\b)(?![a-z]+\b)[a-z0-9]{6,8}\b/g,
+    (match) => {
+      let placeholder = seen.get(match);
+
+      if (!placeholder) {
+        placeholder = `tcls${seen.size}`;
+        seen.set(match, placeholder);
+      }
+
+      return placeholder;
+    },
+  );
+}
+
+/** Both normalisations, in the order a probe applies them. */
+export function canonicalize(text: string): string {
+  return canonicalizeClassNames(canonicalizeIds(text));
+}

--- a/src/probe/canonicalize.ts
+++ b/src/probe/canonicalize.ts
@@ -37,7 +37,14 @@ export function canonicalizeIds(text: string): string {
 
   return (
     text
-      .replace(/«[^»]*»/g, replace)
+      // `[^«»]`, not `[^»]`: excluding the OPENING delimiter too keeps this
+      // linear. With `[^»]*` an unterminated run of `«` makes the engine scan
+      // to the end of the input from every one of them — quadratic, and
+      // reachable now that this is published API called on caller-supplied
+      // markup rather than only on our own renders (CodeQL js/polynomial-redos).
+      // It is also the tighter reading: an unterminated `«r0` should not
+      // swallow the next ID.
+      .replace(/«[^«»]*»/g, replace)
       // react-aria mints its own counter-based IDs in several shapes:
       // `react-aria1`, `react-aria-1`, and `react-aria-description-0`.
       .replace(/\breact-aria[\w-]*?\d+\b/g, replace)

--- a/src/probe/css.ts
+++ b/src/probe/css.ts
@@ -1,0 +1,90 @@
+/**
+ * Extracting the CSS a rendered subtree actually caused.
+ *
+ * The naive approach — read `getCSSTextForNode` for the node you care about —
+ * does not work under a `<Root>`, for two independent reasons:
+ *
+ * 1. `<Root>` declares the whole design-system token block, so the dump is
+ *    dominated by rules the subtree did not cause (~119KB of ~135KB in Cube
+ *    Cloud's console-ui).
+ * 2. Scoping the query to an inner wrapper looks like the fix and is not:
+ *    `<Root>` is the `PortalProvider` target, so Dialog / Menu / Tooltip /
+ *    Select popups mount as *siblings* of that wrapper. Their CSS — and their
+ *    markup — silently vanish from the result.
+ *
+ * So measure the whole region twice and subtract: capture the empty harness,
+ * mount the subject, capture again, and diff. Portals are inside the measured
+ * region in both passes, so they survive.
+ */
+import { getCSSTextForNode } from '@tenphi/tasty';
+
+/** One captured pass: the raw CSS text plus any rules the engine rejected. */
+export interface CssCapture {
+  text: string;
+  warnings: string[];
+}
+
+/**
+ * Split a `getCSSTextForNode` dump into individual rules.
+ *
+ * The dump is one rule per line, including at-rules whose block is inlined onto
+ * the same line, so lines are the natural unit.
+ */
+export function splitRules(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Rules present in `full` but not in `baseline`, in their original order.
+ *
+ * Set-based rather than positional: the injector is free to reorder or coalesce
+ * chunks between passes, and a positional diff would report the whole tail as
+ * new the first time that happens.
+ */
+export function diffRules(baseline: string, full: string): string[] {
+  const seen = new Set(splitRules(baseline));
+
+  return splitRules(full).filter((rule) => !seen.has(rule));
+}
+
+/**
+ * Capture the CSS for a node, collecting the rules the CSS engine refused.
+ *
+ * jsdom does not merely fail to *resolve* `@container style()` and `@property`
+ * rules — it discards them, so a jsdom-derived dump is incomplete rather than
+ * unresolved for any component that uses them. tasty reports each rejection
+ * through `console.warn`, so collect them rather than suppressing: a caller
+ * needs to know when its answer is partial.
+ *
+ * Matched case-insensitively — tasty emits `[Tasty]` with a capital T, and this
+ * repo's own jsdom setup filtered for `[tasty]` for a long time without ever
+ * matching.
+ */
+export function captureCss(node: ParentNode): CssCapture {
+  const warnings: string[] = [];
+  const original = console.warn;
+
+  console.warn = (...args: unknown[]) => {
+    const first = args[0];
+
+    if (
+      typeof first === 'string' &&
+      first.toLowerCase().includes('browser rejected css rule')
+    ) {
+      warnings.push(args.slice(1).map(String).join(' '));
+
+      return;
+    }
+
+    original(...args);
+  };
+
+  try {
+    return { text: getCSSTextForNode(node), warnings };
+  } finally {
+    console.warn = original;
+  }
+}

--- a/src/probe/index.ts
+++ b/src/probe/index.ts
@@ -1,0 +1,30 @@
+/**
+ * `@cube-dev/ui-kit/probe` — helpers for inspecting what a render produced.
+ *
+ * For tooling that answers "what HTML and CSS did this component tree actually
+ * generate?" — the question that otherwise costs a throwaway test file per ask.
+ *
+ * Deliberately small, and deliberately DOM-pure: everything here operates on an
+ * already-rendered node, so it carries no opinion about how you rendered it and
+ * adds no dependency on a test renderer. Consumers wrap their own provider
+ * stack, which is the part that genuinely differs between apps — this package's
+ * harness is `<Root>`, while a product's is usually router + data-layer +
+ * `<Root>`.
+ *
+ * `renderStyles` (what CSS does this styles object produce) and
+ * `renderColorTokens` (what do the color tokens resolve to) are already on the
+ * main entry and are not duplicated here.
+ *
+ * Note for consumers reading CSS out of a jsdom render: jsdom *discards*
+ * `@container style()` and `@property` rules rather than degrading them, so the
+ * result is incomplete for components that use them. `captureCss` reports those
+ * rejections in `warnings` — surface them rather than dropping them, or you
+ * will hand someone a confidently partial answer.
+ */
+export {
+  canonicalize,
+  canonicalizeClassNames,
+  canonicalizeIds,
+} from './canonicalize';
+export { captureCss, diffRules, splitRules } from './css';
+export type { CssCapture } from './css';

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -87,14 +87,18 @@ const suppressedConsoleError = (...args: any[]) => {
 console.error = suppressedConsoleError;
 
 // Suppress console.warn for tasty @container query rejections
-// These warnings occur because jsdom/cssom doesn't support CSS container style queries
+// These warnings occur because jsdom/cssom doesn't support CSS container style queries.
+//
+// Matched case-insensitively: tasty emits `[Tasty] Browser rejected CSS rule:`
+// with a capital T, and `String.prototype.includes` is case-sensitive — so the
+// original lowercase check never matched and this filter suppressed nothing.
 const originalWarn = console.warn;
 console.warn = (...args: any[]) => {
   const firstArg = args[0];
   const secondArg = args[1];
   if (
     typeof firstArg === 'string' &&
-    firstArg.includes('[tasty] Browser rejected CSS rule:')
+    firstArg.toLowerCase().includes('[tasty] browser rejected css rule:')
   ) {
     // Only suppress @container query warnings (style() not supported in jsdom)
     if (typeof secondArg === 'string' && secondArg.includes('@container')) {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
     // registry and its types, so linting never pulls React into the lint
     // process.
     'eslint-plugin/index': 'src/eslint-plugin/index.ts',
+    // Third entry: DOM-pure helpers for tooling that inspects rendered output
+    // (`@cube-dev/ui-kit/probe`). Version-locked for the same reason as above —
+    // the class-name pattern it normalises is tasty's, and the CSS it reads is
+    // this package's.
+    'probe/index': 'src/probe/index.ts',
   },
   format: 'esm',
   outDir: 'dist',


### PR DESCRIPTION
## Why

"What HTML and CSS did this component tree actually generate?" is a recurring question for agents and dev tooling. Today answering it costs a throwaway test file per ask — and the evidence that this is happening is scattered across both repos: this repo has orphaned `__screenshots__/` directories from deleted `describe('probe')` specs, Cube Cloud's `docs/glaze.md` prescribes the throwaway-spec pattern verbatim, and a Playwright spec there hand-transcribes this package's `Board` geometry as raw CSS strings because there was no way to mount the real component.

The pieces to answer it correctly were either unreachable or easy to get subtly wrong. This adds a small, DOM-pure entry with the two that matter.

## What

**`canonicalizeIds` / `canonicalizeClassNames` / `canonicalize`** — normalise React and react-aria element IDs and tasty class-name hashes so two renders compare byte-for-byte. These already existed in `src/eslint-plugin/probe.tsx`, which is **not** part of the `./eslint-plugin` entry — so nothing outside this repo could import them. Moved to `src/probe/` and re-exported from their old home; the defaults registry and its tests are unaffected.

**`captureCss` / `splitRules` / `diffRules`** — read the CSS a subtree caused, by capturing the empty harness, mounting, capturing again and subtracting.

> Scoping `getCSSTextForNode` to an inner wrapper is the obvious approach, and it is wrong. `<Root>` is the `PortalProvider` target, so `Dialog` / `Menu` / `Tooltip` / `Select` popups mount as its **siblings**. Measured that way a `Dialog`'s markup comes back as **zero characters** while its ~219 rules go missing entirely. Subtraction keeps portals inside the measured region in both passes.

**`captureCss` reports refused rules rather than suppressing them.** jsdom *discards* `@container style()` and `@property` rules instead of degrading them, so a jsdom-derived dump is **incomplete**, not merely unresolved, for components that use them. Callers need to know when to escalate to a real browser.

Also fixes the jsdom setup's tasty warning filter, which tested for `[tasty]` against tasty's `[Tasty]`. `String.includes` is case-sensitive, so it has never suppressed anything — the `@container` warnings it exists to hide have been printing all along.

## Design notes

- **Deliberately DOM-pure.** Everything operates on an already-rendered node, so the entry adds no test-renderer dependency and carries no opinion about the provider stack — the part that genuinely differs per consumer. This package's harness is `<Root>`; a product's is usually router + data layer + `<Root>`.
- **`renderStyles` and `renderColorTokens` are not duplicated** — they are already on the main entry.
- Third `tsdown` entry alongside `index` and `eslint-plugin/index`, version-locked for the same reason: the class-name pattern it normalises is tasty's, and the CSS it reads is this package's.

## Verification

- `src/eslint-plugin/probe.test.tsx` + `defaults.test.ts` — 17 passed, covering the moved canonicalisers through their original call sites.
- Built and exercised the emitted entry directly: `canonicalize('«r0» t1iuxaru t1iuxaru')` → `«id0» tcls0 tcls0`; `diffRules` and `splitRules` behave as documented.
- Consumer-side: Cube Cloud's `yarn probe` / `yarn probe:browser` were built against these semantics and verified end to end (a `Dialog` returns 0 inline chars + 219 subtracted rules; jsdom reports `var(--surface-2-color)` where Chromium reports `rgb(248, 248, 249)`). Will re-verify against the canary from this PR via `yarn update-uikit`.