### PR TITLE
feat(Calendar): pick a month or year from a list

### DIFF
--- a/.changeset/calendar-month-year-navigation.md
+++ b/.changeset/calendar-month-year-navigation.md
@@ -1,0 +1,24 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Calendar: pick a month or a year from a list instead of paging with arrows.
+
+- `Calendar` / `RangeCalendar` (and therefore `DatePicker`, `DateRangePicker`
+  and `DateRangeSeparatedPicker`) now render the header month and year as
+  buttons that open a month list and a year list. Opt out with
+  `hasMonthYearNavigation={false}`.
+- `MonthPicker` and `QuarterPicker` gained the same year list behind the year in
+  their header.
+- The period panels are now proper ARIA grids with full keyboard support: arrow
+  keys roll over into the neighbouring year or decade, `PageUp`/`PageDown` page
+  by year or decade, `Home`/`End` jump to the first or last selectable period,
+  and `Escape` steps back one panel instead of closing the popover.
+- Day and period cells mark the cell containing today with a `current` modifier,
+  and periods are disabled only when the whole period falls outside
+  `minValue`/`maxValue`.
+- `PeriodPicker` no longer duplicates the field's label props onto its value
+  text, describes its trigger with the selected value, honours `isReadOnly`, and
+  truncates overlong custom `formatValue` output. Its placeholders and the new
+  calendar labels are translated in all twelve locales.
+- `Calendar` passed its ref through without attaching it to the DOM; it now does.

--- a/.changeset/calendar-month-year-navigation.md
+++ b/.changeset/calendar-month-year-navigation.md
@@ -22,3 +22,9 @@ Calendar: pick a month or a year from a list instead of paging with arrows.
   truncates overlong custom `formatValue` output. Its placeholders and the new
   calendar labels are translated in all twelve locales.
 - `Calendar` passed its ref through without attaching it to the DOM; it now does.
+- `Popover` (every `DialogTrigger type="popover"`, so also `Select`-style
+  fields, menus and the date pickers) only became keyboard-dismissable once its
+  enter animation had settled, because it registered with React Aria's
+  visible-overlay stack on the transition's `isOpen` rather than the trigger's.
+  `Escape` pressed in the first frames after opening did nothing; it now closes
+  the popover immediately.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -20,7 +20,17 @@ module.exports = [
         }),
       );
     },
-    // 495.09 kB in CI at the time of writing, 86 bytes over the previous
+    // 498.78 kB in CI at the time of writing, 1.78 kB over the previous
+    // 497 kB. That is the calendar's month/year navigation: the shared
+    // `CalendarPanel` / `CalendarHeader` / `PeriodGrid` that `Calendar`,
+    // `RangeCalendar` and `PeriodCalendar` now build on (the three of them
+    // previously carried three copies of a header and two of the cell styles,
+    // so the net is smaller than the new code), plus the eleven `calendar.*`
+    // and `datePicker.select*` strings across twelve locales, which are
+    // registered eagerly. Measured against `main` at 496.25 kB with both sides
+    // rebuilt: +2.53 kB. Raised to 501 kB.
+    //
+    // Before this: 495.09 kB in CI, 86 bytes over the previous
     // 495 kB. Two things stack into that: `DataTable`'s column menu, adaptive
     // column colors and column reordering, which left `main` itself ~300 bytes
     // under the old budget, and the ~0.4 kB of disabled-state handling that
@@ -75,7 +85,7 @@ module.exports = [
     //
     // Note when checking locally: `size-limit` bundles the built `./dist`, it
     // does not build. Run `pnpm build` first or you will measure a stale bundle.
-    limit: '497kB',
+    limit: '501kB',
   },
   {
     name: 'Tree shaking (just a Button)',

--- a/src/components/fields/DatePicker/DatePicker.test.tsx
+++ b/src/components/fields/DatePicker/DatePicker.test.tsx
@@ -167,5 +167,64 @@ describe('<DatePicker />', () => {
         timeout: 1500,
       });
     });
+
+    it('Escape closes the popover from the day panel', async () => {
+      const { baseElement } = renderWithRoot(
+        <DatePicker
+          label="Date"
+          defaultValue={new CalendarDate(2025, 6, 15)}
+        />,
+      );
+
+      await user.click(
+        baseElement.querySelector('[data-popover-trigger]') as HTMLElement,
+      );
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(true));
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(false));
+    });
+
+    it('Escape steps back from the month panel instead of closing', async () => {
+      const { baseElement } = renderWithRoot(
+        <DatePicker
+          label="Date"
+          defaultValue={new CalendarDate(2025, 6, 15)}
+        />,
+      );
+
+      await user.click(
+        baseElement.querySelector('[data-popover-trigger]') as HTMLElement,
+      );
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(true));
+
+      const dialog = baseElement.querySelector(
+        '[data-qa="Dialog"]',
+      ) as HTMLElement;
+
+      await user.click(within(dialog).getByRole('button', { name: 'June' }));
+      await waitFor(() =>
+        expect(
+          within(dialog).getByRole('grid', { name: 'Months' }),
+        ).toBeTruthy(),
+      );
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() =>
+        expect(
+          within(dialog).queryByRole('grid', { name: 'Months' }),
+        ).toBeNull(),
+      );
+      expect(isCalendarOpen(baseElement)).toBe(true);
+
+      // A second Escape leaves the calendar entirely.
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => expect(isCalendarOpen(baseElement)).toBe(false));
+    });
   });
 });

--- a/src/components/fields/DatePicker/DatePicker.test.tsx
+++ b/src/components/fields/DatePicker/DatePicker.test.tsx
@@ -14,6 +14,21 @@ describe('<DatePicker />', () => {
   const isCalendarOpen = (baseElement: HTMLElement) =>
     !!baseElement.querySelector('[data-qa="Dialog"]');
 
+  /**
+   * The calendar heading is made of two buttons that open the month and year
+   * pickers, so assert on those instead of the heading's raw text.
+   */
+  const expectVisibleMonth = (
+    dialog: HTMLElement,
+    month: string,
+    year: string,
+  ) => {
+    const heading = within(dialog).getByRole('heading', { level: 6 });
+
+    expect(within(heading).getByRole('button', { name: month })).toBeTruthy();
+    expect(within(heading).getByRole('button', { name: year })).toBeTruthy();
+  };
+
   describe('calendar popover month navigation', () => {
     it('clicking next-month inside a nested popover keeps the parent popover open', async () => {
       const { baseElement } = renderWithRoot(
@@ -85,9 +100,7 @@ describe('<DatePicker />', () => {
         '[data-qa="Dialog"]',
       ) as HTMLElement;
 
-      expect(
-        within(dialog).getByRole('heading', { level: 6 }),
-      ).toHaveTextContent('June 2025');
+      expectVisibleMonth(dialog, 'June', '2025');
 
       // Click the "Next" month navigation button
       await user.click(within(dialog).getByRole('button', { name: /next/i }));
@@ -96,9 +109,7 @@ describe('<DatePicker />', () => {
       await new Promise((resolve) => setTimeout(resolve, 16));
 
       expect(isCalendarOpen(baseElement)).toBe(true);
-      expect(
-        within(dialog).getByRole('heading', { level: 6 }),
-      ).toHaveTextContent('July 2025');
+      expectVisibleMonth(dialog, 'July', '2025');
     });
 
     it('clicking prev-month keeps the popover open', async () => {
@@ -126,9 +137,7 @@ describe('<DatePicker />', () => {
       await new Promise((resolve) => setTimeout(resolve, 16));
 
       expect(isCalendarOpen(baseElement)).toBe(true);
-      expect(
-        within(dialog).getByRole('heading', { level: 6 }),
-      ).toHaveTextContent('May 2025');
+      expectVisibleMonth(dialog, 'May', '2025');
     });
 
     it('selecting a date closes the popover', async () => {

--- a/src/components/fields/DatePicker/PeriodPicker.docs.mdx
+++ b/src/components/fields/DatePicker/PeriodPicker.docs.mdx
@@ -23,6 +23,10 @@ The value is always a single `CalendarDate` (from `@internationalized/date`)
 The field renders a compact label for the selected period (`2026-W33`, `2026-08`,
 `2026-Q3`, `2026`). Use `formatValue` to override it.
 
+In the month and quarter panels the year in the header is a button that opens a
+year list, so picking a period several years away takes two clicks instead of
+paging through the arrows.
+
 ## When to Use
 
 - Filtering or reporting by week, month, quarter, or fiscal year
@@ -37,13 +41,14 @@ The field renders a compact label for the selected period (`2026-W33`, `2026-08`
 
 ### Properties
 
+- **`picker`** `'week' | 'month' | 'quarter' | 'year'` (default: `month`) — Which period is selected. The four named components set it for you; only the base `PeriodPicker` takes it directly
 - **`value`** `DateValue` — The current value (controlled), snapped to the period start
 - **`defaultValue`** `DateValue` — The default value (uncontrolled)
 - **`minValue`** `DateValue` — The earliest selectable period
 - **`maxValue`** `DateValue` — The latest selectable period
 - **`isDateUnavailable`** `(date: DateValue) => boolean` — Marks a period (by its start date) as unavailable
 - **`placeholder`** `string` — Text shown when no value is selected
-- **`formatValue`** `(date: DateValue, picker: PickerType) => string` — Overrides the displayed label
+- **`formatValue`** `(date: DateValue, picker: PickerType, locale: string) => string` — Overrides the displayed label
 - **`size`** `'small' | 'medium' | 'large' | (string & {})` (default: `medium`) — Field size
 - **`shouldFlip`** `boolean` (default: `true`) — Whether the popover flips to fit the viewport
 - **`isOpen`** `boolean` — Whether the popover is open (controlled)
@@ -51,9 +56,8 @@ The field renders a compact label for the selected period (`2026-W33`, `2026-08`
 - **`onChange`** `(value: DateValue | null) => void` — Fired when the selected period changes
 - **`onOpenChange`** `(isOpen: boolean) => void` — Fired when the popover opens or closes
 
-The advanced `PeriodPicker` base component accepts the same props plus a
-**`picker`** `'week' | 'month' | 'quarter' | 'year'` prop; the four named
-components are thin wrappers that set it for you.
+`WeekPicker`, `MonthPicker`, `QuarterPicker` and `YearPicker` are thin wrappers
+that pin `picker`; everything else is identical.
 
 ### Base Properties
 
@@ -69,6 +73,17 @@ Supports all [Field properties](/docs/getting-started-field-properties--docs)
 - **`wrapperStyles`** — the input wrapper
 - **`inputStyles`** — the value/label area
 - **`triggerStyles`** — the calendar trigger button
+
+### Style Properties
+
+These properties allow direct style application without using the `styles` prop:
+
+- **Base:** `display`, `font`, `preset`, `hide`, `whiteSpace`, `opacity`, `transition`
+- **Position:** `gridArea`, `order`, `gridColumn`, `gridRow`, `placeSelf`, `alignSelf`, `justifySelf`, `zIndex`, `margin`, `inset`, `position`, `scrollMargin`
+- **Dimension:** `width`, `height`, `flexBasis`, `flexGrow`, `flexShrink`, `flex`
+- **Block:** `border`, `radius`, `shadow`, `outline`, `padding`, `paddingInline`, `paddingBlock`, `overflow`, `scrollbar`, `textAlign`
+- **Color:** `color`, `fill`, `fade`, `image`
+- **Flow:** `flow`, `place`, `placeItems`, `placeContent`, `alignItems`, `alignContent`, `justifyItems`, `justifyContent`, `align`, `justify`, `gap`, `columnGap`, `rowGap`, `gridColumns`, `gridRows`, `gridTemplate`, `gridAreas`
 
 ## Examples
 
@@ -90,4 +105,30 @@ Supports all [Field properties](/docs/getting-started-field-properties--docs)
 
 ### Limited range
 
+Periods that fall entirely outside `minValue` / `maxValue` are disabled, and the
+navigation arrows stop at the edge of the range.
+
 <Story of={PeriodPickerStories.WithLimitedRange} />
+
+## Accessibility
+
+### Keyboard Navigation
+
+- `Tab` — Moves focus to the calendar trigger
+- `Enter` / `Space` — Opens the panel; focus lands on the selected period
+- `Arrow keys` — Move between periods, rolling over into the neighbouring year or decade
+- `PageUp` / `PageDown` — Previous / next year (or decade in the year list)
+- `Home` / `End` — First / last selectable period on the page
+- `Escape` — Steps back from the year list to the period list
+
+### Screen Reader Support
+
+- The panel is a `grid` labelled `Months`, `Quarters` or `Years`
+- The trigger is described by the field's current value, so the selection is
+  announced along with the button
+
+## Related Components
+
+- [DatePicker](/docs/forms-datepicker--docs) — pick an exact day
+- [DateRangePicker](/docs/forms-daterangepicker--docs) — pick a start and end date
+- [Calendar](/docs/other-calendar--docs) — the panels these fields render

--- a/src/components/fields/DatePicker/PeriodPicker.tsx
+++ b/src/components/fields/DatePicker/PeriodPicker.tsx
@@ -6,7 +6,7 @@ import {
   Styles,
   tasty,
 } from '@tenphi/tasty';
-import { forwardRef, useRef } from 'react';
+import { forwardRef, useId, useRef } from 'react';
 import {
   AriaDatePickerProps,
   DateValue,
@@ -16,6 +16,7 @@ import {
 } from 'react-aria';
 import { useDatePickerState } from 'react-stately';
 
+import { useI18n } from '../../../i18n';
 import { FieldBaseProps } from '../../../shared';
 import { mergeProps } from '../../../utils/react';
 import { extractStyles } from '../../../utils/styles';
@@ -29,21 +30,18 @@ import { DatePickerButton } from './DatePickerButton';
 import { formatPeriod, PickerType, snapToPeriod } from './period';
 import { useFocusManagerRef } from './utils';
 
-const DEFAULT_PLACEHOLDER: Record<PickerType, string> = {
-  week: 'Select week',
-  month: 'Select month',
-  quarter: 'Select quarter',
-  year: 'Select year',
-};
-
 const PeriodValueElement = tasty({
+  qa: 'PeriodPickerValue',
   styles: {
     preset: 't3',
     width: 'max 100%',
     whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
     color: {
       '': '#dark',
       placeholder: '#dark.30',
+      disabled: '#dark.30',
     },
   },
 });
@@ -64,13 +62,15 @@ export interface CubePeriodPickerProps<T extends DateValue = DateValue>
   /** Placeholder shown when no value is selected. */
   placeholder?: string;
   /** Override how the selected value is rendered as text. */
-  formatValue?: (date: DateValue, picker: PickerType) => string;
+  formatValue?: (date: DateValue, picker: PickerType, locale: string) => string;
 }
 
 function PeriodPicker<T extends DateValue>(
   props: CubePeriodPickerProps<T>,
   ref: FocusableRef<HTMLElement>,
 ) {
+  const { t } = useI18n();
+
   props = useFieldProps(props, {
     defaultValidationTrigger: 'onBlur',
   });
@@ -84,10 +84,18 @@ function PeriodPicker<T extends DateValue>(
     placeholder,
     formatValue,
     isDisabled,
+    isReadOnly,
     isInvalid,
     isValid,
     autoFocus,
   } = props;
+
+  let defaultPlaceholder: Record<PickerType, string> = {
+    week: t('datePicker.selectWeek', 'Select week'),
+    month: t('datePicker.selectMonth', 'Select month'),
+    quarter: t('datePicker.selectQuarter', 'Select quarter'),
+    year: t('datePicker.selectYear', 'Select year'),
+  };
 
   let { locale } = useLocale();
   let targetRef = useRef<HTMLDivElement>(null);
@@ -117,7 +125,11 @@ function PeriodPicker<T extends DateValue>(
 
   let displayText = state.value
     ? (formatValue ?? formatPeriod)(state.value, picker, locale)
-    : placeholder ?? DEFAULT_PLACEHOLDER[picker];
+    : placeholder ?? defaultPlaceholder[picker];
+
+  // The value is rendered as text rather than editable segments, so the trigger
+  // has to point at it to announce the current selection.
+  let valueId = useId();
 
   const panel =
     picker === 'week' ? (
@@ -147,7 +159,10 @@ function PeriodPicker<T extends DateValue>(
       qa={qa || 'PeriodPicker'}
       inputType="datepicker"
       styles={{ display: 'grid', ...styles, ...props.wrapperStyles }}
-      inputStyles={props.inputStyles}
+      inputStyles={{
+        cursor: isDisabled || isReadOnly ? 'default' : 'pointer',
+        ...props.inputStyles,
+      }}
       disableFocusRing={isFocusedButton}
       isDisabled={isDisabled}
       isInvalid={isInvalid}
@@ -168,7 +183,8 @@ function PeriodPicker<T extends DateValue>(
           <DatePickerButton
             size={size}
             {...mergeProps(buttonProps, focusPropsButton)}
-            isDisabled={isDisabled}
+            aria-describedby={valueId}
+            isDisabled={isDisabled || isReadOnly}
             styles={props.triggerStyles}
           />
           <Dialog {...dialogProps} width="max-content">
@@ -178,9 +194,9 @@ function PeriodPicker<T extends DateValue>(
       }
     >
       <PeriodValueElement
-        {...labelProps}
-        mods={{ placeholder: !state.value }}
-        onClick={() => !isDisabled && setOpen(true)}
+        id={valueId}
+        mods={{ placeholder: !state.value, disabled: isDisabled }}
+        onClick={() => !isDisabled && !isReadOnly && setOpen(true)}
       >
         {displayText}
       </PeriodValueElement>

--- a/src/components/other/Calendar/Calendar.docs.mdx
+++ b/src/components/other/Calendar/Calendar.docs.mdx
@@ -197,8 +197,6 @@ Month and year lists:
   caps would read better for long ranges.
 - Multi-month (`visibleDuration`) layouts are not implemented; the header falls
   back to a plain title when a range spans more than one month.
-- `Escape` inside the day panel does not close the surrounding popover — that is
-  a `Dialog` behaviour, not a calendar one.
 
 ## Related Components
 

--- a/src/components/other/Calendar/Calendar.docs.mdx
+++ b/src/components/other/Calendar/Calendar.docs.mdx
@@ -1,0 +1,207 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+
+import * as CalendarStories from './Calendar.stories.tsx';
+
+<Meta of={CalendarStories} />
+
+# Calendar
+
+`Calendar` renders a month grid for picking a single date. `RangeCalendar` picks
+a contiguous range, and `PeriodCalendar` picks a whole month, quarter or year.
+All three are the panels behind the date fields — [DatePicker](/docs/forms-datepicker--docs),
+[DateRangePicker](/docs/forms-daterangepicker--docs) and the
+[period pickers](/docs/forms-periodpicker--docs) — and they are built on
+React Aria's `useCalendar` / `useRangeCalendar`.
+
+The header title is the navigation: the month and the year are buttons that open
+a month list and a year list, so reaching a date two years out takes two clicks
+instead of twenty-four.
+
+## When to Use
+
+- Embedding a calendar directly in a page or panel rather than behind a field
+- Building a custom date input that needs the same grid and states
+- Otherwise, prefer the date fields — they add the text input, label, validation
+  and popover for you
+
+## Component
+
+<Story of={CalendarStories.Default} />
+
+---
+
+### Properties
+
+#### Calendar
+
+- **`value`** `DateValue` — The selected date (controlled)
+- **`defaultValue`** `DateValue` — The initially selected date (uncontrolled)
+- **`minValue`** `DateValue` — The earliest selectable date
+- **`maxValue`** `DateValue` — The latest selectable date
+- **`isDateUnavailable`** `(date: DateValue) => boolean` — Marks individual dates as unavailable
+- **`pickerMode`** `'day' | 'week'` (default: `day`) — `week` shows a week-number column and highlights the whole week of the selected day
+- **`hasMonthYearNavigation`** `boolean` (default: `true`) — Whether the header month and year are buttons that open the month and year lists
+- **`selectedRange`** `{ start: DateValue; end: DateValue }` — Highlights a range that lives outside the calendar's own state (used by `DateRangeSeparatedPicker`)
+- **`isDisabled`** `boolean` — Disables the whole calendar
+- **`isReadOnly`** `boolean` — Allows navigation but not selection
+- **`onChange`** `(value: DateValue) => void` — Fired when a date is selected
+
+#### RangeCalendar
+
+Accepts React Aria's `AriaRangeCalendarProps` (a `{ start, end }` value) plus
+**`hasMonthYearNavigation`**.
+
+#### PeriodCalendar
+
+- **`picker`** `'month' | 'quarter' | 'year'` — Which period the panel selects
+- **`value`** `DateValue | null` — The selected period, represented by its start date
+- **`minValue`** / **`maxValue`** `DateValue | null` — Range limits; a period is disabled only when *all* of it falls outside
+- **`isDateUnavailable`** `(date: DateValue) => boolean` — Called with the period's start date
+- **`isDisabled`** `boolean`
+- **`autoFocus`** `boolean` — Moves focus into the grid on mount
+- **`onChange`** `(date: CalendarDate) => void` — Fired with the period's start date
+
+### Base Properties
+
+Supports [Base properties](/docs/getting-started-base-properties--docs)
+
+### Modifiers
+
+Day cells and period cells share one set of modifiers:
+
+| Modifier      | Type      | Description                                          |
+| ------------- | --------- | ---------------------------------------------------- |
+| `selected`    | `boolean` | The cell is part of the current selection            |
+| `current`     | `boolean` | The cell contains today                              |
+| `outside`     | `boolean` | The cell belongs to an adjacent month or decade      |
+| `rangeHover`  | `boolean` | The whole row is highlighted (week mode)             |
+| `pressed`     | `boolean` | The cell is being pressed                            |
+| `focused`     | `boolean` | The cell holds keyboard focus                        |
+| `disabled`    | `boolean` | The cell is outside `minValue` / `maxValue`          |
+| `unavailable` | `boolean` | `isDateUnavailable` returned `true` for the cell     |
+
+## Examples
+
+### Basic Usage
+
+```jsx
+import { parseDate } from '@internationalized/date';
+
+<Calendar
+  defaultValue={parseDate('2026-08-12')}
+  onChange={(date) => console.log(date.toString())}
+/>;
+```
+
+### Week Selection
+
+<Story of={CalendarStories.WeekMode} />
+
+```jsx
+<Calendar pickerMode="week" defaultValue={parseDate('2026-08-12')} />
+```
+
+### Limited Range
+
+Months and years that fall entirely outside `minValue` / `maxValue` are disabled
+in the month and year lists too, and the navigation arrows stop at the edge.
+
+<Story of={CalendarStories.LimitedRange} />
+
+```jsx
+<Calendar
+  defaultValue={parseDate('2026-08-12')}
+  minValue={parseDate('2026-08-05')}
+  maxValue={parseDate('2026-09-20')}
+/>
+```
+
+### Without Month/Year Navigation
+
+<Story of={CalendarStories.WithoutMonthYearNavigation} />
+
+```jsx
+<Calendar hasMonthYearNavigation={false} defaultValue={parseDate('2026-08-12')} />
+```
+
+### Range
+
+<Story of={CalendarStories.Range} />
+
+```jsx
+<RangeCalendar
+  defaultValue={{
+    start: parseDate('2026-08-10'),
+    end: parseDate('2026-08-19'),
+  }}
+/>
+```
+
+### Period Panels
+
+<Story of={CalendarStories.Periods} />
+
+```jsx
+<PeriodCalendar
+  picker="month"
+  value={new CalendarDate(2026, 8, 1)}
+  onChange={(date) => console.log(date.toString())}
+/>
+```
+
+## Accessibility
+
+### Keyboard Navigation
+
+Day grid (provided by React Aria):
+
+- `Arrow keys` — Move between days
+- `PageUp` / `PageDown` — Previous / next month
+- `Home` / `End` — First / last day of the week
+- `Enter` / `Space` — Select the focused day
+
+Month and year lists:
+
+- `Arrow keys` — Move between periods, rolling over into the neighbouring year or decade
+- `PageUp` / `PageDown` — Previous / next year (month list) or decade (year list)
+- `Home` / `End` — First / last selectable period on the page
+- `Enter` / `Space` — Choose the period
+- `Escape` — Step back to the previous panel without closing a surrounding popover
+
+### Screen Reader Support
+
+- Each panel is a `grid`, labelled `Months` / `Quarters` / `Years`
+- The visible month and year are the calendar's `heading`, and their buttons are
+  the controls that open the lists
+- Cells expose `aria-selected`; out-of-range periods are `disabled`
+
+## Best Practices
+
+1. **Do**: bound the calendar when the domain is bounded — the month and year
+   lists disable everything out of range, which is far clearer than letting the
+   user land somewhere unselectable.
+
+   ```jsx
+   <Calendar minValue={today(getLocalTimeZone())} />
+   ```
+
+2. **Don't**: reach for `PeriodCalendar` to pick a day. Its value is always the
+   *start* of a period, never an exact date.
+
+3. **Accessibility**: always give a standalone calendar an `aria-label` — inside
+   a field the label comes from the field.
+
+## Suggested Improvements
+
+- Range calendars paint every day in the range the same way; distinct start/end
+  caps would read better for long ranges.
+- Multi-month (`visibleDuration`) layouts are not implemented; the header falls
+  back to a plain title when a range spans more than one month.
+- `Escape` inside the day panel does not close the surrounding popover — that is
+  a `Dialog` behaviour, not a calendar one.
+
+## Related Components
+
+- [DatePicker](/docs/forms-datepicker--docs) — a date field with this calendar in a popover
+- [DateRangePicker](/docs/forms-daterangepicker--docs) — a range field built on `RangeCalendar`
+- [PeriodPicker](/docs/forms-periodpicker--docs) — week / month / quarter / year fields

--- a/src/components/other/Calendar/Calendar.stories.tsx
+++ b/src/components/other/Calendar/Calendar.stories.tsx
@@ -1,0 +1,111 @@
+import { CalendarDate, parseDate } from '@internationalized/date';
+import { StoryFn } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { baseProps } from '../../../stories/lists/baseProps';
+import { Space } from '../../layout/Space';
+
+import { Calendar, CubeCalendarProps } from './Calendar';
+import { CubePeriodCalendarProps, PeriodCalendar } from './PeriodCalendar';
+import { RangeCalendar } from './RangeCalendar';
+
+export default {
+  title: 'Other/Calendar',
+  component: Calendar,
+  parameters: {
+    controls: {
+      exclude: baseProps,
+    },
+  },
+  argTypes: {
+    /* Presentation */
+    pickerMode: {
+      options: ['day', 'week'],
+      control: { type: 'radio' },
+      description:
+        'Set to `week` to show week numbers and highlight the whole week.',
+      table: { defaultValue: { summary: 'day' } },
+    },
+    hasMonthYearNavigation: {
+      control: { type: 'boolean' },
+      description:
+        'Whether the header lets the user jump straight to a month or a year.',
+      table: { defaultValue: { summary: 'true' } },
+    },
+    /* State */
+    isDisabled: { control: { type: 'boolean' } },
+    isReadOnly: { control: { type: 'boolean' } },
+    /* Events */
+    onChange: { action: 'change', control: { type: null } },
+  },
+};
+
+const Template: StoryFn<CubeCalendarProps> = (props) => <Calendar {...props} />;
+
+export const Default = Template.bind({});
+Default.args = { defaultValue: parseDate('2026-08-12') };
+
+export const WeekMode = Template.bind({});
+WeekMode.args = {
+  defaultValue: parseDate('2026-08-12'),
+  pickerMode: 'week',
+};
+
+export const LimitedRange = Template.bind({});
+LimitedRange.args = {
+  defaultValue: parseDate('2026-08-12'),
+  minValue: parseDate('2026-08-05'),
+  maxValue: parseDate('2026-09-20'),
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = { defaultValue: parseDate('2026-08-12'), isDisabled: true };
+
+export const WithoutMonthYearNavigation = Template.bind({});
+WithoutMonthYearNavigation.args = {
+  defaultValue: parseDate('2026-08-12'),
+  hasMonthYearNavigation: false,
+};
+
+export const Range: StoryFn = () => (
+  <RangeCalendar
+    defaultValue={{
+      start: parseDate('2026-08-10'),
+      end: parseDate('2026-08-19'),
+    }}
+  />
+);
+
+export const Periods: StoryFn<CubePeriodCalendarProps> = () => (
+  <Space gap="2x" placeItems="start">
+    <PeriodCalendar picker="month" value={new CalendarDate(2026, 8, 1)} />
+    <PeriodCalendar picker="quarter" value={new CalendarDate(2026, 7, 1)} />
+    <PeriodCalendar picker="year" value={new CalendarDate(2026, 1, 1)} />
+  </Space>
+);
+
+/** The month panel is only reachable through an interaction. */
+export const MonthPanel = Template.bind({});
+MonthPanel.args = { defaultValue: parseDate('2026-08-12') };
+MonthPanel.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.click(await canvas.findByRole('button', { name: 'August' }));
+
+  await waitFor(() =>
+    expect(canvas.getByRole('grid', { name: 'Months' })).toBeVisible(),
+  );
+};
+
+/** The year panel is only reachable through an interaction. */
+export const YearPanel = Template.bind({});
+YearPanel.args = { defaultValue: parseDate('2026-08-12') };
+YearPanel.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.click(await canvas.findByRole('button', { name: '2026' }));
+
+  await waitFor(() =>
+    expect(canvas.getByRole('grid', { name: 'Years' })).toBeVisible(),
+  );
+};

--- a/src/components/other/Calendar/Calendar.test.tsx
+++ b/src/components/other/Calendar/Calendar.test.tsx
@@ -1,0 +1,180 @@
+import { CalendarDate } from '@internationalized/date';
+
+import { renderWithRoot, userEvent, waitFor, within } from '../../../test';
+
+import { Calendar } from './Calendar';
+import { PeriodCalendar } from './PeriodCalendar';
+
+vi.mock('../../../_internal/hooks/use-warn');
+
+describe('<Calendar />', () => {
+  const user = userEvent.setup({ delay: null });
+
+  const heading = (container: HTMLElement) =>
+    within(container).getByRole('heading', { level: 6 });
+
+  it('jumps to a month picked from the month panel', async () => {
+    const { getByRole, container } = renderWithRoot(
+      <Calendar
+        aria-label="Date"
+        defaultValue={new CalendarDate(2026, 8, 12)}
+      />,
+    );
+
+    await user.click(getByRole('button', { name: 'August' }));
+
+    const months = await waitFor(() => getByRole('grid', { name: 'Months' }));
+
+    await user.click(within(months).getByRole('button', { name: 'Nov' }));
+
+    await waitFor(() => {
+      expect(
+        within(heading(container)).getByRole('button', { name: 'November' }),
+      ).toBeTruthy();
+    });
+
+    // Navigating must not select anything — August 12 is still the only
+    // selected day, and November has none.
+    expect(container.querySelectorAll('[aria-selected="true"]')).toHaveLength(
+      0,
+    );
+  });
+
+  it('drills year → month → day', async () => {
+    const { getByRole, container } = renderWithRoot(
+      <Calendar
+        aria-label="Date"
+        defaultValue={new CalendarDate(2026, 8, 12)}
+      />,
+    );
+
+    await user.click(getByRole('button', { name: '2026' }));
+
+    const years = await waitFor(() => getByRole('grid', { name: 'Years' }));
+
+    expect(within(years).getByRole('button', { name: '2020' })).toBeTruthy();
+
+    await user.click(within(years).getByRole('button', { name: '2028' }));
+
+    const months = await waitFor(() => getByRole('grid', { name: 'Months' }));
+
+    await user.click(within(months).getByRole('button', { name: 'Mar' }));
+
+    await waitFor(() => {
+      const title = heading(container);
+      expect(within(title).getByRole('button', { name: 'March' })).toBeTruthy();
+      expect(within(title).getByRole('button', { name: '2028' })).toBeTruthy();
+    });
+  });
+
+  it('returns to the day panel on Escape', async () => {
+    const { getByRole, queryByRole } = renderWithRoot(
+      <Calendar
+        aria-label="Date"
+        defaultValue={new CalendarDate(2026, 8, 12)}
+      />,
+    );
+
+    await user.click(getByRole('button', { name: 'August' }));
+    await waitFor(() =>
+      expect(getByRole('grid', { name: 'Months' })).toBeTruthy(),
+    );
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(queryByRole('grid', { name: 'Months' })).toBeNull(),
+    );
+  });
+
+  it('disables months and years outside the allowed range', async () => {
+    const { getByRole } = renderWithRoot(
+      <Calendar
+        aria-label="Date"
+        defaultValue={new CalendarDate(2026, 8, 12)}
+        minValue={new CalendarDate(2026, 5, 1)}
+        maxValue={new CalendarDate(2026, 9, 30)}
+      />,
+    );
+
+    await user.click(getByRole('button', { name: 'August' }));
+
+    const months = await waitFor(() => getByRole('grid', { name: 'Months' }));
+
+    expect(within(months).getByRole('button', { name: 'Jan' })).toBeDisabled();
+    expect(
+      within(months).getByRole('button', { name: 'May' }),
+    ).not.toBeDisabled();
+    expect(within(months).getByRole('button', { name: 'Oct' })).toBeDisabled();
+  });
+
+  it('omits the month/year navigation when disabled', () => {
+    const { queryByRole, getByRole } = renderWithRoot(
+      <Calendar
+        hasMonthYearNavigation={false}
+        aria-label="Date"
+        defaultValue={new CalendarDate(2026, 8, 12)}
+      />,
+    );
+
+    expect(queryByRole('button', { name: 'August' })).toBeNull();
+    expect(getByRole('heading', { level: 6 })).toHaveTextContent('August 2026');
+  });
+
+  it('moves focus across the year boundary with arrow keys', async () => {
+    const { getByRole } = renderWithRoot(
+      <Calendar
+        aria-label="Date"
+        defaultValue={new CalendarDate(2026, 8, 12)}
+      />,
+    );
+
+    await user.click(getByRole('button', { name: 'August' }));
+    await waitFor(() =>
+      expect(document.activeElement).toBe(getByRole('button', { name: 'Aug' })),
+    );
+
+    // Aug → Nov → Feb of the next year.
+    await user.keyboard('{ArrowDown}{ArrowDown}');
+
+    await waitFor(() =>
+      expect(document.activeElement).toBe(getByRole('button', { name: 'Feb' })),
+    );
+    expect(getByRole('grid', { name: 'Months' })).toBeTruthy();
+    expect(getByRole('button', { name: '2027' })).toBeTruthy();
+  });
+});
+
+describe('<PeriodCalendar />', () => {
+  const user = userEvent.setup({ delay: null });
+
+  it('picks a year from the list and returns to the month list', async () => {
+    const onChange = vi.fn();
+    const { getByRole } = renderWithRoot(
+      <PeriodCalendar
+        picker="month"
+        value={new CalendarDate(2026, 8, 1)}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(getByRole('button', { name: '2026' }));
+
+    const years = await waitFor(() => getByRole('grid', { name: 'Years' }));
+
+    await user.click(within(years).getByRole('button', { name: '2023' }));
+
+    const months = await waitFor(() => getByRole('grid', { name: 'Months' }));
+
+    // Choosing a year only navigates.
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.click(within(months).getByRole('button', { name: 'Mar' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const value = onChange.mock.calls[0][0] as CalendarDate;
+    expect(value.year).toBe(2023);
+    expect(value.month).toBe(3);
+    expect(value.day).toBe(1);
+  });
+});

--- a/src/components/other/Calendar/Calendar.tsx
+++ b/src/components/other/Calendar/Calendar.tsx
@@ -5,7 +5,6 @@ import {
 } from '@internationalized/date';
 import { createDOMRef } from '@react-spectrum/utils';
 import { FocusableRef } from '@react-types/shared';
-import { tasty } from '@tenphi/tasty';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import {
   AriaCalendarProps,
@@ -15,31 +14,16 @@ import {
 } from 'react-aria';
 import { useCalendarState } from 'react-stately';
 
-import { LeftIcon, RightIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
-import { Button } from '../../actions';
-import { Title } from '../../content/Title';
-import { Space } from '../../layout/Space';
 
-import { CalendarGrid } from './CalendarGrid';
+import { CalendarPanel } from './CalendarPanel';
+import { CalendarCoreProps, CalendarValueProps } from './types';
 
-const CalendarElement = tasty({
-  styles: {
-    padding: '1x',
-    gap: '1x',
-  },
-});
-
-const CalendarHeaderElement = tasty({
-  styles: {
-    display: 'flex',
-    placeContent: 'center space-between',
-    placeItems: 'center',
-    gap: '1.5x',
-  },
-});
-
-export interface CubeCalendarProps extends AriaCalendarProps<DateValue> {
+export interface CubeCalendarProps
+  extends AriaCalendarProps<DateValue>,
+    CalendarCoreProps,
+    CalendarValueProps {
+  /** Highlights a range that lives outside the calendar's own state. */
   selectedRange?: {
     start: DateValue;
     end: DateValue;
@@ -81,32 +65,17 @@ function Calendar(props: CubeCalendarProps, ref: FocusableRef<HTMLElement>) {
   }
 
   return (
-    <CalendarElement {...calendarProps}>
-      <CalendarHeaderElement>
-        <Title level={6} preset="h6">
-          {title}
-        </Title>
-        <Space gap=".5x">
-          <Button
-            data-popover-keep
-            size="xsmall"
-            {...prevButtonProps}
-            icon={<LeftIcon />}
-          />
-          <Button
-            data-popover-keep
-            size="xsmall"
-            {...nextButtonProps}
-            icon={<RightIcon />}
-          />
-        </Space>
-      </CalendarHeaderElement>
-      <CalendarGrid
-        state={state}
-        selectedRange={selectedRange}
-        pickerMode={props.pickerMode}
-      />
-    </CalendarElement>
+    <CalendarPanel
+      elementRef={domRef}
+      state={state}
+      title={title}
+      calendarProps={calendarProps}
+      prevButtonProps={prevButtonProps}
+      nextButtonProps={nextButtonProps}
+      hasMonthYearNavigation={props.hasMonthYearNavigation}
+      selectedRange={selectedRange}
+      pickerMode={props.pickerMode}
+    />
   );
 }
 

--- a/src/components/other/Calendar/CalendarCell.tsx
+++ b/src/components/other/Calendar/CalendarCell.tsx
@@ -1,11 +1,14 @@
+import { CalendarDate, isSameDay } from '@internationalized/date';
 import { tasty } from '@tenphi/tasty';
 import { useRef } from 'react';
-import { useCalendarCell } from 'react-aria';
+import { DateValue, useCalendarCell } from 'react-aria';
+import { CalendarState, RangeCalendarState } from 'react-stately';
+
+import { CALENDAR_CELL_STYLES } from './styled';
 
 const CalendarCellElement = tasty({
   as: 'td',
   styles: {
-    preset: 't3m',
     margin: 0,
     padding: '2bw right bottom',
   },
@@ -14,38 +17,25 @@ const CalendarCellElement = tasty({
 const CalendarButtonElement = tasty({
   'data-popover-keep': true,
   styles: {
-    display: 'grid',
-    placeItems: 'center',
+    ...CALENDAR_CELL_STYLES,
     width: '3x',
     height: '3x',
-    fill: {
-      '': '#primary.0',
-      ':hover': '#primary.16',
-      rangeHover: '#primary.16',
-      pressed: '#primary.10',
-
-      selected: '#primary',
-      'selected & :hover': '#primary-text',
-      'selected & pressed': '#primary',
-
-      'disabled | unavailable': '#primary.0',
-    },
-    color: {
-      '': '#dark',
-      selected: '#white',
-      'disabled | unavailable': '#dark.30',
-    },
-    outline: {
-      '': '1bw #primary-text.0',
-      focused: '1bw #primary-text',
-    },
-    outlineOffset: 0.5,
-    radius: true,
-    cursor: '$pointer',
   },
 });
 
-export function CalendarCell({ state, selectedRange, date, rangeHover }) {
+export interface CubeCalendarCellProps {
+  state: CalendarState | RangeCalendarState;
+  date: CalendarDate;
+  /** Today, expressed in the calendar system of the grid. */
+  today?: CalendarDate;
+  /** Explicit range highlight, used when the range lives outside the state. */
+  selectedRange?: { start: DateValue; end: DateValue };
+  /** Whether the whole row is highlighted (week picker mode). */
+  rangeHover?: boolean;
+}
+
+export function CalendarCell(props: CubeCalendarCellProps) {
+  let { state, selectedRange, date, today, rangeHover } = props;
   let ref = useRef(null);
   let {
     cellProps,
@@ -60,19 +50,22 @@ export function CalendarCell({ state, selectedRange, date, rangeHover }) {
     formattedDate,
   } = useCalendarCell({ date }, state, ref);
 
-  const isFinalSelected = selectedRange
-    ? date.compare(selectedRange.start) >= 0 &&
-      date.compare(selectedRange.end) <= 0
-    : isSelected;
+  const isFinalSelected =
+    !isOutsideVisibleRange &&
+    (selectedRange
+      ? date.compare(selectedRange.start) >= 0 &&
+        date.compare(selectedRange.end) <= 0
+      : isSelected);
 
   return (
     <CalendarCellElement {...cellProps}>
       <CalendarButtonElement
         {...buttonProps}
         ref={ref}
-        hidden={isOutsideVisibleRange}
         mods={{
           selected: isFinalSelected,
+          current: !!today && !isOutsideVisibleRange && isSameDay(date, today),
+          outside: isOutsideVisibleRange,
           rangeHover: rangeHover && !isFinalSelected,
           pressed: isPressed,
           focused: isFocused,

--- a/src/components/other/Calendar/CalendarGrid.tsx
+++ b/src/components/other/Calendar/CalendarGrid.tsx
@@ -1,7 +1,12 @@
-import { getWeeksInMonth } from '@internationalized/date';
+import {
+  today as getToday,
+  getWeeksInMonth,
+  toCalendar,
+} from '@internationalized/date';
 import { tasty } from '@tenphi/tasty';
-import { useState } from 'react';
-import { useCalendarGrid, useLocale } from 'react-aria';
+import { useMemo, useState } from 'react';
+import { DateValue, useCalendarGrid, useLocale } from 'react-aria';
+import { CalendarState, RangeCalendarState } from 'react-stately';
 
 import { getWeekNumber } from '../../fields/DatePicker/period';
 
@@ -11,6 +16,7 @@ const TableElement = tasty({
   as: 'table',
   styles: {
     borderCollapse: 'collapse',
+    borderSpacing: 0,
 
     HeadRow: {
       color: '#dark-04',
@@ -25,13 +31,31 @@ const TableElement = tasty({
   },
 });
 
-export function CalendarGrid({ state, pickerMode = 'day', ...props }) {
+export interface CubeCalendarGridProps {
+  state: CalendarState | RangeCalendarState;
+  /** Explicit range highlight, used when the range lives outside the state. */
+  selectedRange?: { start: DateValue; end: DateValue };
+  /**
+   * When set to `week`, the grid shows a leading week-number column and
+   * highlights the whole week under the pointer.
+   */
+  pickerMode?: 'day' | 'week';
+}
+
+export function CalendarGrid(props: CubeCalendarGridProps) {
+  let { state, selectedRange, pickerMode = 'day' } = props;
   let { locale } = useLocale();
   let { gridProps, headerProps, weekDays } = useCalendarGrid(props, state);
 
   // Get the number of weeks in the month, so we can render the proper number of rows.
   let weeksInMonth = getWeeksInMonth(state.visibleRange.start, locale);
   let showWeekNumbers = pickerMode === 'week';
+
+  let today = useMemo(
+    () =>
+      toCalendar(getToday(state.timeZone), state.visibleRange.start.calendar),
+    [state.timeZone, state.visibleRange.start.calendar],
+  );
 
   // In week mode, hovering any day highlights the whole week row.
   let [hoveredWeek, setHoveredWeek] = useState<number | null>(null);
@@ -74,7 +98,8 @@ export function CalendarGrid({ state, pickerMode = 'day', ...props }) {
                     key={i}
                     state={state}
                     date={date}
-                    selectedRange={props.selectedRange}
+                    today={today}
+                    selectedRange={selectedRange}
                     rangeHover={isRowHovered}
                   />
                 ) : (

--- a/src/components/other/Calendar/CalendarHeader.tsx
+++ b/src/components/other/Calendar/CalendarHeader.tsx
@@ -1,0 +1,91 @@
+import { tasty } from '@tenphi/tasty';
+import { ReactNode } from 'react';
+
+import { LeftIcon, RightIcon } from '../../../icons';
+import { Button } from '../../actions';
+import { Title } from '../../content/Title';
+import { Space } from '../../layout/Space';
+
+import { CalendarHeaderElement } from './styled';
+
+import type { Props } from '../../../props';
+
+const CalendarTitleElement = tasty(Title, {
+  level: 6,
+  preset: 'h6',
+  styles: {
+    display: 'flex',
+    placeItems: 'center',
+    gap: '.25x',
+    // When the title doubles as the view switcher its buttons carry their own
+    // padding — pull them back so the label keeps its original alignment.
+    margin: {
+      '': 0,
+      interactive: '0 -.75x',
+    },
+  },
+});
+
+const CalendarTitleButton = tasty(Button, {
+  'data-popover-keep': true,
+  type: 'clear',
+  size: 'small',
+  styles: {
+    preset: 'h6',
+    padding: '0 .75x',
+  },
+});
+
+export interface CubeCalendarHeaderSegment {
+  key: string;
+  label: string;
+  onPress: () => void;
+  isDisabled?: boolean;
+}
+
+export interface CubeCalendarHeaderProps {
+  /**
+   * Interactive title segments (month / year). When omitted the header falls
+   * back to a plain `title` — e.g. for a multi-month range.
+   */
+  segments?: CubeCalendarHeaderSegment[];
+  title?: ReactNode;
+  prevButtonProps?: Props;
+  nextButtonProps?: Props;
+}
+
+export function CalendarHeader(props: CubeCalendarHeaderProps) {
+  let { segments, title, prevButtonProps, nextButtonProps } = props;
+
+  return (
+    <CalendarHeaderElement>
+      <CalendarTitleElement mods={{ interactive: !!segments?.length }}>
+        {segments?.length
+          ? segments.map(({ key, label, onPress, isDisabled }) => (
+              <CalendarTitleButton
+                key={key}
+                isDisabled={isDisabled}
+                onPress={onPress}
+              >
+                {label}
+              </CalendarTitleButton>
+            ))
+          : title}
+      </CalendarTitleElement>
+      <Space gap=".5x">
+        <Button
+          data-popover-keep
+          size="xsmall"
+          {...prevButtonProps}
+          icon={<LeftIcon />}
+        />
+        <Button
+          data-popover-keep
+          size="xsmall"
+          {...nextButtonProps}
+          icon={<RightIcon />}
+        />
+      </Space>
+    </CalendarHeaderElement>
+  );
+}

--- a/src/components/other/Calendar/CalendarHeader.tsx
+++ b/src/components/other/Calendar/CalendarHeader.tsx
@@ -10,18 +10,22 @@ import { CalendarHeaderElement } from './styled';
 
 import type { Props } from '../../../props';
 
+/**
+ * A heading that holds the view switcher. Its own preset matches the type scale
+ * of an `xsmall` button so the plain-title fallback (a decade range, or a
+ * calendar with navigation turned off) doesn't outweigh the interactive one.
+ */
 const CalendarTitleElement = tasty(Title, {
   level: 6,
-  preset: 'h6',
+  preset: 't4',
   styles: {
     display: 'flex',
     placeItems: 'center',
     gap: '.25x',
-    // When the title doubles as the view switcher its buttons carry their own
-    // padding — pull them back so the label keeps its original alignment.
-    margin: {
-      '': 0,
-      interactive: '0 -.75x',
+    // Line the plain title up with the label inside a button.
+    padding: {
+      '': '0 (1x - 1bw)',
+      interactive: 0,
     },
   },
 });
@@ -29,11 +33,7 @@ const CalendarTitleElement = tasty(Title, {
 const CalendarTitleButton = tasty(Button, {
   'data-popover-keep': true,
   type: 'clear',
-  size: 'small',
-  styles: {
-    preset: 'h6',
-    padding: '0 .75x',
-  },
+  size: 'xsmall',
 });
 
 export interface CubeCalendarHeaderSegment {

--- a/src/components/other/Calendar/CalendarPanel.tsx
+++ b/src/components/other/Calendar/CalendarPanel.tsx
@@ -133,6 +133,9 @@ export function CalendarPanel(props: CubeCalendarPanelProps) {
       e.preventDefault();
       e.stopPropagation();
       setView('day');
+      // The grid the user was in is about to unmount. Claim focus for the day
+      // cell, or it falls out of the popover and the next `Escape` is lost.
+      state.setFocused(true);
     }
   };
 

--- a/src/components/other/Calendar/CalendarPanel.tsx
+++ b/src/components/other/Calendar/CalendarPanel.tsx
@@ -1,0 +1,324 @@
+import {
+  CalendarDate,
+  endOfMonth,
+  endOfYear,
+  isSameMonth,
+  startOfMonth,
+  startOfYear,
+  toCalendar,
+  today,
+} from '@internationalized/date';
+import { KeyboardEvent, ReactElement, Ref, useMemo, useState } from 'react';
+import { DateValue, useDateFormatter } from 'react-aria';
+import { CalendarState, RangeCalendarState } from 'react-stately';
+
+import { useI18n } from '../../../i18n';
+import { mergeProps } from '../../../utils/react';
+
+import { CalendarGrid } from './CalendarGrid';
+import { CalendarHeader } from './CalendarHeader';
+import { CubePeriodGridCell, PeriodGrid } from './PeriodGrid';
+import { CalendarElement } from './styled';
+
+import type { Props } from '../../../props';
+
+/** Which panel the calendar currently shows. */
+export type CubeCalendarView = 'day' | 'month' | 'year';
+
+/** The year grid shows a decade plus one adjacent year on either side. */
+const YEAR_CELLS = 12;
+const MONTH_COLUMNS = 3;
+const YEAR_COLUMNS = 3;
+
+/**
+ * Exactly as wide as seven day cells (`3x` cell + a `2bw` gutter), so switching
+ * between the day, month and year panels keeps the popover roughly in place.
+ */
+const PERIOD_GRID_STYLES = { width: '(7 * (3x + 2bw))' } as const;
+
+interface Formatter {
+  format(date: Date): string;
+}
+
+export interface CubeCalendarPanelProps {
+  state: CalendarState | RangeCalendarState;
+  /** The visible range title provided by React Aria. */
+  title: string;
+  calendarProps: Props;
+  prevButtonProps: Props;
+  nextButtonProps: Props;
+  /**
+   * Whether the header lets the user jump straight to a month or a year.
+   * @default true
+   */
+  hasMonthYearNavigation?: boolean;
+  selectedRange?: { start: DateValue; end: DateValue };
+  pickerMode?: 'day' | 'week';
+  elementRef?: Ref<HTMLElement>;
+}
+
+/**
+ * The body shared by `Calendar` and `RangeCalendar`: a header plus one of three
+ * panels. The month and year panels only *navigate* — they move the focused
+ * date and never select a value, so a range selection in progress survives a
+ * jump to another month.
+ */
+export function CalendarPanel(props: CubeCalendarPanelProps) {
+  const { t } = useI18n();
+
+  let {
+    state,
+    title,
+    calendarProps,
+    prevButtonProps,
+    nextButtonProps,
+    hasMonthYearNavigation = true,
+    selectedRange,
+    pickerMode,
+    elementRef,
+  } = props;
+
+  let [view, setView] = useState<CubeCalendarView>('day');
+  // The period the month / year panels navigate around. Seeded from the
+  // focused date every time the user leaves the day panel.
+  let [anchor, setAnchor] = useState<CalendarDate>(state.focusedDate);
+
+  let visibleStart = state.visibleRange.start;
+  let calendar = visibleStart.calendar;
+  let timeZone = state.timeZone;
+  let calendarId = calendar.identifier;
+
+  let monthFormatter = useDateFormatter({
+    month: 'long',
+    timeZone,
+    calendar: calendarId,
+  });
+  let shortMonthFormatter = useDateFormatter({
+    month: 'short',
+    timeZone,
+    calendar: calendarId,
+  });
+  let yearFormatter = useDateFormatter({
+    year: 'numeric',
+    timeZone,
+    calendar: calendarId,
+  });
+
+  let todayDate = useMemo(
+    () => toCalendar(today(timeZone), calendar),
+    [timeZone, calendar],
+  );
+
+  let format = (formatter: Formatter, date: CalendarDate) =>
+    formatter.format(date.toDate(timeZone));
+
+  /** Whether a whole period lies outside the calendar's allowed range. */
+  let isPeriodDisabled = (start: CalendarDate, end: CalendarDate) =>
+    state.isDisabled ||
+    (state.minValue != null && end.compare(state.minValue) < 0) ||
+    (state.maxValue != null && start.compare(state.maxValue) > 0);
+
+  // A multi-month view has no single month or year to drill into.
+  let hasNavigation =
+    hasMonthYearNavigation && isSameMonth(visibleStart, state.visibleRange.end);
+
+  let openView = (next: CubeCalendarView) => {
+    setAnchor(state.focusedDate);
+    setView(next);
+  };
+
+  let onKeyDown = (e: KeyboardEvent) => {
+    // Step back to the day panel rather than closing the surrounding popover.
+    if (view !== 'day' && e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      setView('day');
+    }
+  };
+
+  let header: ReactElement;
+  let body: ReactElement;
+
+  if (view === 'month') {
+    let monthDate = (month: number) => startOfMonth(anchor.set({ month }));
+    let monthCount = calendar.getMonthsInYear(anchor);
+
+    let cells: CubePeriodGridCell[] = Array.from(
+      { length: monthCount },
+      (_, index) => {
+        let date = monthDate(index + 1);
+
+        return {
+          key: `month-${index + 1}`,
+          label: format(shortMonthFormatter, date),
+          isSelected: isSameMonth(date, visibleStart),
+          isCurrent: isSameMonth(date, todayDate),
+          isDisabled: isPeriodDisabled(date, endOfMonth(date)),
+        };
+      },
+    );
+
+    let prevYear = anchor.subtract({ years: 1 });
+    let nextYear = anchor.add({ years: 1 });
+
+    header = (
+      <CalendarHeader
+        segments={[
+          {
+            key: 'year',
+            label: format(yearFormatter, anchor),
+            isDisabled: state.isDisabled,
+            onPress: () => setView('year'),
+          },
+        ]}
+        prevButtonProps={{
+          'aria-label': t('calendar.previousYear', 'Previous year'),
+          isDisabled: isPeriodDisabled(
+            startOfYear(prevYear),
+            endOfYear(prevYear),
+          ),
+          onPress: () => setAnchor(prevYear),
+        }}
+        nextButtonProps={{
+          'aria-label': t('calendar.nextYear', 'Next year'),
+          isDisabled: isPeriodDisabled(
+            startOfYear(nextYear),
+            endOfYear(nextYear),
+          ),
+          onPress: () => setAnchor(nextYear),
+        }}
+      />
+    );
+
+    body = (
+      <PeriodGrid
+        // Remount per view so focus follows the user into the new grid.
+        key="month"
+        autoFocus
+        aria-label={t('calendar.months', 'Months')}
+        cells={cells}
+        styles={PERIOD_GRID_STYLES}
+        columns={MONTH_COLUMNS}
+        focusedIndex={anchor.month - 1}
+        onCellPress={(index) => {
+          state.setFocusedDate(anchor.set({ month: index + 1 }));
+          setView('day');
+        }}
+        onCellFocus={(index) => setAnchor(anchor.set({ month: index + 1 }))}
+        onMoveFocus={(delta) => setAnchor(anchor.add({ months: delta }))}
+        onMovePage={(delta) => setAnchor(anchor.add({ years: delta }))}
+      />
+    );
+  } else if (view === 'year') {
+    let yearDate = (year: number) => startOfYear(anchor.set({ year }));
+    let decadeStart = Math.floor(anchor.year / 10) * 10;
+    let firstYear = decadeStart - 1;
+
+    let cells: CubePeriodGridCell[] = Array.from(
+      { length: YEAR_CELLS },
+      (_, index) => {
+        let year = firstYear + index;
+        let date = yearDate(year);
+
+        return {
+          key: `year-${year}`,
+          label: format(yearFormatter, date),
+          isSelected: year === visibleStart.year,
+          isCurrent: year === todayDate.year,
+          isOutside: year < decadeStart || year > decadeStart + 9,
+          isDisabled: isPeriodDisabled(date, endOfYear(date)),
+        };
+      },
+    );
+
+    header = (
+      <CalendarHeader
+        title={`${format(yearFormatter, yearDate(decadeStart))} – ${format(
+          yearFormatter,
+          yearDate(decadeStart + 9),
+        )}`}
+        prevButtonProps={{
+          'aria-label': t('calendar.previousYears', 'Previous years'),
+          isDisabled: isPeriodDisabled(
+            yearDate(decadeStart - 10),
+            endOfYear(yearDate(decadeStart - 1)),
+          ),
+          onPress: () => setAnchor(anchor.subtract({ years: 10 })),
+        }}
+        nextButtonProps={{
+          'aria-label': t('calendar.nextYears', 'Next years'),
+          isDisabled: isPeriodDisabled(
+            yearDate(decadeStart + 10),
+            endOfYear(yearDate(decadeStart + 19)),
+          ),
+          onPress: () => setAnchor(anchor.add({ years: 10 })),
+        }}
+      />
+    );
+
+    body = (
+      <PeriodGrid
+        key="year"
+        autoFocus
+        aria-label={t('calendar.years', 'Years')}
+        cells={cells}
+        styles={PERIOD_GRID_STYLES}
+        columns={YEAR_COLUMNS}
+        focusedIndex={anchor.year - firstYear}
+        onCellPress={(index) => {
+          setAnchor(anchor.set({ year: firstYear + index }));
+          setView('month');
+        }}
+        onCellFocus={(index) =>
+          setAnchor(anchor.set({ year: firstYear + index }))
+        }
+        onMoveFocus={(delta) => setAnchor(anchor.add({ years: delta }))}
+        onMovePage={(delta) => setAnchor(anchor.add({ years: delta * 10 }))}
+      />
+    );
+  } else {
+    header = (
+      <CalendarHeader
+        title={title}
+        segments={
+          hasNavigation
+            ? [
+                {
+                  key: 'month',
+                  label: format(monthFormatter, visibleStart),
+                  isDisabled: state.isDisabled,
+                  onPress: () => openView('month'),
+                },
+                {
+                  key: 'year',
+                  label: format(yearFormatter, visibleStart),
+                  isDisabled: state.isDisabled,
+                  onPress: () => openView('year'),
+                },
+              ]
+            : undefined
+        }
+        prevButtonProps={prevButtonProps}
+        nextButtonProps={nextButtonProps}
+      />
+    );
+
+    body = (
+      <CalendarGrid
+        state={state}
+        selectedRange={selectedRange}
+        pickerMode={pickerMode}
+      />
+    );
+  }
+
+  return (
+    <CalendarElement
+      ref={elementRef}
+      {...mergeProps(calendarProps, { onKeyDown })}
+    >
+      {header}
+      {body}
+    </CalendarElement>
+  );
+}

--- a/src/components/other/Calendar/PeriodCalendar.tsx
+++ b/src/components/other/Calendar/PeriodCalendar.tsx
@@ -1,85 +1,32 @@
-import { CalendarDate, getLocalTimeZone, today } from '@internationalized/date';
-import { tasty } from '@tenphi/tasty';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { DateValue, useDateFormatter, useLocale } from 'react-aria';
-
-import { LeftIcon, RightIcon } from '../../../icons';
-import { useProviderProps } from '../../../provider';
-import { Button } from '../../actions';
-import { Title } from '../../content/Title';
 import {
-  getQuarter,
-  PickerType,
-  snapToPeriod,
-} from '../../fields/DatePicker/period';
-import { Space } from '../../layout/Space';
+  CalendarDate,
+  endOfMonth,
+  endOfYear,
+  getLocalTimeZone,
+  toCalendarDate,
+  today,
+} from '@internationalized/date';
+import { KeyboardEvent, ReactElement, useMemo, useState } from 'react';
+import { DateValue, useDateFormatter } from 'react-aria';
 
-const PeriodCalendarElement = tasty({
-  styles: {
-    padding: '1x',
-    gap: '1x',
-    width: 'min 30x',
-  },
-});
+import { useI18n } from '../../../i18n';
+import { useProviderProps } from '../../../provider';
+import { getQuarter } from '../../fields/DatePicker/period';
 
-const PeriodHeaderElement = tasty({
-  styles: {
-    display: 'flex',
-    placeContent: 'center space-between',
-    placeItems: 'center',
-    gap: '1.5x',
-  },
-});
+import { CalendarHeader } from './CalendarHeader';
+import { CubePeriodGridCell, PeriodGrid } from './PeriodGrid';
+import { CalendarElement } from './styled';
 
-const PeriodGridElement = tasty({
-  styles: {
-    display: 'grid',
-    gap: '1bw',
-    padding: '.5x top',
-  },
-});
+/** The year grid shows a decade plus one adjacent year on either side. */
+const YEAR_CELLS = 12;
 
-const PeriodCellElement = tasty({
-  as: 'button',
-  'data-popover-keep': true,
-  styles: {
-    preset: 't3m',
-    display: 'grid',
-    placeItems: 'center',
-    height: '5x',
-    padding: '1x',
-    border: 0,
-    fill: {
-      '': '#primary.0',
-      ':hover': '#primary.16',
-      pressed: '#primary.10',
+/** Explicit so the panel keeps one width across all three period views. */
+const PERIOD_GRID_STYLES = { width: '28x' } as const;
 
-      selected: '#primary',
-      'selected & :hover': '#primary',
+export type CubePeriodCalendarPicker = 'month' | 'quarter' | 'year';
 
-      disabled: '#primary.0',
-    },
-    color: {
-      '': '#dark',
-      outside: '#dark.30',
-      selected: '#white',
-      disabled: '#dark.30',
-    },
-    outline: {
-      '': '1bw #primary-text.0',
-      focused: '1bw #primary-text',
-    },
-    outlineOffset: 0.5,
-    radius: true,
-    cursor: {
-      '': 'pointer',
-      disabled: 'not-allowed',
-    },
-  },
-});
-
-// picker → grid columns
-const COLUMNS: Record<'month' | 'quarter' | 'year', number> = {
+/** picker → grid columns */
+const COLUMNS: Record<CubePeriodCalendarPicker, number> = {
   month: 3,
   quarter: 4,
   year: 3,
@@ -87,7 +34,7 @@ const COLUMNS: Record<'month' | 'quarter' | 'year', number> = {
 
 export interface CubePeriodCalendarProps {
   /** Which non-day period this panel selects. */
-  picker: 'month' | 'quarter' | 'year';
+  picker: CubePeriodCalendarPicker;
   value?: DateValue | null;
   onChange?: (date: CalendarDate) => void;
   minValue?: DateValue | null;
@@ -97,16 +44,14 @@ export interface CubePeriodCalendarProps {
   autoFocus?: boolean;
 }
 
-interface Cell {
-  key: string;
-  label: string;
-  date: CalendarDate;
-  isSelected: boolean;
-  isDisabled: boolean;
-  isOutside: boolean;
-}
-
+/**
+ * The panel behind `MonthPicker`, `QuarterPicker` and `YearPicker`. The month
+ * and quarter panels drill up into a year list, so reaching a distant year
+ * never means clicking the arrow a dozen times.
+ */
 export function PeriodCalendar(props: CubePeriodCalendarProps) {
+  const { t } = useI18n();
+
   props = useProviderProps(props);
 
   let {
@@ -120,202 +65,223 @@ export function PeriodCalendar(props: CubePeriodCalendarProps) {
     autoFocus,
   } = props;
 
-  let { locale } = useLocale();
   let monthFormatter = useDateFormatter({ month: 'short', timeZone: 'UTC' });
 
-  let selected = value ?? null;
-  let selectedYear = selected?.year ?? null;
-  let selectedMonth = selected?.month ?? null;
+  let selected = value ? toCalendarDate(value) : null;
+  let todayDate = useMemo(() => today(getLocalTimeZone()), []);
 
-  let [focusedYear, setFocusedYear] = useState(
-    () => selectedYear ?? today(getLocalTimeZone()).year,
-  );
+  // A date inside the period the keyboard currently focuses. Drives both the
+  // roving tab stop and which year / decade the panel shows.
+  let [anchor, setAnchor] = useState<CalendarDate>(() => selected ?? todayDate);
+  let [isYearView, setIsYearView] = useState(false);
+  // Switching panels always moves focus into the new grid — the button the
+  // user just pressed is gone by then.
+  let [autoFocusGrid, setAutoFocusGrid] = useState(!!autoFocus);
 
-  let cols = COLUMNS[picker];
-  let step = picker === 'year' ? 10 : 1;
-  let decadeStart = Math.floor(focusedYear / 10) * 10;
-
-  let isPeriodDisabled = (date: CalendarDate) => {
-    if (isDisabled) return true;
-    if (minValue && date.compare(snapToPeriod(minValue, picker, locale)) < 0) {
-      return true;
-    }
-    if (maxValue && date.compare(snapToPeriod(maxValue, picker, locale)) > 0) {
-      return true;
-    }
-
-    return isDateUnavailable?.(date) ?? false;
+  let showYearView = (next: boolean) => {
+    setAutoFocusGrid(true);
+    setIsYearView(next);
   };
 
-  let cells = useMemo<Cell[]>(() => {
-    if (picker === 'month') {
-      return Array.from({ length: 12 }, (_, m) => {
-        let date = new CalendarDate(focusedYear, m + 1, 1);
+  let view: CubePeriodCalendarPicker =
+    picker === 'year' || isYearView ? 'year' : picker;
 
-        return {
-          key: `m-${m}`,
-          label: monthFormatter.format(new Date(Date.UTC(2021, m, 15))),
-          date,
-          isSelected: selectedYear === focusedYear && selectedMonth === m + 1,
-          isDisabled: isPeriodDisabled(date),
-          isOutside: false,
-        };
-      });
+  let yearStart = (year: number) => new CalendarDate(year, 1, 1);
+
+  let isPeriodDisabled = (start: CalendarDate, end: CalendarDate) => {
+    if (isDisabled) return true;
+    if (minValue && end.compare(minValue) < 0) return true;
+    if (maxValue && start.compare(maxValue) > 0) return true;
+
+    return isDateUnavailable?.(start) ?? false;
+  };
+
+  /** Header for the month and quarter panels — the year drills up to a list. */
+  let renderYearHeader = () => {
+    let prevYear = anchor.year - 1;
+    let nextYear = anchor.year + 1;
+
+    return (
+      <CalendarHeader
+        segments={[
+          {
+            key: 'year',
+            label: String(anchor.year),
+            isDisabled,
+            onPress: () => showYearView(true),
+          },
+        ]}
+        prevButtonProps={{
+          'aria-label': t('calendar.previousYear', 'Previous year'),
+          isDisabled: isPeriodDisabled(
+            yearStart(prevYear),
+            endOfYear(yearStart(prevYear)),
+          ),
+          onPress: () => setAnchor(anchor.subtract({ years: 1 })),
+        }}
+        nextButtonProps={{
+          'aria-label': t('calendar.nextYear', 'Next year'),
+          isDisabled: isPeriodDisabled(
+            yearStart(nextYear),
+            endOfYear(yearStart(nextYear)),
+          ),
+          onPress: () => setAnchor(anchor.add({ years: 1 })),
+        }}
+      />
+    );
+  };
+
+  let onKeyDown = (e: KeyboardEvent) => {
+    // The year list is a detour, so `Escape` returns to the period list rather
+    // than closing the surrounding popover.
+    if (isYearView && picker !== 'year' && e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      showYearView(false);
     }
+  };
 
-    if (picker === 'quarter') {
-      return Array.from({ length: 4 }, (_, q) => {
-        let date = new CalendarDate(focusedYear, q * 3 + 1, 1);
+  let cells: CubePeriodGridCell[];
+  let focusedIndex: number;
+  let gridLabel: string;
+  let header: ReactElement;
+  let onCellPress: (index: number) => void;
+  let onCellFocus: (index: number) => void;
+  let onMoveFocus: (delta: number) => void;
+  let onMovePage: (delta: -1 | 1) => void;
 
-        return {
-          key: `q-${q}`,
-          label: `Q${q + 1}`,
-          date,
-          isSelected:
-            selectedYear === focusedYear &&
-            selectedMonth != null &&
-            getQuarter(selectedMonth) === q + 1,
-          isDisabled: isPeriodDisabled(date),
-          isOutside: false,
-        };
-      });
-    }
+  if (view === 'year') {
+    let decadeStart = Math.floor(anchor.year / 10) * 10;
+    let firstYear = decadeStart - 1;
 
-    // year: render 12 cells — one leading + a decade + one trailing.
-    return Array.from({ length: 12 }, (_, i) => {
-      let year = decadeStart - 1 + i;
-      let date = new CalendarDate(year, 1, 1);
+    cells = Array.from({ length: YEAR_CELLS }, (_, index) => {
+      let year = firstYear + index;
+      let date = yearStart(year);
 
       return {
-        key: `y-${year}`,
+        key: `year-${year}`,
         label: String(year),
-        date,
-        isSelected: selectedYear === year,
-        isDisabled: isPeriodDisabled(date),
+        isSelected: selected?.year === year,
+        isCurrent: todayDate.year === year,
         isOutside: year < decadeStart || year > decadeStart + 9,
+        isDisabled: isPeriodDisabled(date, endOfYear(date)),
       };
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    picker,
-    focusedYear,
-    decadeStart,
-    selectedYear,
-    selectedMonth,
-    monthFormatter,
-    locale,
-    minValue,
-    maxValue,
-    isDateUnavailable,
-    isDisabled,
-  ]);
 
-  let title =
-    picker === 'year'
-      ? `${decadeStart}-${decadeStart + 9}`
-      : String(focusedYear);
+    focusedIndex = anchor.year - firstYear;
+    gridLabel = t('calendar.years', 'Years');
 
-  let cellRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  let [focusedIndex, setFocusedIndex] = useState(() => {
-    let idx = cells.findIndex((cell) => cell.isSelected);
+    header = (
+      <CalendarHeader
+        title={`${decadeStart} – ${decadeStart + 9}`}
+        prevButtonProps={{
+          'aria-label': t('calendar.previousYears', 'Previous years'),
+          isDisabled: isPeriodDisabled(
+            yearStart(decadeStart - 10),
+            endOfYear(yearStart(decadeStart - 1)),
+          ),
+          onPress: () => setAnchor(anchor.subtract({ years: 10 })),
+        }}
+        nextButtonProps={{
+          'aria-label': t('calendar.nextYears', 'Next years'),
+          isDisabled: isPeriodDisabled(
+            yearStart(decadeStart + 10),
+            endOfYear(yearStart(decadeStart + 19)),
+          ),
+          onPress: () => setAnchor(anchor.add({ years: 10 })),
+        }}
+      />
+    );
 
-    return idx >= 0 ? idx : 0;
-  });
+    onCellPress = (index) => {
+      let year = firstYear + index;
 
-  useEffect(() => {
-    if (autoFocus) {
-      cellRefs.current[focusedIndex]?.focus();
-    }
-    // Focus only on mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+      if (picker === 'year') {
+        onChange?.(yearStart(year));
+      } else {
+        setAnchor(anchor.set({ year }));
+        showYearView(false);
+      }
+    };
+    onCellFocus = (index) => setAnchor(anchor.set({ year: firstYear + index }));
+    onMoveFocus = (delta) => setAnchor(anchor.add({ years: delta }));
+    onMovePage = (delta) => setAnchor(anchor.add({ years: delta * 10 }));
+  } else if (view === 'quarter') {
+    let quarterDate = (quarter: number) =>
+      new CalendarDate(anchor.year, (quarter - 1) * 3 + 1, 1);
 
-  let moveFocus = (index: number) => {
-    let clamped = Math.max(0, Math.min(cells.length - 1, index));
-    setFocusedIndex(clamped);
-    cellRefs.current[clamped]?.focus();
-  };
+    cells = Array.from({ length: 4 }, (_, index) => {
+      let quarter = index + 1;
+      let date = quarterDate(quarter);
 
-  let onKeyDown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case 'ArrowRight':
-        moveFocus(focusedIndex + 1);
-        break;
-      case 'ArrowLeft':
-        moveFocus(focusedIndex - 1);
-        break;
-      case 'ArrowDown':
-        moveFocus(focusedIndex + cols);
-        break;
-      case 'ArrowUp':
-        moveFocus(focusedIndex - cols);
-        break;
-      case 'Home':
-        moveFocus(0);
-        break;
-      case 'End':
-        moveFocus(cells.length - 1);
-        break;
-      default:
-        return;
-    }
-    e.preventDefault();
-  };
+      return {
+        key: `quarter-${quarter}`,
+        label: `Q${quarter}`,
+        isSelected:
+          selected != null &&
+          selected.year === anchor.year &&
+          getQuarter(selected.month) === quarter,
+        isCurrent:
+          todayDate.year === anchor.year &&
+          getQuarter(todayDate.month) === quarter,
+        isDisabled: isPeriodDisabled(date, endOfMonth(date.add({ months: 2 }))),
+      };
+    });
+
+    focusedIndex = getQuarter(anchor.month) - 1;
+    gridLabel = t('calendar.quarters', 'Quarters');
+    header = renderYearHeader();
+
+    onCellPress = (index) => onChange?.(quarterDate(index + 1));
+    onCellFocus = (index) => setAnchor(quarterDate(index + 1));
+    onMoveFocus = (delta) => setAnchor(anchor.add({ months: delta * 3 }));
+    onMovePage = (delta) => setAnchor(anchor.add({ years: delta }));
+  } else {
+    let monthDate = (month: number) => new CalendarDate(anchor.year, month, 1);
+
+    cells = Array.from({ length: 12 }, (_, index) => {
+      let month = index + 1;
+      let date = monthDate(month);
+
+      return {
+        key: `month-${month}`,
+        label: monthFormatter.format(date.toDate('UTC')),
+        isSelected:
+          selected != null &&
+          selected.year === anchor.year &&
+          selected.month === month,
+        isCurrent: todayDate.year === anchor.year && todayDate.month === month,
+        isDisabled: isPeriodDisabled(date, endOfMonth(date)),
+      };
+    });
+
+    focusedIndex = anchor.month - 1;
+    gridLabel = t('calendar.months', 'Months');
+    header = renderYearHeader();
+
+    onCellPress = (index) => onChange?.(monthDate(index + 1));
+    onCellFocus = (index) => setAnchor(monthDate(index + 1));
+    onMoveFocus = (delta) => setAnchor(anchor.add({ months: delta }));
+    onMovePage = (delta) => setAnchor(anchor.add({ years: delta }));
+  }
 
   return (
-    <PeriodCalendarElement>
-      <PeriodHeaderElement>
-        <Title level={6} preset="h6">
-          {title}
-        </Title>
-        <Space gap=".5x">
-          <Button
-            data-popover-keep
-            size="xsmall"
-            aria-label="Previous"
-            icon={<LeftIcon />}
-            isDisabled={isDisabled}
-            onPress={() => setFocusedYear((year) => year - step)}
-          />
-          <Button
-            data-popover-keep
-            size="xsmall"
-            aria-label="Next"
-            icon={<RightIcon />}
-            isDisabled={isDisabled}
-            onPress={() => setFocusedYear((year) => year + step)}
-          />
-        </Space>
-      </PeriodHeaderElement>
-      <PeriodGridElement
-        role="grid"
-        styles={{ gridColumns: `repeat(${cols}, 1fr)` }}
-        onKeyDown={onKeyDown}
-      >
-        {cells.map((cell, i) => (
-          <PeriodCellElement
-            key={cell.key}
-            ref={(el: HTMLButtonElement | null) => {
-              cellRefs.current[i] = el;
-            }}
-            type="button"
-            tabIndex={i === focusedIndex ? 0 : -1}
-            disabled={cell.isDisabled}
-            aria-pressed={cell.isSelected}
-            mods={{
-              selected: cell.isSelected,
-              outside: cell.isOutside,
-              disabled: cell.isDisabled,
-            }}
-            onFocus={() => setFocusedIndex(i)}
-            onClick={() => {
-              if (!cell.isDisabled) onChange?.(cell.date);
-            }}
-          >
-            {cell.label}
-          </PeriodCellElement>
-        ))}
-      </PeriodGridElement>
-    </PeriodCalendarElement>
+    <CalendarElement onKeyDown={onKeyDown}>
+      {header}
+      <PeriodGrid
+        // Remount per view so focus follows the user into the new grid.
+        key={view}
+        autoFocus={autoFocusGrid}
+        aria-label={gridLabel}
+        cells={cells}
+        styles={PERIOD_GRID_STYLES}
+        columns={COLUMNS[view]}
+        focusedIndex={focusedIndex}
+        onCellPress={onCellPress}
+        onCellFocus={onCellFocus}
+        onMoveFocus={onMoveFocus}
+        onMovePage={onMovePage}
+      />
+    </CalendarElement>
   );
 }

--- a/src/components/other/Calendar/PeriodGrid.tsx
+++ b/src/components/other/Calendar/PeriodGrid.tsx
@@ -1,0 +1,226 @@
+import { Styles, tasty } from '@tenphi/tasty';
+import { KeyboardEvent, useLayoutEffect, useRef } from 'react';
+
+import { CALENDAR_CELL_STYLES } from './styled';
+
+const PeriodGridElement = tasty({
+  as: 'table',
+  role: 'grid',
+  styles: {
+    borderCollapse: 'collapse',
+    borderSpacing: 0,
+    // Columns share the width evenly. The owner passes that width explicitly —
+    // a percentage here would resolve against the popover's `max-content` box.
+    tableLayout: 'fixed',
+  },
+});
+
+const PeriodGridCellElement = tasty({
+  as: 'td',
+  role: 'gridcell',
+  styles: {
+    margin: 0,
+    padding: '2bw right bottom',
+  },
+});
+
+const PeriodGridButtonElement = tasty({
+  as: 'button',
+  'data-popover-keep': true,
+  styles: {
+    ...CALENDAR_CELL_STYLES,
+    width: '100%',
+    height: '4x',
+    padding: '0 .5x',
+  },
+});
+
+export interface CubePeriodGridCell {
+  /** Stable identity of the cell, also used as the React key. */
+  key: string;
+  label: string;
+  /** Overrides the accessible name when the visible label is ambiguous. */
+  ariaLabel?: string;
+  isSelected?: boolean;
+  /** Whether the cell contains today. */
+  isCurrent?: boolean;
+  isDisabled?: boolean;
+  /** Whether the cell belongs to a neighbouring page (e.g. an adjacent decade). */
+  isOutside?: boolean;
+}
+
+export interface CubePeriodGridProps {
+  cells: CubePeriodGridCell[];
+  columns: number;
+  /** Index of the cell that holds the roving tab stop. */
+  focusedIndex: number;
+  autoFocus?: boolean;
+  'aria-label'?: string;
+  styles?: Styles;
+  onCellPress: (index: number) => void;
+  /** Focus moved to another cell of the current page. */
+  onCellFocus: (index: number) => void;
+  /**
+   * Focus moved past the edge of the current page by `delta` periods. The owner
+   * moves its anchor, which in turn flips the page and the focused index.
+   */
+  onMoveFocus: (delta: number) => void;
+  /** `PageUp` / `PageDown` — one page back or forward. */
+  onMovePage: (delta: -1 | 1) => void;
+}
+
+/**
+ * A keyboard-navigable grid of calendar periods (months, quarters or years).
+ *
+ * The grid owns rendering, the roving tab stop and DOM focus; the owner owns
+ * the periods themselves. Arrow keys that leave the page are reported through
+ * `onMoveFocus` so the owner can page and keep focus on the adjacent period.
+ */
+export function PeriodGrid(props: CubePeriodGridProps) {
+  let {
+    cells,
+    columns,
+    focusedIndex,
+    autoFocus,
+    styles,
+    onCellPress,
+    onCellFocus,
+    onMoveFocus,
+    onMovePage,
+  } = props;
+
+  let cellRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  // Set by the grid's own keyboard handling and by `autoFocus`, so paging with
+  // the header buttons never steals focus into the grid.
+  let shouldFocusRef = useRef(!!autoFocus);
+
+  let safeIndex = Math.max(0, Math.min(cells.length - 1, focusedIndex));
+
+  cellRefs.current.length = cells.length;
+
+  useLayoutEffect(() => {
+    if (shouldFocusRef.current) {
+      shouldFocusRef.current = false;
+      cellRefs.current[safeIndex]?.focus();
+    }
+  });
+
+  let moveFocus = (delta: number) => {
+    shouldFocusRef.current = true;
+
+    let next = safeIndex + delta;
+
+    // Disabled cells can't hold DOM focus, so step over them instead of
+    // stranding the caret on an unreachable period.
+    while (next >= 0 && next < cells.length && cells[next].isDisabled) {
+      next += delta;
+    }
+
+    if (next < 0 || next >= cells.length) {
+      onMoveFocus(delta);
+    } else {
+      onCellFocus(next);
+    }
+  };
+
+  let focusEdge = (edge: 'start' | 'end') => {
+    let step = edge === 'start' ? 1 : -1;
+    let index = edge === 'start' ? 0 : cells.length - 1;
+
+    while (index >= 0 && index < cells.length && cells[index].isDisabled) {
+      index += step;
+    }
+
+    if (index < 0 || index >= cells.length) return;
+
+    shouldFocusRef.current = true;
+    onCellFocus(index);
+  };
+
+  let onKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowRight':
+        moveFocus(1);
+        break;
+      case 'ArrowLeft':
+        moveFocus(-1);
+        break;
+      case 'ArrowDown':
+        moveFocus(columns);
+        break;
+      case 'ArrowUp':
+        moveFocus(-columns);
+        break;
+      case 'Home':
+        focusEdge('start');
+        break;
+      case 'End':
+        focusEdge('end');
+        break;
+      case 'PageUp':
+        shouldFocusRef.current = true;
+        onMovePage(-1);
+        break;
+      case 'PageDown':
+        shouldFocusRef.current = true;
+        onMovePage(1);
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  let rows: CubePeriodGridCell[][] = [];
+
+  for (let i = 0; i < cells.length; i += columns) {
+    rows.push(cells.slice(i, i + columns));
+  }
+
+  return (
+    <PeriodGridElement
+      aria-label={props['aria-label']}
+      styles={styles}
+      onKeyDown={onKeyDown}
+    >
+      <tbody data-element="Body">
+        {rows.map((row, rowIndex) => (
+          <tr key={rowIndex} role="row" data-element="Row">
+            {row.map((cell, columnIndex) => {
+              let index = rowIndex * columns + columnIndex;
+
+              return (
+                <PeriodGridCellElement
+                  key={cell.key}
+                  aria-selected={!!cell.isSelected}
+                >
+                  <PeriodGridButtonElement
+                    ref={(element: HTMLButtonElement | null) => {
+                      cellRefs.current[index] = element;
+                    }}
+                    type="button"
+                    tabIndex={index === safeIndex ? 0 : -1}
+                    disabled={cell.isDisabled}
+                    aria-label={cell.ariaLabel}
+                    mods={{
+                      selected: cell.isSelected,
+                      current: cell.isCurrent,
+                      outside: cell.isOutside,
+                      disabled: cell.isDisabled,
+                    }}
+                    onFocus={() => onCellFocus(index)}
+                    onClick={() => onCellPress(index)}
+                  >
+                    {cell.label}
+                  </PeriodGridButtonElement>
+                </PeriodGridCellElement>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </PeriodGridElement>
+  );
+}

--- a/src/components/other/Calendar/RangeCalendar.tsx
+++ b/src/components/other/Calendar/RangeCalendar.tsx
@@ -1,7 +1,6 @@
 import { createCalendar } from '@internationalized/date';
 import { createDOMRef } from '@react-spectrum/utils';
 import { FocusableRef } from '@react-types/shared';
-import { tasty } from '@tenphi/tasty';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import {
   AriaRangeCalendarProps,
@@ -11,32 +10,18 @@ import {
 } from 'react-aria';
 import { useRangeCalendarState } from 'react-stately';
 
-import { LeftIcon, RightIcon } from '../../../icons';
 import { useProviderProps } from '../../../provider';
-import { Button } from '../../actions';
-import { Title } from '../../content/Title';
-import { Space } from '../../layout/Space';
 
-import { CalendarGrid } from './CalendarGrid';
+import { CalendarPanel } from './CalendarPanel';
+import { CalendarCoreProps, RangeCalendarValueProps } from './types';
 
-const CalendarElement = tasty({
-  styles: {
-    padding: '1x',
-    gap: '1x',
-  },
-});
-
-const CalendarHeaderElement = tasty({
-  styles: {
-    display: 'flex',
-    placeContent: 'center space-between',
-    placeItems: 'center',
-    gap: '1.5x',
-  },
-});
+export interface CubeRangeCalendarProps<T extends DateValue = DateValue>
+  extends AriaRangeCalendarProps<T>,
+    CalendarCoreProps,
+    RangeCalendarValueProps {}
 
 function RangeCalendar<T extends DateValue>(
-  props: AriaRangeCalendarProps<T>,
+  props: CubeRangeCalendarProps<T>,
   ref: FocusableRef<HTMLElement>,
 ) {
   props = useProviderProps(props);
@@ -60,28 +45,15 @@ function RangeCalendar<T extends DateValue>(
     useRangeCalendar(props, state, domRef);
 
   return (
-    <CalendarElement ref={domRef} {...calendarProps}>
-      <CalendarHeaderElement>
-        <Title level={6} preset="h6">
-          {title}
-        </Title>
-        <Space gap=".5x">
-          <Button
-            data-popover-keep
-            size="small"
-            {...prevButtonProps}
-            icon={<LeftIcon />}
-          />
-          <Button
-            data-popover-keep
-            size="small"
-            {...nextButtonProps}
-            icon={<RightIcon />}
-          />
-        </Space>
-      </CalendarHeaderElement>
-      <CalendarGrid state={state} />
-    </CalendarElement>
+    <CalendarPanel
+      elementRef={domRef}
+      state={state}
+      title={title}
+      calendarProps={calendarProps}
+      prevButtonProps={prevButtonProps}
+      nextButtonProps={nextButtonProps}
+      hasMonthYearNavigation={props.hasMonthYearNavigation}
+    />
   );
 }
 
@@ -90,5 +62,3 @@ const _RangeCalendar = forwardRef(RangeCalendar);
 _RangeCalendar.displayName = 'RangeCalendar';
 
 export { _RangeCalendar as RangeCalendar };
-
-export type { AriaRangeCalendarProps as CubeRangeCalendarProps };

--- a/src/components/other/Calendar/index.ts
+++ b/src/components/other/Calendar/index.ts
@@ -1,0 +1,14 @@
+export { Calendar } from './Calendar';
+export type { CubeCalendarProps } from './Calendar';
+export { RangeCalendar } from './RangeCalendar';
+export type { CubeRangeCalendarProps } from './RangeCalendar';
+export { PeriodCalendar } from './PeriodCalendar';
+export type {
+  CubePeriodCalendarProps,
+  CubePeriodCalendarPicker,
+} from './PeriodCalendar';
+export type {
+  CalendarCoreProps,
+  CalendarValueProps,
+  RangeCalendarValueProps,
+} from './types';

--- a/src/components/other/Calendar/styled.tsx
+++ b/src/components/other/Calendar/styled.tsx
@@ -1,0 +1,70 @@
+import { Styles, tasty } from '@tenphi/tasty';
+
+/**
+ * Every calendar flavour (day, range, period) shares the same shell so the
+ * popover keeps a stable size and rhythm when the user switches between the
+ * day grid and the month / year panels.
+ */
+export const CalendarElement = tasty({
+  styles: {
+    display: 'grid',
+    // Shrink-wrap the grid so a standalone calendar doesn't stretch its cells
+    // across whatever container it lands in.
+    width: 'max-content',
+    padding: '1x',
+    gap: '1x',
+  },
+});
+
+export const CalendarHeaderElement = tasty({
+  styles: {
+    display: 'flex',
+    placeContent: 'center space-between',
+    placeItems: 'center',
+    gap: '1.5x',
+  },
+});
+
+/**
+ * The interactive states shared by day cells and period (month / quarter /
+ * year) cells. Kept in one place so a day and a month never drift apart.
+ */
+export const CALENDAR_CELL_STYLES: Styles = {
+  preset: 't3m',
+  display: 'grid',
+  placeItems: 'center',
+  border: 0,
+  fill: {
+    '': '#primary.0',
+    ':hover': '#primary.16',
+    rangeHover: '#primary.16',
+    pressed: '#primary.10',
+
+    selected: '#primary',
+    'selected & :hover': '#primary-text',
+    'selected & pressed': '#primary',
+
+    'disabled | unavailable': '#primary.0',
+    // A disabled calendar still has to show what is selected.
+    'selected & (disabled | unavailable)': '#primary.30',
+  },
+  color: {
+    '': '#dark',
+    outside: '#dark.30',
+    // The cell that contains today — a hint, not a selection.
+    'current & !selected': '#primary-text',
+    selected: '#white',
+    'disabled | unavailable': '#dark.30',
+    'selected & (disabled | unavailable)': '#white',
+  },
+  outline: {
+    '': '1bw #primary-text.0',
+    focused: '1bw #primary-text',
+  },
+  outlineOffset: 0.5,
+  radius: true,
+  cursor: {
+    '': '$pointer',
+    'disabled | unavailable': 'default',
+  },
+};

--- a/src/components/other/Calendar/types.ts
+++ b/src/components/other/Calendar/types.ts
@@ -1,0 +1,53 @@
+import { CalendarDate } from '@internationalized/date';
+import { RangeValue } from '@react-types/shared';
+import { DateValue } from 'react-aria';
+
+/**
+ * `AriaCalendarProps` silently resolves to nothing under `preserveSymlinks`
+ * (see AGENTS.md → TypeScript & Exports), so `extends AriaCalendarProps`
+ * contributes no members and every prop below would go unchecked. Declare the
+ * ones the calendars genuinely support instead.
+ */
+export interface CalendarCoreProps {
+  /** The earliest date a user may select. */
+  minValue?: DateValue | null;
+  /** The latest date a user may select. */
+  maxValue?: DateValue | null;
+  /** Called for each visible date; return `true` to make it unselectable. */
+  isDateUnavailable?: (date: DateValue) => boolean;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isInvalid?: boolean;
+  autoFocus?: boolean;
+  /** The date the calendar shows and focuses (controlled). */
+  focusedValue?: DateValue | null;
+  /** The date the calendar shows and focuses initially (uncontrolled). */
+  defaultFocusedValue?: DateValue | null;
+  /** Whether paging moves by one page or by one unit. */
+  pageBehavior?: 'single' | 'visible';
+  onFocusChange?: (date: CalendarDate) => void;
+  /**
+   * Whether the header month and year are buttons that open the month and year
+   * lists.
+   * @default true
+   */
+  hasMonthYearNavigation?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+  'aria-details'?: string;
+}
+
+export interface CalendarValueProps {
+  value?: DateValue | null;
+  defaultValue?: DateValue | null;
+  onChange?: (value: DateValue) => void;
+}
+
+export interface RangeCalendarValueProps {
+  value?: RangeValue<DateValue> | null;
+  defaultValue?: RangeValue<DateValue> | null;
+  onChange?: (value: RangeValue<DateValue>) => void;
+  /** Whether a range may span dates that `isDateUnavailable` rejects. */
+  allowsNonContiguousRanges?: boolean;
+}

--- a/src/components/overlays/Dialog/DialogTrigger.test.tsx
+++ b/src/components/overlays/Dialog/DialogTrigger.test.tsx
@@ -1,0 +1,82 @@
+import { renderWithRoot, userEvent, waitFor } from '../../../test';
+import { Button } from '../../actions/Button';
+
+import { Dialog } from './Dialog';
+import { DialogTrigger } from './DialogTrigger';
+
+vi.mock('../../../_internal/hooks/use-warn');
+
+describe('<DialogTrigger type="popover" />', () => {
+  const user = userEvent.setup({ delay: null });
+
+  const openPopover = async (baseElement: HTMLElement) => {
+    await user.click(
+      baseElement.querySelector('[data-qa="Trigger"]') as HTMLElement,
+    );
+
+    return waitFor(() => {
+      const dialog = baseElement.querySelector('[data-qa="Dialog"]');
+      expect(dialog).toBeTruthy();
+      return dialog as HTMLElement;
+    });
+  };
+
+  const renderPopover = () =>
+    renderWithRoot(
+      <DialogTrigger type="popover">
+        <Button qa="Trigger">Open</Button>
+        <Dialog>
+          <Button qa="Inside">Inside</Button>
+        </Dialog>
+      </DialogTrigger>,
+    );
+
+  it('closes on Escape right after opening', async () => {
+    const { baseElement } = renderPopover();
+
+    await openPopover(baseElement);
+
+    // No wait: the popover has to be dismissable from the first frame, not
+    // only once its enter animation has settled.
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(baseElement.querySelector('[data-qa="Dialog"]')).toBeNull(),
+    );
+  });
+
+  it('closes on Escape once the enter animation has settled', async () => {
+    const { baseElement } = renderPopover();
+
+    await openPopover(baseElement);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(baseElement.querySelector('[data-qa="Dialog"]')).toBeNull(),
+    );
+  });
+
+  it('stays open when Escape is handled inside the popover', async () => {
+    const { baseElement } = renderWithRoot(
+      <DialogTrigger type="popover">
+        <Button qa="Trigger">Open</Button>
+        <Dialog>
+          <div onKeyDown={(e) => e.stopPropagation()}>
+            <Button qa="Inside">Inside</Button>
+          </div>
+        </Dialog>
+      </DialogTrigger>,
+    );
+
+    await openPopover(baseElement);
+
+    (baseElement.querySelector('[data-qa="Inside"]') as HTMLElement).focus();
+    await user.keyboard('{Escape}');
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(baseElement.querySelector('[data-qa="Dialog"]')).toBeTruthy();
+  });
+});

--- a/src/components/overlays/Modal/Popover.tsx
+++ b/src/components/overlays/Modal/Popover.tsx
@@ -1,3 +1,4 @@
+import { useObjectRef } from '@react-aria/utils';
 import { BaseProps, tasty } from '@tenphi/tasty';
 import { forwardRef, HTMLAttributes } from 'react';
 import { OverlayProps, useModal, useOverlay } from 'react-aria';
@@ -7,6 +8,8 @@ import { mergeProps } from '../../../utils/react';
 
 import { Overlay } from './Overlay';
 import { TransitionState, WithCloseBehavior } from './types';
+
+import type { Props } from '../../../props';
 
 const PopoverElement = tasty({
   role: 'presentation',
@@ -62,30 +65,36 @@ function Popover(props: CubePopoverProps, ref) {
     children,
     placement,
     arrowProps,
-    onClose,
-    shouldCloseOnBlur,
-    isKeyboardDismissDisabled,
     isNonModal,
     isDismissable = true,
-    shouldCloseOnInteractOutside,
     ...otherProps
   } = props;
+
+  let domRef = useObjectRef(ref);
+
+  // `useOverlay` has to run here rather than inside `PopoverWrapper`, on the
+  // *logical* open state — `Overlay` hands its child an `isOpen` that only
+  // turns true once the enter animation has settled. Registering the overlay
+  // that late leaves it out of React Aria's visible-overlay stack for the first
+  // frames, and `Escape` silently does nothing until the popover finishes
+  // animating in. `Modal` and `Tray` call it from the same place for the same
+  // reason.
+  let { overlayProps } = useOverlay(
+    { ...props, isDismissable: isDismissable && props.isOpen },
+    domRef,
+  );
 
   return (
     <Overlay {...otherProps}>
       <PopoverWrapper
-        ref={ref}
+        ref={domRef}
         qa={qa}
         style={style}
         styles={styles}
         placement={placement}
         arrowProps={arrowProps}
-        shouldCloseOnBlur={shouldCloseOnBlur}
-        isKeyboardDismissDisabled={isKeyboardDismissDisabled}
         isNonModal={isNonModal}
-        isDismissable={isDismissable}
-        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
-        onClose={onClose}
+        overlayProps={overlayProps}
       >
         {children}
       </PopoverWrapper>
@@ -93,8 +102,14 @@ function Popover(props: CubePopoverProps, ref) {
   );
 }
 
+interface PopoverWrapperProps
+  extends Omit<CubePopoverProps, 'isDismissable'>,
+    TransitionState {
+  overlayProps?: Props;
+}
+
 const PopoverWrapper = forwardRef(function PopoverWrapper(
-  props: CubePopoverProps,
+  props: PopoverWrapperProps,
   ref,
 ) {
   let {
@@ -102,22 +117,16 @@ const PopoverWrapper = forwardRef(function PopoverWrapper(
     children,
     placement = 'bottom',
     arrowProps,
+    // `isOpen` here is the transition's settled state, not the trigger's — it
+    // drives the enter/exit styles only.
     isOpen,
     style,
     styles,
-    shouldCloseOnBlur,
-    isKeyboardDismissDisabled,
     isNonModal,
-    isDismissable,
     transitionState,
-    shouldCloseOnInteractOutside,
+    overlayProps,
     ...otherProps
   } = props;
-  let { overlayProps } = useOverlay(
-    { ...props, isDismissable: isDismissable && isOpen },
-    // @ts-ignore
-    ref,
-  );
   let { modalProps } = useModal({
     isDisabled: isNonModal,
   });

--- a/src/i18n/locales/de-DE/uikit.json
+++ b/src/i18n/locales/de-DE/uikit.json
@@ -66,7 +66,20 @@
     "time": "Uhrzeit",
     "startTime": "Startzeit",
     "endTime": "Endzeit",
-    "showEndCalendar": "Kalender für das Enddatum anzeigen"
+    "showEndCalendar": "Kalender für das Enddatum anzeigen",
+    "selectWeek": "Woche auswählen",
+    "selectMonth": "Monat auswählen",
+    "selectQuarter": "Quartal auswählen",
+    "selectYear": "Jahr auswählen"
+  },
+  "calendar": {
+    "previousYear": "Vorheriges Jahr",
+    "nextYear": "Nächstes Jahr",
+    "previousYears": "Vorherige Jahre",
+    "nextYears": "Nächste Jahre",
+    "months": "Monate",
+    "quarters": "Quartale",
+    "years": "Jahre"
   },
   "fileInput": {
     "chooseFile": "Datei auswählen",

--- a/src/i18n/locales/en-US/uikit.json
+++ b/src/i18n/locales/en-US/uikit.json
@@ -66,7 +66,20 @@
     "time": "Time",
     "startTime": "Start time",
     "endTime": "End time",
-    "showEndCalendar": "Show calendar for the end date"
+    "showEndCalendar": "Show calendar for the end date",
+    "selectWeek": "Select week",
+    "selectMonth": "Select month",
+    "selectQuarter": "Select quarter",
+    "selectYear": "Select year"
+  },
+  "calendar": {
+    "previousYear": "Previous year",
+    "nextYear": "Next year",
+    "previousYears": "Previous years",
+    "nextYears": "Next years",
+    "months": "Months",
+    "quarters": "Quarters",
+    "years": "Years"
   },
   "fileInput": {
     "chooseFile": "Choose file",

--- a/src/i18n/locales/es-ES/uikit.json
+++ b/src/i18n/locales/es-ES/uikit.json
@@ -66,7 +66,20 @@
     "time": "Hora",
     "startTime": "Hora de inicio",
     "endTime": "Hora de fin",
-    "showEndCalendar": "Mostrar el calendario de la fecha de fin"
+    "showEndCalendar": "Mostrar el calendario de la fecha de fin",
+    "selectWeek": "Seleccionar semana",
+    "selectMonth": "Seleccionar mes",
+    "selectQuarter": "Seleccionar trimestre",
+    "selectYear": "Seleccionar año"
+  },
+  "calendar": {
+    "previousYear": "Año anterior",
+    "nextYear": "Año siguiente",
+    "previousYears": "Años anteriores",
+    "nextYears": "Años siguientes",
+    "months": "Meses",
+    "quarters": "Trimestres",
+    "years": "Años"
   },
   "fileInput": {
     "chooseFile": "Elegir archivo",

--- a/src/i18n/locales/es-MX/uikit.json
+++ b/src/i18n/locales/es-MX/uikit.json
@@ -66,7 +66,20 @@
     "time": "Hora",
     "startTime": "Hora de inicio",
     "endTime": "Hora de fin",
-    "showEndCalendar": "Mostrar el calendario de la fecha de fin"
+    "showEndCalendar": "Mostrar el calendario de la fecha de fin",
+    "selectWeek": "Seleccionar semana",
+    "selectMonth": "Seleccionar mes",
+    "selectQuarter": "Seleccionar trimestre",
+    "selectYear": "Seleccionar año"
+  },
+  "calendar": {
+    "previousYear": "Año anterior",
+    "nextYear": "Año siguiente",
+    "previousYears": "Años anteriores",
+    "nextYears": "Años siguientes",
+    "months": "Meses",
+    "quarters": "Trimestres",
+    "years": "Años"
   },
   "fileInput": {
     "chooseFile": "Elegir archivo",

--- a/src/i18n/locales/fr-FR/uikit.json
+++ b/src/i18n/locales/fr-FR/uikit.json
@@ -66,7 +66,20 @@
     "time": "Heure",
     "startTime": "Heure de début",
     "endTime": "Heure de fin",
-    "showEndCalendar": "Afficher le calendrier de la date de fin"
+    "showEndCalendar": "Afficher le calendrier de la date de fin",
+    "selectWeek": "Sélectionner une semaine",
+    "selectMonth": "Sélectionner un mois",
+    "selectQuarter": "Sélectionner un trimestre",
+    "selectYear": "Sélectionner une année"
+  },
+  "calendar": {
+    "previousYear": "Année précédente",
+    "nextYear": "Année suivante",
+    "previousYears": "Années précédentes",
+    "nextYears": "Années suivantes",
+    "months": "Mois",
+    "quarters": "Trimestres",
+    "years": "Années"
   },
   "fileInput": {
     "chooseFile": "Choisir un fichier",

--- a/src/i18n/locales/it-IT/uikit.json
+++ b/src/i18n/locales/it-IT/uikit.json
@@ -66,7 +66,20 @@
     "time": "Ora",
     "startTime": "Ora di inizio",
     "endTime": "Ora di fine",
-    "showEndCalendar": "Mostra il calendario della data di fine"
+    "showEndCalendar": "Mostra il calendario della data di fine",
+    "selectWeek": "Seleziona settimana",
+    "selectMonth": "Seleziona mese",
+    "selectQuarter": "Seleziona trimestre",
+    "selectYear": "Seleziona anno"
+  },
+  "calendar": {
+    "previousYear": "Anno precedente",
+    "nextYear": "Anno successivo",
+    "previousYears": "Anni precedenti",
+    "nextYears": "Anni successivi",
+    "months": "Mesi",
+    "quarters": "Trimestri",
+    "years": "Anni"
   },
   "fileInput": {
     "chooseFile": "Scegli file",

--- a/src/i18n/locales/ja-JP/uikit.json
+++ b/src/i18n/locales/ja-JP/uikit.json
@@ -66,7 +66,20 @@
     "time": "時刻",
     "startTime": "開始時刻",
     "endTime": "終了時刻",
-    "showEndCalendar": "終了日のカレンダーを表示"
+    "showEndCalendar": "終了日のカレンダーを表示",
+    "selectWeek": "週を選択",
+    "selectMonth": "月を選択",
+    "selectQuarter": "四半期を選択",
+    "selectYear": "年を選択"
+  },
+  "calendar": {
+    "previousYear": "前年",
+    "nextYear": "翌年",
+    "previousYears": "前の年代",
+    "nextYears": "次の年代",
+    "months": "月",
+    "quarters": "四半期",
+    "years": "年"
   },
   "fileInput": {
     "chooseFile": "ファイルを選択",

--- a/src/i18n/locales/nb-NO/uikit.json
+++ b/src/i18n/locales/nb-NO/uikit.json
@@ -66,7 +66,20 @@
     "time": "Tid",
     "startTime": "Starttid",
     "endTime": "Sluttid",
-    "showEndCalendar": "Vis kalender for sluttdato"
+    "showEndCalendar": "Vis kalender for sluttdato",
+    "selectWeek": "Velg uke",
+    "selectMonth": "Velg måned",
+    "selectQuarter": "Velg kvartal",
+    "selectYear": "Velg år"
+  },
+  "calendar": {
+    "previousYear": "Forrige år",
+    "nextYear": "Neste år",
+    "previousYears": "Forrige år-periode",
+    "nextYears": "Neste år-periode",
+    "months": "Måneder",
+    "quarters": "Kvartaler",
+    "years": "År"
   },
   "fileInput": {
     "chooseFile": "Velg fil",

--- a/src/i18n/locales/pt-BR/uikit.json
+++ b/src/i18n/locales/pt-BR/uikit.json
@@ -66,7 +66,20 @@
     "time": "Hora",
     "startTime": "Hora de início",
     "endTime": "Hora de término",
-    "showEndCalendar": "Mostrar o calendário da data de término"
+    "showEndCalendar": "Mostrar o calendário da data de término",
+    "selectWeek": "Selecionar semana",
+    "selectMonth": "Selecionar mês",
+    "selectQuarter": "Selecionar trimestre",
+    "selectYear": "Selecionar ano"
+  },
+  "calendar": {
+    "previousYear": "Ano anterior",
+    "nextYear": "Próximo ano",
+    "previousYears": "Anos anteriores",
+    "nextYears": "Próximos anos",
+    "months": "Meses",
+    "quarters": "Trimestres",
+    "years": "Anos"
   },
   "fileInput": {
     "chooseFile": "Escolher arquivo",

--- a/src/i18n/locales/pt-PT/uikit.json
+++ b/src/i18n/locales/pt-PT/uikit.json
@@ -66,7 +66,20 @@
     "time": "Hora",
     "startTime": "Hora de início",
     "endTime": "Hora de fim",
-    "showEndCalendar": "Mostrar o calendário da data de fim"
+    "showEndCalendar": "Mostrar o calendário da data de fim",
+    "selectWeek": "Selecionar semana",
+    "selectMonth": "Selecionar mês",
+    "selectQuarter": "Selecionar trimestre",
+    "selectYear": "Selecionar ano"
+  },
+  "calendar": {
+    "previousYear": "Ano anterior",
+    "nextYear": "Ano seguinte",
+    "previousYears": "Anos anteriores",
+    "nextYears": "Anos seguintes",
+    "months": "Meses",
+    "quarters": "Trimestres",
+    "years": "Anos"
   },
   "fileInput": {
     "chooseFile": "Escolher ficheiro",

--- a/src/i18n/locales/sv-SE/uikit.json
+++ b/src/i18n/locales/sv-SE/uikit.json
@@ -66,7 +66,20 @@
     "time": "Tid",
     "startTime": "Starttid",
     "endTime": "Sluttid",
-    "showEndCalendar": "Visa kalender för slutdatum"
+    "showEndCalendar": "Visa kalender för slutdatum",
+    "selectWeek": "Välj vecka",
+    "selectMonth": "Välj månad",
+    "selectQuarter": "Välj kvartal",
+    "selectYear": "Välj år"
+  },
+  "calendar": {
+    "previousYear": "Föregående år",
+    "nextYear": "Nästa år",
+    "previousYears": "Föregående år",
+    "nextYears": "Nästa år",
+    "months": "Månader",
+    "quarters": "Kvartal",
+    "years": "År"
   },
   "fileInput": {
     "chooseFile": "Välj fil",

--- a/src/i18n/locales/vi-VN/uikit.json
+++ b/src/i18n/locales/vi-VN/uikit.json
@@ -66,7 +66,20 @@
     "time": "Thời gian",
     "startTime": "Thời gian bắt đầu",
     "endTime": "Thời gian kết thúc",
-    "showEndCalendar": "Hiển thị lịch cho ngày kết thúc"
+    "showEndCalendar": "Hiển thị lịch cho ngày kết thúc",
+    "selectWeek": "Chọn tuần",
+    "selectMonth": "Chọn tháng",
+    "selectQuarter": "Chọn quý",
+    "selectYear": "Chọn năm"
+  },
+  "calendar": {
+    "previousYear": "Năm trước",
+    "nextYear": "Năm sau",
+    "previousYears": "Các năm trước",
+    "nextYears": "Các năm sau",
+    "months": "Tháng",
+    "quarters": "Quý",
+    "years": "Năm"
   },
   "fileInput": {
     "chooseFile": "Chọn tệp",


### PR DESCRIPTION
Closes [CUB-3903](https://linear.app/cube-d3/issue/CUB-3903/improve-calendar-component-in-ui-kit).

## Pick a month or a year from a list

The calendar header's title is now the navigation. The month and the year are separate buttons: pressing the month opens a month list, pressing the year opens a year list, and picking a year drops you into that year's months. Reaching a date two years out is two clicks instead of twenty-four.

`MonthPicker` and `QuarterPicker` get the same treatment — the year in their header opens a year list, so `2026 → 2019` no longer means seven clicks on the arrow.

The month and year panels only *navigate*. They move the focused date and never select a value, so a range selection in progress survives a jump to another month.

Opt out with `hasMonthYearNavigation={false}`.

## Shared internals

`Calendar`, `RangeCalendar` and `PeriodCalendar` had three copies of the same header, the same shell element and two divergent copies of the cell styles. They now share:

- `CalendarHeader` — title segments + prev/next, one size of nav button (`RangeCalendar` used `small` where `Calendar` used `xsmall`)
- `PeriodGrid` — one accessible grid for months, quarters and years
- `styled.tsx` — one set of cell states

`CalendarPanel` holds the day/month/year switching for both `Calendar` and `RangeCalendar`.

## Review findings, fixed

- **`Calendar` never attached its ref.** `domRef` was created, wrapped in `useImperativeHandle`, and then dropped — `createDOMRef(domRef)` always resolved to `null`. `RangeCalendar` did attach it.
- **`PeriodPicker` spread the field's `labelProps` onto its value text**, duplicating the label's `id` (`wrapWithField` applies the same props to the real `<label>`).
- **`PeriodPicker` ignored `isReadOnly`** — clicking the field opened the popover anyway.
- **The trigger never announced the selected value.** There are no date segments to read, so the button is now `aria-describedby` the value text.
- **The period panel was a `role="grid"` with no rows** and `aria-pressed` on its cells. It is now a real grid (rows, `gridcell`, `aria-selected`) with a roving tab stop.
- **Keyboard support in the period panels was partial**: arrows clamped at the page edge and there was no paging. Arrows now roll over into the neighbouring year or decade, `PageUp`/`PageDown` page, `Home`/`End` jump to the first/last *selectable* period, disabled cells are stepped over, and `Escape` steps back one panel instead of closing the popover.
- **Switching panels dropped focus to `<body>`** (the button you pressed unmounts). Focus now follows into the new grid.
- **Periods were disabled by comparing against a snapped bound**, so `maxValue={2026-09-15}` disabled all of September. A period is now disabled only when *all* of it falls outside the range.
- **`hidden` on out-of-range day cells did nothing** (`display: grid` overrides `[hidden]`), so they rendered anyway. Replaced with an explicit `outside` modifier — same pixels, honest markup.
- **`gap: 1x` on the calendar shell did nothing** (`display: block`). The shell is now a `max-content` grid, which also stops a standalone calendar from stretching its cells across its container.
- **Nothing marked today.** Day and period cells now carry a `current` modifier.
- **`formatValue` was typed `(date, picker)` but called with `(date, picker, locale)`.**
- `PeriodPicker`'s placeholders were hardcoded English; those and the new calendar labels are translated in all twelve locales.

## Not fixed (pre-existing, out of scope)

- Range selections still paint every day in the range identically; distinct start/end caps would read better. Noted in the docs' *Suggested Improvements*.

## Docs, stories, tests

`Calendar` had no stories, docs or tests. It now has all three (`Other/Calendar`), including `play`-driven stories for the month and year panels so Chromatic captures them. `PeriodPicker.docs.mdx` gained accessibility and style-props sections.

`Calendar` is still not exported from the package root: `export * from '@internationalized/date'` already exports a `Calendar` interface, and shadowing it would be a breaking change for consumers.

## Verification

`pnpm test` (90 files, 1841 tests), `pnpm oxlint`, `tsc --noEmit` and `pnpm audit-defaults` are clean. Every panel was driven by hand in Storybook — light and dark, mouse and keyboard, across `DatePicker`, `DateRangePicker`, `DateRangeSeparatedPicker` and the four period pickers.

Two existing `DatePicker` assertions changed: the heading's text is now two buttons rather than one string, so they assert on the buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: `Escape` now closes the popover

The earlier note claiming this was pre-existing `Dialog` behaviour was wrong on the cause, and the bug turned out to be fixable — it is fixed here.

`Popover` called `useOverlay` from inside `PopoverWrapper`. That component is rendered by `Overlay`, which clones its child with an `isOpen` derived from the *transition* (`phase === 'entered'`), not from the trigger. React Aria only pushes an overlay onto its visible-overlay stack while `isOpen`, and `onHide` dismisses only the topmost entry — so for the first frames after opening, the popover was not in the stack and `Escape` did nothing. In a background tab, where `requestAnimationFrame` never advances the phase past `enter`, it never worked at all, which is why it looked permanent.

`useOverlay` now runs in `Popover` against the trigger's open state, exactly where `Modal` and `Tray` already call it. This affects every `DialogTrigger type="popover"`, not just the date fields.

One more fix fell out of it: when `Escape` steps back from the calendar's month or year panel, the grid the user was in unmounts. Without claiming focus for the day cell, focus fell out of the popover entirely and the *next* `Escape` was lost. `CalendarPanel` now calls `state.setFocused(true)` on the way back.

Covered by three new tests in `DialogTrigger.test.tsx` (dismiss during `enter`, dismiss after `entered`, and staying open when a child handles `Escape`) plus two in `DatePicker.test.tsx` for the step-back behaviour. Reverting `Popover.tsx` alone fails the "right after opening" test and passes the "once settled" one, which pins the diagnosis.
