### PR TITLE
feat(eslint-plugin): lint ui-kit with its own no-redundant-default-prop rule

### DIFF
--- a/.changeset/radiogroup-size-default.md
+++ b/.changeset/radiogroup-size-default.md
@@ -1,0 +1,11 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Fix `RadioGroup`'s documented `size` default, which was wrong in a way the lint rule acted on.
+
+`RadioGroup.docs.mdx` contradicted both itself and the implementation: the `## Properties` bullet said `(default: xsmall)` while its own prose said `medium`, and `Radio.tsx` resolves `size ?? contextSize ?? 'medium'`. The default is `medium`.
+
+That annotation is what seeds the `no-redundant-default-prop` registry, so the shipped rule claimed `<RadioGroup size="xsmall">` was redundant and offered to delete it — which silently resized the radios to `medium`. The prover could not catch the drift because `size` only reaches the DOM through the radios and a plain `type="radio"` radio renders identically at every size, so any documented value verified. The fixture now probes under `type="button"` and `type="tabs"` as well, which is what makes a wrong `size` value fail: restoring `xsmall` under the new conditions correctly downgrades the prop to `skip: 'conditional'` instead of passing as a verified default.
+
+Also corrects the tabs-mode size mapping table. It claimed `xlarge` maps to `large` and listed `xsmall` as passing through, but `Radio.tsx` maps only `large`, funnelling every other size through `RADIO_SIZE_MAP.medium` — so `xsmall`, `small`, `medium` and `xlarge` all collapse to `xsmall`.

--- a/.changeset/self-lint-redundant-default-prop.md
+++ b/.changeset/self-lint-redundant-default-prop.md
@@ -1,0 +1,18 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Lint ui-kit's own source with the `no-redundant-default-prop` rule it ships, and fix four registry entries that autofixing would have broken.
+
+The plugin was never applied to this repo. Two things prevented it, and the second was silent: nothing loaded the plugin, and provenance is gated on the import specifier literally matching `@cube-dev/ui-kit`, which no file in `src/` uses — every component import here is relative, across 210 distinct specifiers that share no usable prefix. So even once loaded, the rule reported nothing.
+
+- New `relativeImports` rule option, which also accepts relative specifiers as ui-kit provenance. It exists for linting this repository and must not be enabled in a consumer project, where a relative import is the consumer's own component. Shadowing still bails either way — resolution requires an `ImportBinding`, so a local `const Badge = tasty({})` is never matched.
+- `configs.recommended` now sets stories and `.docs.mdx` to `warn` instead of `off`. Stories are the code people copy, so redundant props there travel outward and are worth surfacing; a deliberate side-by-side contrast still has a real reason to name a default, so it warns rather than failing a build.
+
+Four props were classified as plain defaults when they are actually inherited overrides, so the rule would have offered — and `--fix` would have taken — an autofix that changed behaviour. Each is now `skip: 'context'`:
+
+- `ItemAction` `isDisabled` and `type`. `<Item isDisabled>` renders its `actions` inside `ItemActionProvider`, and `isDisabled = isDisabledProp ?? contextIsDisabled`, so `<ItemAction isDisabled={false}>` is the documented way to keep one action live inside a disabled item. Stripping it silently disabled that action.
+- `ItemBadge` `type` and `theme`, which read the same context and had no conditions on their fixture at all.
+- `Dialog` `isDismissable`, resolved as `contextProps.isDismissable` with no literal fallback while `DialogContainer` and `DialogTrigger` default that context value to `true`, so a nested `<Dialog isDismissable={false}>` is an override. Three call sites in shipped source relied on it.
+
+The cause is general: a prop resolved as `prop ?? context ?? literal` probes as a plain default in a bare tree, because the literal wins when nothing supplies the context. Only `ItemAction`'s `theme` was classified correctly, and only because it happened to be the one prop with a matching condition. The fixtures now supply a differing value for each such prop, so the prover derives these skips itself and the sync guard re-proves them on every test run rather than trusting a hand-written note. A repo-wide audit for the pattern found no other affected component.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,7 +2,11 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": [],
   "jsPlugins": [
-    { "name": "tasty", "specifier": "@tenphi/eslint-plugin-tasty" }
+    { "name": "tasty", "specifier": "@tenphi/eslint-plugin-tasty" },
+    {
+      "name": "cube-ui-kit",
+      "specifier": "./scripts/oxlint-cube-ui-kit-plugin.mjs"
+    }
   ],
   "categories": {
     "correctness": "off"
@@ -100,7 +104,13 @@
     "tasty/prefer-hide": "warn",
     "tasty/no-raw-color-values": "warn",
     "tasty/prefer-directional-shorthand": "warn",
-    "tasty/prefer-longhand-property": "error"
+    "tasty/prefer-longhand-property": "error",
+    "cube-ui-kit/no-redundant-default-prop": [
+      "error",
+      {
+        "relativeImports": true
+      }
+    ]
   },
   "overrides": [
     {
@@ -1315,6 +1325,30 @@
         "react",
         "typescript"
       ]
+    },
+    {
+      // Generator input for the differential-render prover, not consumer code.
+      // Autofixing it would rewrite the very inputs that establish the registry.
+      "files": [
+        "**/eslint-plugin/fixtures.tsx"
+      ],
+      "rules": {
+        "cube-ui-kit/no-redundant-default-prop": "off"
+      }
+    },
+    {
+      // A test that pins an expected value should keep stating it. The removals
+      // are render-equivalent today, but stripping `cols={12}` makes the test
+      // assert whatever the default happens to be, so a later change to that
+      // default passes instead of failing.
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.test.jsx"
+      ],
+      "rules": {
+        "cube-ui-kit/no-redundant-default-prop": "off"
+      }
     }
   ]
 }

--- a/docs/rules/eslint-plugin.md
+++ b/docs/rules/eslint-plugin.md
@@ -30,6 +30,37 @@ The rule only reports components it can prove were imported from `@cube-dev/ui-k
 { rules: { 'cube-ui-kit/no-redundant-default-prop': ['warn', { packages: ['~/components/ui'] }] } }
 ```
 
+Stories and `.docs.mdx` are set to `warn`, not `off`. They are the code people copy, so redundant props there travel outward — but a deliberate side-by-side contrast has a real reason to name the default, and failing a build over it would be wrong. Silence those individual sites with a disable comment.
+
+## Linting this repository with its own rule
+
+`pnpm lint` runs the rule against ui-kit's own source, including stories. Two pieces make that work.
+
+First, provenance. In this repo components are imported by path (`../../layout/Space`, `./Button`, `..`), never by package name, so the `packages` check matches nothing and the rule would silently do nothing. The `relativeImports` option adds relative specifiers as an accepted source:
+
+```jsonc
+// .oxlintrc.json
+"cube-ui-kit/no-redundant-default-prop": ["error", { "relativeImports": true }]
+```
+
+Never enable it in a consumer project: there, a relative import *is* the consumer's own component, and trusting it would rewrite props on code this registry knows nothing about. Shadowing is still safe either way — resolution requires an `ImportBinding`, so a local `const Badge = tasty({})` is never matched.
+
+Second, loading. Oxlint's `jsPlugins` takes `./scripts/oxlint-cube-ui-kit-plugin.mjs`, a jiti shim that imports `src/eslint-plugin/index.ts` directly. That keeps linting honest against the source rather than a possibly stale `dist/`, and needs no build step in front of `pnpm lint`. Oxlint's own loader cannot read the TS source directly — it is a bare `await import()`, which will not resolve the extensionless relative imports the source uses.
+
+Two exclusions are deliberate, both in `.oxlintrc.json`:
+
+- `eslint-plugin/fixtures.tsx` — generator input for the prover. Autofixing it would rewrite the inputs that establish the registry.
+- `*.test.ts(x)` — a test that pins an expected value should keep stating it. The removals are render-equivalent, but stripping `cols={12}` makes the test assert whatever the default happens to be, so a later change to that default passes instead of failing.
+
+Suppress a deliberate case at the site. Inside a JSX opening tag use a line comment; in children position only a JSX comment parses:
+
+```jsx
+{/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- Sizes story names every size */}
+<Badge size="inline">8</Badge>
+```
+
+Note that `.lintstagedrc` runs `oxlint --fix` on commit, so an unsuppressed redundant prop is stripped automatically by the next commit that touches its file.
+
 ## When you change a default
 
 Run `pnpm audit-defaults`, then commit the regenerated `src/eslint-plugin/defaults.generated.ts`. `pnpm test` fails until it matches, naming the exact prop — this is what keeps the list in sync.
@@ -74,7 +105,31 @@ Then bump `COVERED` in `defaults.test.ts` and run `pnpm audit-defaults`.
 
 A fixture must render the component for real — required props, collection children, `defaultOpen` for portalled overlays. Some components throw without exactly the right children (`DialogTrigger`, `MenuTrigger` and `TooltipTrigger` require exactly two; `DisplayTransition` requires a function child). Every fixture is rendered inside `<Root>`, which is what satisfies `useEventBus` for the popover-based components.
 
-## Two traps worth knowing
+## Excluding one prop on one component
+
+Every exclusion is scoped to a component *and* a prop: `curatedSkips` and `ignoreProps` are keyed by prop name on a single fixture, and the registry is `component -> prop -> entry` throughout. Excluding a prop name globally is deliberately not possible — `isDisabled` is a genuine plain default on `ButtonSplit`, `Disclosure`, `InlineInput`, `Portal` and `Tree`, and an inherited override only on `ItemAction`. A name-level exclusion would silence the former to protect the latter.
+
+Which of the three to reach for:
+
+| Situation | Use |
+|---|---|
+| The prop is load-bearing under a provider, or under a co-prop of the same component | `conditions` |
+| The probe reports a difference and only a person can say what it means | `curatedSkips`, with a reason and a note |
+| The fixture sets the prop itself, so it cannot be probed at all | `ignoreProps` |
+
+Prefer `conditions` whenever the difference is reproducible in a render. A `curatedSkips` entry short-circuits `classifyProp` (`generate.ts`) and is never probed again, so it keeps asserting its reason after the component stops behaving that way; a condition is re-proved by the sync guard on every `pnpm test`, and flips back to a plain default the moment it stops holding. Use `curatedSkips` when there is nothing to reproduce.
+
+There is no consumer-side override, by design. A product hitting a one-off uses a disable comment at the site; anything systemic is a registry bug and belongs in a fixture here, where it ships to every consumer at once.
+
+## Three traps worth knowing
+
+**A prop whose default comes from context needs a condition, or it is misfiled as a plain default.** When a component resolves a prop as `prop ?? context ?? literal`, probing it bare hits the literal and the prop looks redundant — while in a real tree it is what stops the inherited value from applying. Stripping it is then a behaviour change, not a cleanup. Three cases were caught this way:
+
+- `ItemAction` reads `type`, `theme` and `isDisabled` off `ItemActionContext`. `<Item isDisabled>` renders its `actions` inside that provider, so `<ItemAction isDisabled={false}>` is the documented way to keep one action live inside a disabled item.
+- `ItemBadge` reads `type` and `theme` the same way and had no conditions at all.
+- `Dialog` resolves `isDismissable = contextProps.isDismissable` with no literal fallback, and `DialogContainer`/`DialogTrigger` default that context value to `true`, so a nested `<Dialog isDismissable={false}>` is an override.
+
+Only `theme` on `ItemAction` was classified correctly at first, because it was the only one with a matching condition. When you add a fixture, check what the component reads from context and add a condition supplying a *different* value for each such prop — the prover can only see what a condition lets it see. Grep for `= context` and `?? context` in the component to find them.
 
 **A fixture that renders nothing is worse than a missing one.** Every prop would look like a no-op and be recorded as a verified default, and the rule would then delete real props. `fixtures.test.tsx` compares each fixture against an empty tree to catch that.
 

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "dedent": "^0.7.0",
     "eslint": "^10.8.0",
     "husky": "^6.0.0",
+    "jiti": "^2.6.1",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.0.8",
     "markdown-table": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       husky:
         specifier: ^6.0.0
         version: 6.0.0
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1

--- a/scripts/oxlint-cube-ui-kit-plugin.mjs
+++ b/scripts/oxlint-cube-ui-kit-plugin.mjs
@@ -1,0 +1,18 @@
+/**
+ * Loads the shipped ESLint plugin from `src/` so `pnpm lint` dogfoods
+ * `no-redundant-default-prop` against the very source the package publishes.
+ *
+ * The indirection is not decoration. Oxlint's `jsPlugins` loader is a bare
+ * `(await import(url)).default`, so pointing it at `src/eslint-plugin/index.ts`
+ * fails: Node's TypeScript type-stripping keeps Node's ESM resolver, which will
+ * not resolve the extensionless relative imports the source uses. Jiti resolves
+ * them. Pointing oxlint at `dist/` instead would work but couples linting to a
+ * prior build — `dist` is gitignored and CI lints without building first.
+ */
+import { createJiti } from 'jiti';
+
+const jiti = createJiti(import.meta.url);
+
+export default await jiti.import('../src/eslint-plugin/index.ts', {
+  default: true,
+});

--- a/src/components/actions/Banner/Banner.stories.tsx
+++ b/src/components/actions/Banner/Banner.stories.tsx
@@ -42,6 +42,7 @@ export const Themes: StoryFn<BannerProps> = () => {
       >
         Warning: API usage at 85% of monthly limit.
       </Banner>
+      {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- themed banner list names every theme, note included, so the set reads */}
       <Banner theme="note" actions={<Banner.Action>Learn More</Banner.Action>}>
         Tip: Enable auto-scaling to handle traffic spikes automatically.
       </Banner>
@@ -57,7 +58,7 @@ export const Themes: StoryFn<BannerProps> = () => {
  */
 export const WithLinks: StoryFn<BannerProps> = () => {
   return (
-    <Space direction="vertical" gap="1x" width="100%">
+    <Space direction="vertical" width="100%">
       <Banner
         theme="warning"
         actions={<Banner.Action>Upgrade tier</Banner.Action>}
@@ -104,6 +105,7 @@ export const Stacked: StoryFn<BannerProps> = () => {
       >
         Warning: You have exceeded 80% of your query limit.
       </Banner>
+      {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- themed banner list names every theme, note included, so the set reads */}
       <Banner isDismissable theme="note" shape="sharp">
         New deployment features are available.
       </Banner>
@@ -129,7 +131,6 @@ CustomIcon.args = {
 export const WithDescription: StoryFn<BannerProps> = () => {
   return (
     <Banner
-      theme="note"
       width="300px"
       description="This is an extended description that spans multiple lines to demonstrate text overflow behavior. When the banner container has limited width, the description should show ellipsis after two lines."
     >

--- a/src/components/actions/Button/Button.stories.tsx
+++ b/src/components/actions/Button/Button.stories.tsx
@@ -468,7 +468,7 @@ export const ToggleLoading = () => {
   return (
     <Space>
       <Button isLoading={isLoading}>Target Button</Button>
-      <Button type="outline" onPress={() => setIsLoading((prev) => !prev)}>
+      <Button onPress={() => setIsLoading((prev) => !prev)}>
         {isLoading ? 'Stop Loading' : 'Start Loading'}
       </Button>
     </Space>
@@ -564,7 +564,6 @@ const CurrentContext = ({
 }) => (
   <Space
     flow="column"
-    gap="1x"
     padding="1.5x"
     radius="1x"
     border={fill ? undefined : true}

--- a/src/components/actions/CommandMenu/CommandMenu.stories.tsx
+++ b/src/components/actions/CommandMenu/CommandMenu.stories.tsx
@@ -990,7 +990,7 @@ DifferentSizes.parameters = {
 export const WithDialog: StoryFn<CubeCommandMenuProps<any>> = (args) => (
   <DialogTrigger>
     <Button>Open Command Menu</Button>
-    <Dialog size="medium" isDismissable={false}>
+    <Dialog isDismissable={false}>
       <CommandMenu {...args}>
         {basicCommands.map((command) => (
           <CommandMenu.Item
@@ -1099,7 +1099,7 @@ function CommandMenuDialogContent({
   };
 
   return (
-    <Dialog size="medium" isDismissable={false}>
+    <Dialog isDismissable={false}>
       <CommandMenu {...commandMenuProps}>
         {basicCommands.map((command) => (
           <CommandMenu.Item

--- a/src/components/actions/ItemAction/ItemAction.stories.tsx
+++ b/src/components/actions/ItemAction/ItemAction.stories.tsx
@@ -305,6 +305,7 @@ export const States: Story = {
         <Title level={4}>Selected</Title>
         <Space>
           <ItemAction isSelected icon="checkmark" tooltip="Select" />
+          {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- contrasts with the isSelected sibling; dropping it makes the pair identical */}
           <ItemAction icon="checkmark" tooltip="Select" isSelected={false} />
           <ItemAction isSelected icon={<IconStar />} tooltip="Favorite" />
         </Space>
@@ -318,7 +319,7 @@ export const InsideItemButton: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Icon Only Actions</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             type="outline"
             icon={<IconFile />}
@@ -349,7 +350,7 @@ export const InsideItemButton: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Labels</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             type="outline"
             icon={<IconFile />}
@@ -370,7 +371,7 @@ export const InsideItemButton: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Actions automatically inherit type and theme from parent ItemButton
         </Paragraph>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             type="primary"
             theme="default"
@@ -405,7 +406,7 @@ export const InsideItemButton: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Actions can override inherited type/theme
         </Paragraph>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             type="outline"
             icon={<IconFile />}
@@ -444,7 +445,7 @@ export const InsideItemButton: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Different Sizes</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             type="outline"
             size="small"
@@ -460,7 +461,6 @@ export const InsideItemButton: Story = {
           </ItemButton>
           <ItemButton
             type="outline"
-            size="medium"
             icon={<IconFile />}
             actions={
               <>
@@ -492,7 +492,7 @@ export const InsideItemButton: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Actions can appear only on hover
         </Paragraph>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             autoHideActions
             type="outline"
@@ -549,9 +549,8 @@ export const InsideItem: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Basic Usage</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
-            type="item"
             icon={<IconFile />}
             actions={
               <>
@@ -563,7 +562,6 @@ export const InsideItem: Story = {
             Document.pdf
           </Item>
           <Item
-            type="item"
             icon={<IconFile />}
             actions={
               <>
@@ -580,7 +578,7 @@ export const InsideItem: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Different Item Types</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
             type="primary"
             icon={<IconFile />}
@@ -622,12 +620,10 @@ export const InsideItem: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Description</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
-            type="item"
             icon={<IconFile />}
             description="Last modified 2 days ago"
-            descriptionPlacement="inline"
             actions={
               <>
                 <ItemAction icon={<IconEdit />} tooltip="Edit" />
@@ -638,7 +634,6 @@ export const InsideItem: Story = {
             Document.pdf
           </Item>
           <Item
-            type="item"
             icon={<IconFile />}
             description="Last modified 2 days ago"
             descriptionPlacement="block"
@@ -656,9 +651,8 @@ export const InsideItem: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Theme Inheritance</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
-            type="item"
             theme="danger"
             icon={<IconFile />}
             actions={
@@ -671,7 +665,6 @@ export const InsideItem: Story = {
             Danger Theme Item
           </Item>
           <Item
-            type="item"
             theme="success"
             icon={<IconFile />}
             actions={
@@ -688,9 +681,8 @@ export const InsideItem: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Mixed Action Types</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
-            type="item"
             icon={<IconFile />}
             actions={
               <>
@@ -712,9 +704,8 @@ export const InsideItem: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Loading States</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
-            type="item"
             icon={<IconFile />}
             actions={
               <>
@@ -734,10 +725,9 @@ export const InsideItem: Story = {
           Actions inherit disabled state from parent Item. Use isDisabled=false
           to keep action enabled.
         </Paragraph>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
             isDisabled
-            type="item"
             icon={<IconFile />}
             actions={
               <>
@@ -750,7 +740,6 @@ export const InsideItem: Story = {
           </Item>
           <Item
             isDisabled
-            type="item"
             icon={<IconFile />}
             actions={
               <>
@@ -770,9 +759,8 @@ export const InsideItem: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Truncated Content</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <Item
-            type="item"
             icon={<IconFile />}
             styles={{ width: 'max 300px' }}
             actions={
@@ -806,7 +794,7 @@ export const InteractiveExample: Story = {
       <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
         Click on the action buttons to see the interactions
       </Paragraph>
-      <Space flow="column" gap="1x" placeItems="start">
+      <Space flow="column" placeItems="start">
         <ItemButton
           type="outline"
           icon={<IconFile />}

--- a/src/components/actions/ItemButton/ItemButton.stories.tsx
+++ b/src/components/actions/ItemButton/ItemButton.stories.tsx
@@ -154,7 +154,7 @@ export const AsLink: Story = {
 
 export const States: Story = {
   render: (args) => (
-    <Space flow="column" gap="1x" placeItems="start">
+    <Space flow="column" placeItems="start">
       <ItemButton
         {...args}
         mods={{ hovered: false, pressed: false, focused: false }}
@@ -234,7 +234,7 @@ export const WithHotkeys: Story = {
         <Paragraph preset="t4" color="#dark-03" margin="0 0 2x 0">
           Try pressing the keyboard shortcuts to trigger the buttons:
         </Paragraph>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             hotkeys="cmd+s"
@@ -277,7 +277,7 @@ export const WithHotkeys: Story = {
           When a custom suffix is provided, hotkeys are still functional but the
           shortcut hint is not shown:
         </Paragraph>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             hotkeys="cmd+d"
@@ -291,7 +291,7 @@ export const WithHotkeys: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Different Hotkey Formats</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             hotkeys="ctrl+alt+d"
@@ -337,7 +337,7 @@ export const WithCheckbox: Story = {
     <Flow gap="2x">
       <Flow gap="1x">
         <Title level={4}>Selected Items (Checkmark Visible)</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} isSelected={true}>
             Selected item with checkmark
           </ItemButton>
@@ -352,7 +352,7 @@ export const WithCheckbox: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Non-Selected Items (Checkmark Hidden)</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} isSelected={false}>
             Non-selected item with hidden checkmark
           </ItemButton>
@@ -367,7 +367,7 @@ export const WithCheckbox: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Mixed Selection States</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} isSelected={true} type="primary">
             Selected Item 1
           </ItemButton>
@@ -382,7 +382,7 @@ export const WithCheckbox: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Comparison: Checkmark vs Regular Icon</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} isSelected={true}>
             With checkmark (selected)
           </ItemButton>
@@ -415,7 +415,7 @@ export const WithLoading: Story = {
       <Flow gap="2x">
         <Flow gap="1x">
           <Title level={4}>Loading States with Auto Slot Selection</Title>
-          <Space flow="column" gap="1x" placeItems="start">
+          <Space flow="column" placeItems="start">
             <ItemButton {...cleanArgs} isLoading={false} icon={<IconFile />}>
               Normal state
             </ItemButton>
@@ -437,7 +437,7 @@ export const WithLoading: Story = {
 
         <Flow gap="1x">
           <Title level={4}>Loading with Different Types</Title>
-          <Space flow="column" gap="1x" placeItems="start">
+          <Space flow="column" placeItems="start">
             <ItemButton
               {...cleanArgs}
               type="primary"
@@ -468,7 +468,7 @@ export const WithLoading: Story = {
 
         <Flow gap="1x">
           <Title level={4}>Explicit Loading Slots</Title>
-          <Space flow="column" gap="1x" placeItems="start">
+          <Space flow="column" placeItems="start">
             <ItemButton
               {...cleanArgs}
               isLoading={true}
@@ -505,7 +505,7 @@ export const WithLoading: Story = {
             Loading buttons are automatically disabled and cannot be interacted
             with:
           </Paragraph>
-          <Space flow="column" gap="1x" placeItems="start">
+          <Space flow="column" placeItems="start">
             <ItemButton
               {...cleanArgs}
               isLoading={true}
@@ -542,7 +542,7 @@ export const AutoTooltipOnOverflow: Story = {
     <Flow gap="2x">
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with tooltip=true</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             tooltip={true}
@@ -564,7 +564,7 @@ export const AutoTooltipOnOverflow: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with Configuration Object</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             tooltip={{ auto: true, placement: 'top' }}
@@ -586,7 +586,7 @@ export const AutoTooltipOnOverflow: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Auto vs Explicit Tooltip</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             tooltip={{ title: 'Custom tooltip text', auto: true }}
@@ -608,7 +608,7 @@ export const AutoTooltipOnOverflow: Story = {
 
       <Flow gap="1x">
         <Title level={4}>No Tooltip When Not Overflowed</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             tooltip={true}
@@ -630,7 +630,7 @@ export const AutoTooltipOnOverflow: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with Different Button Types</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             tooltip={true}
@@ -663,7 +663,7 @@ export const AutoTooltipOnOverflow: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Auto Tooltip with Hotkeys</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             tooltip={{ auto: true, placement: 'top' }}
@@ -704,7 +704,7 @@ export const WithActionsLayouts: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Different Sizes</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -780,7 +780,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Only Actions</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -811,7 +811,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Left Icon</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -844,7 +844,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Prefix</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -877,7 +877,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Left Icon and Prefix</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -912,7 +912,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Inline Description</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -947,7 +947,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Inline Description and Left Icon</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -984,7 +984,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Block Description</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1019,7 +1019,7 @@ export const WithActionsLayouts: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Block Description and Left Icon</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1070,7 +1070,7 @@ export const WithHighlight: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Basic Highlight</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} icon={<IconFile />} highlight="file">
             File management options
           </ItemButton>
@@ -1087,7 +1087,7 @@ export const WithHighlight: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Case Sensitivity</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1110,7 +1110,7 @@ export const WithHighlight: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Multiple Matches</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1124,7 +1124,7 @@ export const WithHighlight: Story = {
 
       <Flow gap="1x">
         <Title level={4}>With Custom Highlight Styles</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1139,7 +1139,7 @@ export const WithHighlight: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Combined with Other Features</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1361,7 +1361,7 @@ export const Disabled: Story = {
     <Flow gap="2x" width="max 600px">
       <Flow gap="1x">
         <Title level={4}>Basic Disabled Buttons</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} isDisabled={true}>
             Disabled button
           </ItemButton>
@@ -1373,7 +1373,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Icons</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton {...args} isDisabled={true} icon={<IconFile />}>
             Disabled with icon
           </ItemButton>
@@ -1390,7 +1390,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Disabled Across Different Types</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="primary"
@@ -1429,7 +1429,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Disabled Across Different Sizes</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             size="xsmall"
@@ -1475,7 +1475,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Description</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1501,7 +1501,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Actions</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="outline"
@@ -1521,7 +1521,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Disabled with Hotkeys</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             isDisabled={true}
@@ -1536,7 +1536,7 @@ export const Disabled: Story = {
 
       <Flow gap="1x">
         <Title level={4}>Comparison: Enabled vs Disabled</Title>
-        <Space flow="column" gap="1x" placeItems="start">
+        <Space flow="column" placeItems="start">
           <ItemButton
             {...args}
             type="primary"

--- a/src/components/actions/Menu/Menu.stories.tsx
+++ b/src/components/actions/Menu/Menu.stories.tsx
@@ -1501,7 +1501,7 @@ export const MenuSynchronization = () => {
       </Space>
 
       <Alert type="info" title="Try it out">
-        <Space flow="column" gap="1x">
+        <Space flow="column">
           <Text>1. Open any menu by clicking a button</Text>
           <Text>
             2. Try opening another menu - the first one will automatically close
@@ -1816,7 +1816,7 @@ export const SubMenuCustomization = () => {
       </Space>
 
       <Alert type="info" title="SubMenu Features">
-        <Space flow="column" gap="1x">
+        <Space flow="column">
           <Text>
             • <Text.Strong>Keyboard Navigation:</Text.Strong> Use arrow keys to
             navigate between menus
@@ -2094,7 +2094,7 @@ export const ComprehensivePopoverSynchronization = () => {
         </DialogTrigger>
 
         {/* DialogTrigger (modal) */}
-        <DialogTrigger type="modal">
+        <DialogTrigger>
           <Button size="small">DialogTrigger (modal)</Button>
           <Dialog>
             <Header>

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -144,7 +144,6 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
 
     return (
       <MenuTrigger
-        placement="bottom start"
         {...mergeProps(defaultTriggerProps, triggerProps || undefined)}
         isDummy
         isOpen={isOpen}

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -308,7 +308,6 @@ export function useContextMenu<
         )}
         <MenuTrigger
           offset={0}
-          crossOffset={0}
           placement={
             (triggerProps as ComponentProps<typeof MenuTrigger>)?.placement ||
             defaultTriggerProps?.placement ||

--- a/src/components/content/Badge/Badge.stories.tsx
+++ b/src/components/content/Badge/Badge.stories.tsx
@@ -130,7 +130,8 @@ export const Default: Story = {
 
 export const Themes: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
+      {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- Themes story names every theme, the default included */}
       <Badge theme="special">Special</Badge>
       <Badge theme="warning">Warning</Badge>
       <Badge theme="note">Note</Badge>
@@ -143,7 +144,7 @@ export const Themes: Story = {
 
 export const Numbers: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <Badge>1</Badge>
       <Badge>5</Badge>
       <Badge>12</Badge>
@@ -155,7 +156,7 @@ export const Numbers: Story = {
 
 export const TextContent: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <Badge>NEW</Badge>
       <Badge theme="success">OK</Badge>
       <Badge theme="danger">ERR</Badge>
@@ -166,7 +167,8 @@ export const TextContent: Story = {
 
 export const Sizes: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
+      {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- Sizes story names every size, the default included */}
       <Badge size="inline">8</Badge>
       <Badge size="xsmall">8</Badge>
       <Badge size="small">8</Badge>
@@ -179,7 +181,7 @@ export const Sizes: Story = {
 
 export const WithIcon: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <Badge icon={<IconCoin />}>5</Badge>
       <Badge icon={<IconCoin />} theme="success">
         12
@@ -196,7 +198,7 @@ export const WithIcon: Story = {
 
 export const WithRightIcon: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <Badge rightIcon={<IconCoin />}>5</Badge>
       <Badge rightIcon={<IconCoin />} theme="success">
         OK
@@ -210,7 +212,7 @@ export const WithRightIcon: Story = {
 
 export const WithBothIcons: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <Badge icon={<IconCoin />} rightIcon={<IconCoin />}>
         NEW
       </Badge>

--- a/src/components/content/Disclosure/Disclosure.stories.tsx
+++ b/src/components/content/Disclosure/Disclosure.stories.tsx
@@ -229,7 +229,7 @@ export const Controlled: Story = {
 
     return (
       <Space flow="column" gap="2x">
-        <Space gap="1x">
+        <Space>
           <Button onPress={() => setExpanded(true)}>Open</Button>
           <Button onPress={() => setExpanded(false)}>Close</Button>
           <Button onPress={() => setExpanded((prev) => !prev)}>Toggle</Button>
@@ -475,7 +475,7 @@ export const ContentPreservation: Story = {
           >
             {({ isExpanded: isExpandedNow, toggle }) => (
               <>
-                <Button type="outline" onPress={toggle}>
+                <Button onPress={toggle}>
                   {isExpandedNow ? 'Hide Content' : 'Show Content'}
                 </Button>
                 <Disclosure.Content>

--- a/src/components/content/InfoBadge/InfoBadge.stories.tsx
+++ b/src/components/content/InfoBadge/InfoBadge.stories.tsx
@@ -46,7 +46,7 @@ export const WithoutSuffix: Story = {
 
 export const Sizes: Story = {
   render: (args) => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <InfoBadge {...args} size="small" />
       <InfoBadge {...args} size="medium" />
       <InfoBadge {...args} size="large" />
@@ -73,7 +73,7 @@ export const SizesInText: Story = {
 
 export const Themes: Story = {
   render: (args) => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <InfoBadge {...args} theme="default" />
       <InfoBadge {...args} theme="danger" />
       <InfoBadge {...args} theme="success" />
@@ -83,7 +83,7 @@ export const Themes: Story = {
 
 export const Disabled: Story = {
   render: (args) => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <InfoBadge {...args} isDisabled />
       <InfoBadge {...args} isDisabled to="!https://docs.cube.dev" />
       <InfoBadge {...args} isDisabled onPress={() => {}} />
@@ -93,7 +93,7 @@ export const Disabled: Story = {
 
 export const Types: Story = {
   render: (args) => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <InfoBadge {...args} type="clear" />
       <InfoBadge {...args} type="outline" />
       <InfoBadge {...args} type="primary" />

--- a/src/components/content/Item/Item.stories.tsx
+++ b/src/components/content/Item/Item.stories.tsx
@@ -331,7 +331,7 @@ export const TextOverflow: StoryFn<CubeItemProps> = (args) => (
     </Item>
 
     <Title level={5}>Different Sizes with Text Overflow</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         size="small"
@@ -393,7 +393,7 @@ export const ExtraWidth: StoryFn<CubeItemProps> = (args) => (
     </Item>
 
     <Title level={5}>Different Sizes with Extra Width</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         size="small"
@@ -444,7 +444,7 @@ ExtraWidth.parameters = {
 export const WithCheckbox: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Selected Items (Checkmark Visible)</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} isSelected={true}>
         Selected item with checkmark
       </Item>
@@ -457,7 +457,7 @@ export const WithCheckbox: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Non-Selected Items (Checkmark Hidden)</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} isSelected={false}>
         Non-selected item with hidden checkmark
       </Item>
@@ -470,7 +470,7 @@ export const WithCheckbox: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Mixed Selection States</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} isSelected={true} suffix="Selected">
         Item 1
       </Item>
@@ -483,7 +483,7 @@ export const WithCheckbox: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Comparison: Checkmark vs Regular Icon</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} isSelected={true}>
         With checkmark (selected)
       </Item>
@@ -514,7 +514,7 @@ WithCheckbox.parameters = {
 export const WithHotkeys: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Item with Hotkeys</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         hotkeys="cmd+s"
@@ -545,7 +545,7 @@ export const WithHotkeys: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Different Sizes with Hotkeys</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         size="small"
@@ -595,7 +595,7 @@ WithHotkeys.parameters = {
 export const WithTooltip: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Simple String Tooltips</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         tooltip={{ title: 'Simple tooltip text', activeWrap: true }}
@@ -620,7 +620,7 @@ export const WithTooltip: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Advanced Tooltip Configuration</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         tooltip={{
@@ -665,7 +665,7 @@ export const WithTooltip: StoryFn<CubeItemProps> = (args) => (
     </Item>
 
     <Title level={5}>Different Sizes with Tooltips</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         size="small"
@@ -704,7 +704,7 @@ WithTooltip.parameters = {
 export const CombinedFeatures: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Hotkeys + Tooltip + Icons</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         hotkeys="cmd+n"
@@ -737,7 +737,7 @@ export const CombinedFeatures: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>With Checkmark Selection</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         isSelected={true}
@@ -806,7 +806,7 @@ CombinedFeatures.parameters = {
 export const WithLoading: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Auto Loading Slot Selection</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         isLoading={true}
@@ -836,7 +836,7 @@ export const WithLoading: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Specific Loading Slots</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         isLoading={true}
@@ -876,7 +876,7 @@ export const WithLoading: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Different Sizes with Auto Loading</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} size="small" isLoading={true} icon={<IconUser />}>
         Small size
       </Item>
@@ -889,7 +889,7 @@ export const WithLoading: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Loading with Different Visual Types</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="item" isLoading={true} icon={<IconUser />}>
         Item type
       </Item>
@@ -925,7 +925,7 @@ WithLoading.parameters = {
 export const WithDescription: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Description Placement: Inline (Default)</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -957,7 +957,7 @@ export const WithDescription: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Description Placement: Block</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1028,7 +1028,7 @@ WithDescription.parameters = {
 export const DescriptionWithSizes: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Inline Description Across Sizes</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1082,7 +1082,7 @@ export const DescriptionWithSizes: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Block Description Across Sizes</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1153,7 +1153,7 @@ DescriptionWithSizes.parameters = {
 export const DescriptionWithTypes: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Inline Description with Different Types</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="item"
@@ -1212,7 +1212,7 @@ export const DescriptionWithTypes: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Block Description with Different Types</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="item"
@@ -1270,7 +1270,7 @@ DescriptionWithTypes.parameters = {
 export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
   <Flow gap="2x">
     <Title level={5}>Inline Description with All Elements</Title>
-    <Space flow="column" gap="1x" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1317,7 +1317,7 @@ export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Block Description with All Elements</Title>
-    <Space flow="column" gap="1x" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1364,7 +1364,7 @@ export const DescriptionWithComplexContent: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Description with Actions</Title>
-    <Space flow="column" gap="1x" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1415,7 +1415,7 @@ DescriptionWithComplexContent.parameters = {
 export const DescriptionOverflow: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Long Inline Descriptions (with overflow)</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         styles={{ width: '300px' }}
@@ -1439,7 +1439,7 @@ export const DescriptionOverflow: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Long Block Descriptions (with wrapping)</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         styles={{ width: '300px' }}
@@ -1504,7 +1504,7 @@ DescriptionOverflow.parameters = {
 export const WithActions: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Basic Item with Inline Actions</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1533,7 +1533,7 @@ export const WithActions: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Different Sizes with Actions</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1607,7 +1607,7 @@ export const WithActions: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Different Types with Actions</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="item"
@@ -1664,7 +1664,7 @@ export const WithActions: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>With Complex Configurations</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1761,7 +1761,7 @@ WithActions.parameters = {
 export const WithActionsOnHover: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Actions Shown on Hover</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         qa="HoverActionsItem"
@@ -1826,7 +1826,7 @@ export const WithActionsOnHover: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Different Sizes with Hover Actions</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1875,7 +1875,7 @@ export const WithActionsOnHover: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>With Description and Hover Actions</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1930,7 +1930,7 @@ export const ActionsPreserveSpace: StoryFn<CubeItemProps> = (args) => (
     <Title level={5}>
       Comparison: Collapse vs Preserve Space on Hover Actions
     </Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -1965,7 +1965,7 @@ export const ActionsPreserveSpace: StoryFn<CubeItemProps> = (args) => (
 
     <Title level={5}>Side by Side Comparison</Title>
     <Space gap="2x" flow="row" placeItems="start">
-      <Space gap="1x" flow="column" placeItems="start">
+      <Space flow="column" placeItems="start">
         <Title level={6}>preserveActionsSpace=false (default)</Title>
         <Item
           {...args}
@@ -1997,7 +1997,7 @@ export const ActionsPreserveSpace: StoryFn<CubeItemProps> = (args) => (
           Single action item
         </Item>
       </Space>
-      <Space gap="1x" flow="column" placeItems="start">
+      <Space flow="column" placeItems="start">
         <Title level={6}>preserveActionsSpace=true</Title>
         <Item
           {...args}
@@ -2032,7 +2032,7 @@ export const ActionsPreserveSpace: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>With Description</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -2207,7 +2207,7 @@ export const DifferentShapes: StoryFn<CubeItemProps> = (args) => (
     </Item>
 
     <Title level={5}>All Shapes Comparison</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="outline" shape="card" icon={<IconCoin />}>
         Card shape
       </Item>
@@ -2240,7 +2240,7 @@ DifferentShapes.parameters = {
 export const WithHighlight: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Basic Highlight</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="outline" icon={<IconUser />} highlight="user">
         User account settings
       </Item>
@@ -2255,7 +2255,7 @@ export const WithHighlight: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Case Sensitivity</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="outline" icon={<IconUser />} highlight="USER">
         Case-insensitive: USER and user match
       </Item>
@@ -2287,7 +2287,7 @@ export const WithHighlight: StoryFn<CubeItemProps> = (args) => (
     </Item>
 
     <Title level={5}>Combined with Other Features</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -2391,7 +2391,7 @@ export const TypesAndThemes: StoryFn<CubeItemProps> = (args) => {
 
       <Space gap="2x" flow="column" placeItems="start">
         <Title level={5}>Type: header (default theme only)</Title>
-        <Space gap="1x" flow="row wrap" placeItems="start">
+        <Space flow="row wrap" placeItems="start">
           <Item {...args} type="header" theme="default" icon={<IconUser />}>
             default
           </Item>
@@ -2401,7 +2401,7 @@ export const TypesAndThemes: StoryFn<CubeItemProps> = (args) => {
       {standardTypes.map((type) => (
         <Space key={type} gap="2x" flow="column" placeItems="start">
           <Title level={5}>Type: {type}</Title>
-          <Space gap="1x" flow="row wrap" placeItems="start">
+          <Space flow="row wrap" placeItems="start">
             {standardThemes.map((theme) => {
               const item = (
                 <Item {...args} type={type} theme={theme} icon={<IconUser />}>
@@ -2430,7 +2430,7 @@ export const TypesAndThemes: StoryFn<CubeItemProps> = (args) => {
 
       <Space gap="2x" flow="column" placeItems="start">
         <Title level={5}>Type: card</Title>
-        <Space gap="1x" flow="row wrap" placeItems="start">
+        <Space flow="row wrap" placeItems="start">
           {cardThemes.map((theme) => (
             <Item
               key={`card-${theme}`}
@@ -2499,7 +2499,7 @@ export const CurrentType: StoryFn<CubeItemProps> = (args) => (
           >
             <Flow gap="1x" placeItems="start">
               <Block preset="c2">{label}</Block>
-              <Space gap="1x" flow="row wrap" placeItems="start">
+              <Space flow="row wrap" placeItems="start">
                 <Item {...args} type="current" icon={<IconUser />}>
                   Default
                 </Item>
@@ -2537,7 +2537,7 @@ export const CurrentType: StoryFn<CubeItemProps> = (args) => (
         >
           <Flow gap="1x" placeItems="start">
             <Block preset="c2">{label}</Block>
-            <Space gap="1x" flow="row wrap" placeItems="start">
+            <Space flow="row wrap" placeItems="start">
               {CURRENT_STATES.map(({ label: stateLabel, mods }) => (
                 <Item
                   key={stateLabel}
@@ -2582,7 +2582,7 @@ export const CurrentType: StoryFn<CubeItemProps> = (args) => (
           <Flow gap="1x" placeItems="start">
             <Block preset="c2">{label}</Block>
             {(['item', 'current'] as const).map((type) => (
-              <Space key={type} gap="1x" flow="row wrap" placeItems="center">
+              <Space key={type} flow="row wrap" placeItems="center">
                 <Block preset="c2" width="8x">
                   {type}
                 </Block>
@@ -2607,7 +2607,7 @@ export const CurrentType: StoryFn<CubeItemProps> = (args) => (
         color="#note-accent-text"
       >
         <Flow gap="1x" placeItems="start">
-          <Space gap="1x" flow="row wrap" placeItems="start">
+          <Space flow="row wrap" placeItems="start">
             {(['xsmall', 'small', 'medium', 'large', 'xlarge'] as const).map(
               (size) => (
                 <Item
@@ -2622,7 +2622,7 @@ export const CurrentType: StoryFn<CubeItemProps> = (args) => (
               ),
             )}
           </Space>
-          <Space gap="1x" flow="row wrap" placeItems="start">
+          <Space flow="row wrap" placeItems="start">
             <Item {...args} type="current" icon={<IconUser />} />
             <Item {...args} type="current" icon={<IconCoin />} shape="pill">
               Pill
@@ -2675,7 +2675,7 @@ CurrentType.parameters = {
 export const SemanticHeadingLevel: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Header and Card with Semantic Heading Level</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="header" level={2} icon={<IconUser />}>
         Header (renders as h2)
       </Item>
@@ -2708,7 +2708,7 @@ SemanticHeadingLevel.parameters = {
 export const Disabled: StoryFn<CubeItemProps> = (args) => (
   <Space gap="2x" flow="column" placeItems="start">
     <Title level={5}>Basic Disabled Items</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} isDisabled={true}>
         Disabled item
       </Item>
@@ -2718,7 +2718,7 @@ export const Disabled: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Disabled with Icons</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} isDisabled={true} icon={<IconUser />}>
         Disabled with icon
       </Item>
@@ -2733,7 +2733,7 @@ export const Disabled: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Disabled Across Different Types</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="primary" isDisabled={true} icon={<IconUser />}>
         Disabled primary
       </Item>
@@ -2755,7 +2755,7 @@ export const Disabled: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Disabled Across Different Sizes</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} size="xsmall" isDisabled={true} icon={<IconUser />}>
         Disabled xsmall
       </Item>
@@ -2774,7 +2774,7 @@ export const Disabled: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Disabled with Description</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -2798,7 +2798,7 @@ export const Disabled: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Disabled with Actions</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item
         {...args}
         type="outline"
@@ -2816,7 +2816,7 @@ export const Disabled: StoryFn<CubeItemProps> = (args) => (
     </Space>
 
     <Title level={5}>Comparison: Enabled vs Disabled</Title>
-    <Space gap="1x" flow="column" placeItems="start">
+    <Space flow="column" placeItems="start">
       <Item {...args} type="primary" icon={<IconUser />} isDisabled={false}>
         Enabled primary button
       </Item>

--- a/src/components/content/ItemBadge/ItemBadge.stories.tsx
+++ b/src/components/content/ItemBadge/ItemBadge.stories.tsx
@@ -35,7 +35,7 @@ export const WithLabel: Story = {
 
 export const Types: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <ItemBadge icon={<KeyIcon />} type="primary" tooltip="Primary" />
       <ItemBadge icon={<KeyIcon />} type="outline" tooltip="Outline" />
       <ItemBadge
@@ -57,7 +57,7 @@ export const Types: Story = {
 
 export const Themes: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
       <ItemBadge icon={<KeyIcon />} theme="default" tooltip="Default" />
       <ItemBadge icon={<KeyIcon />} theme="danger" tooltip="Danger" />
       <ItemBadge icon={<KeyIcon />} theme="success" tooltip="Success" />

--- a/src/components/content/ItemCard/ItemCard.stories.tsx
+++ b/src/components/content/ItemCard/ItemCard.stories.tsx
@@ -112,7 +112,7 @@ export const Default: Story = {
 };
 
 export const Sizes = (args: CubeItemCardProps) => (
-  <Space gap="1x" flow="column" width="max 400px">
+  <Space flow="column" width="max 400px">
     <ItemCard
       {...args}
       size="medium"

--- a/src/components/content/Layout/Layout.stories.tsx
+++ b/src/components/content/Layout/Layout.stories.tsx
@@ -1332,7 +1332,7 @@ export const Container: Story = {
             This content is horizontally centered with a constrained max-width.
             It works well for forms, articles, and focused content.
           </Text>
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t3">• Min width: 40x (320px at default gap)</Text>
             <Text preset="t3">• Max width: 120x (960px at default gap)</Text>
             <Text preset="t3">• Content scrolls vertically when needed</Text>

--- a/src/components/content/Result/Result.stories.tsx
+++ b/src/components/content/Result/Result.stories.tsx
@@ -66,7 +66,7 @@ Success.args = {
   children: (
     <Space>
       <Button type="primary">Go Console</Button>
-      <Button type="outline">Buy Again</Button>
+      <Button>Buy Again</Button>
     </Space>
   ),
 };
@@ -94,7 +94,7 @@ Error.args = {
   children: (
     <Space>
       <Button type="primary">Go Console</Button>
-      <Button type="outline">Buy Again</Button>
+      <Button>Buy Again</Button>
     </Space>
   ),
 };
@@ -108,7 +108,7 @@ CustomIcon.args = {
       <IconLock />
     </Icon>
   ),
-  children: <Button type="outline">Request</Button>,
+  children: <Button>Request</Button>,
 };
 
 export const CustomTitle = Template.bind({});
@@ -137,7 +137,7 @@ Compact.args = {
   children: (
     <Space>
       <Button type="primary">Go Console</Button>
-      <Button type="outline">Buy Again</Button>
+      <Button>Buy Again</Button>
     </Space>
   ),
 };

--- a/src/components/content/Tag/Tag.stories.tsx
+++ b/src/components/content/Tag/Tag.stories.tsx
@@ -151,7 +151,7 @@ export const Default: Story = {
 
 export const Themes: Story = {
   render: () => (
-    <Space gap="1x">
+    <Space>
       <Tag>Default</Tag>
       <Tag theme="warning">Warning</Tag>
       <Tag theme="note">Note</Tag>
@@ -165,7 +165,7 @@ export const Themes: Story = {
 
 export const WithIcons: Story = {
   render: () => (
-    <Space gap="1x">
+    <Space>
       <Tag icon={<IconCoin />}>With Icon</Tag>
       <Tag icon={<IconCoin />} theme="success">
         Success
@@ -179,7 +179,7 @@ export const WithIcons: Story = {
 
 export const Closable: Story = {
   render: () => (
-    <Space gap="1x">
+    <Space>
       <Tag isClosable>Default</Tag>
       <Tag isClosable theme="warning">
         Warning
@@ -202,7 +202,7 @@ export const Closable: Story = {
 
 export const ClosableWithIcons: Story = {
   render: () => (
-    <Space gap="1x">
+    <Space>
       <Tag isClosable icon={<IconCoin />}>
         Default
       </Tag>
@@ -218,7 +218,8 @@ export const ClosableWithIcons: Story = {
 
 export const Sizes: Story = {
   render: () => (
-    <Space gap="1x" placeItems="center">
+    <Space placeItems="center">
+      {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- Sizes story labels this one "(default)" */}
       <Tag size="inline">Inline (default)</Tag>
       <Tag size="xsmall">Extra Small</Tag>
       <Tag size="small">Small</Tag>

--- a/src/components/content/TextItem/TextItem.stories.tsx
+++ b/src/components/content/TextItem/TextItem.stories.tsx
@@ -199,6 +199,7 @@ export const TooltipPlacements: Story = {
   render: () => (
     <Space flow="column" gap="2x" padding="8x">
       <Block width="200px">
+        {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- TooltipPlacements story: the placement is what it demonstrates */}
         <TextItem tooltipPlacement="top">
           Tooltip on top - hover to see long text tooltip
         </TextItem>

--- a/src/components/data/DataTable/DataTable.stories.tsx
+++ b/src/components/data/DataTable/DataTable.stories.tsx
@@ -440,7 +440,7 @@ export const PersistedColumnLayout: Story = {
           isColumnReorderable
           storageKey={STORAGE_KEY}
         />
-        <Space gap="1x" placeItems="center start">
+        <Space placeItems="center start">
           <Button
             size="small"
             onPress={() => {
@@ -612,11 +612,11 @@ export const QueryResultsLayout: Story = {
         </Space>
       }
       footerEnd={
-        <Space gap="1x" placeItems="center">
+        <Space placeItems="center">
           <Text color="#dark-03" preset="t4">
             showing {ROWS.length} out of 649 total rows
           </Text>
-          <Button type="outline" size="xsmall" icon={<ReloadIcon />}>
+          <Button size="xsmall" icon={<ReloadIcon />}>
             Load All Results
           </Button>
         </Space>

--- a/src/components/data/ItemTable/ItemTable.stories.tsx
+++ b/src/components/data/ItemTable/ItemTable.stories.tsx
@@ -453,7 +453,6 @@ export const Search: Story = {
         filters={
           <FilterPicker
             aria-label="Filter by region"
-            type="outline"
             size="small"
             selectionMode="multiple"
             placeholder="All regions"
@@ -580,11 +579,7 @@ export const CustomSearchPlacement: Story = {
                   ))}
                 </FilterPicker>
               }
-              actions={
-                <Button type="outline" size="small">
-                  Export
-                </Button>
-              }
+              actions={<Button size="small">Export</Button>}
             />
           }
         />
@@ -629,9 +624,7 @@ export const FooterSlots: Story = {
     footerStart: (
       // The footer's own controls are `xsmall`; a slot button should match them
       // rather than the toolbar above.
-      <Button type="outline" size="xsmall">
-        Load all results
-      </Button>
+      <Button size="xsmall">Load all results</Button>
     ),
     footerCenter: <Text color="#dark-03">Partial result set</Text>,
   },
@@ -1059,7 +1052,7 @@ export const DropOntoRow: Story = {
               // A folder reads as a folder, so it is obvious which rows accept
               // a drop rather than something to be discovered by trying.
               render: (value, row) => (
-                <Space gap="1x" placeItems="center">
+                <Space placeItems="center">
                   {row.isFolder ? <FolderIcon /> : <DatabaseIcon />}
                   <Text>{String(value)}</Text>
                 </Space>

--- a/src/components/data/ItemTable/ItemTableToolbar.tsx
+++ b/src/components/data/ItemTable/ItemTableToolbar.tsx
@@ -142,7 +142,6 @@ export function ItemTableToolbar({
         {onRefresh ? (
           <Button
             qa="ItemTableRefreshButton"
-            type="outline"
             size="small"
             icon={<ReloadIcon />}
             isLoading={isLoading}

--- a/src/components/data/TableBase/TableView.tsx
+++ b/src/components/data/TableBase/TableView.tsx
@@ -824,7 +824,7 @@ export function TableView<T = any>(props: TableViewProps<T>) {
             aria-colindex={column.ariaColIndex}
             style={pinStyle(column)}
           >
-            <Placeholder size="2x" />
+            <Placeholder />
           </td>
         ))}
       </tr>

--- a/src/components/fields/ComboBox/ComboBox.stories.tsx
+++ b/src/components/fields/ComboBox/ComboBox.stories.tsx
@@ -413,7 +413,7 @@ export const AllowsCustomValue = () => {
         <ComboBox.Item key="angular">Angular</ComboBox.Item>
         <ComboBox.Item key="svelte">Svelte</ComboBox.Item>
       </ComboBox>
-      <Space flow="column" gap="1x">
+      <Space flow="column">
         <Text>
           Input value: <Text.Strong>{inputValue || 'none'}</Text.Strong>
         </Text>
@@ -489,7 +489,7 @@ export const ClearOnBlur = () => {
         <ComboBox.Item key="cherry">Cherry</ComboBox.Item>
         <ComboBox.Item key="date">Date</ComboBox.Item>
       </ComboBox>
-      <Space flow="column" gap="1x">
+      <Space flow="column">
         <Text>
           Selected: <Text.Strong>{selectedKey || 'none'}</Text.Strong>
         </Text>
@@ -617,6 +617,7 @@ export const Validation = () => (
 
 export const PopoverTriggers = () => (
   <Flex flow="column" gap="2x">
+    {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- labelled "Trigger on Input (default)" - the trigger is what it demonstrates */}
     <ComboBox label="Trigger on Input (default)" popoverTrigger="input">
       <ComboBox.Item key="apple">Apple</ComboBox.Item>
       <ComboBox.Item key="banana">Banana</ComboBox.Item>
@@ -642,6 +643,7 @@ export const Sizes = () => (
       <ComboBox.Item key="banana">Banana</ComboBox.Item>
       <ComboBox.Item key="cherry">Cherry</ComboBox.Item>
     </ComboBox>
+    {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- labelled "Medium (default)" - the size is what it demonstrates */}
     <ComboBox label="Medium (default)" size="medium" placeholder="Medium size">
       <ComboBox.Item key="apple">Apple</ComboBox.Item>
       <ComboBox.Item key="banana">Banana</ComboBox.Item>
@@ -834,7 +836,7 @@ export const IndependentControls = () => {
         <ComboBox.Item key="date">Date</ComboBox.Item>
         <ComboBox.Item key="elderberry">Elderberry</ComboBox.Item>
       </ComboBox>
-      <Space flow="column" gap="1x">
+      <Space flow="column">
         <Text>
           Input value: <Text.Strong>{inputValue || 'empty'}</Text.Strong>
         </Text>
@@ -874,7 +876,7 @@ export const AllowsCustomValueNoCommitOnBlur = () => {
         <ComboBox.Item key="angular">Angular</ComboBox.Item>
         <ComboBox.Item key="svelte">Svelte</ComboBox.Item>
       </ComboBox>
-      <Space flow="column" gap="1x">
+      <Space flow="column">
         <Text>
           Input value: <Text.Strong>{inputValue || 'none'}</Text.Strong>
         </Text>

--- a/src/components/fields/CommandTextArea/CommandTextArea.stories.tsx
+++ b/src/components/fields/CommandTextArea/CommandTextArea.stories.tsx
@@ -317,7 +317,6 @@ export const TopPopoverPosition: StoryFn = (props) => (
       label="Message"
       placeholder="Type / to see commands…"
       width="40x"
-      direction="top"
       {...props}
     >
       {commands.map((c) => (

--- a/src/components/fields/FilterListBox/FilterListBox.stories.tsx
+++ b/src/components/fields/FilterListBox/FilterListBox.stories.tsx
@@ -618,7 +618,7 @@ export const WithHeaderAndFooter: StoryFn<CubeFilterListBoxProps<any>> = (
     {...args}
     header={
       <>
-        <Space gap="1x" flow="row" placeItems="center">
+        <Space flow="row" placeItems="center">
           <Title level={6}>Programming Languages</Title>
           <Badge type="purple">12</Badge>
         </Space>
@@ -774,7 +774,7 @@ export const WithTextValue: Story = {
         key="basic"
         textValue="Basic Plan - Free with limited features"
       >
-        <Space gap="1x" flow="column">
+        <Space flow="column">
           <Text weight="600">Basic Plan</Text>
           <Badge type="disabled">Free</Badge>
         </Space>
@@ -783,7 +783,7 @@ export const WithTextValue: Story = {
         key="pro"
         textValue="Pro Plan - Monthly subscription with all features"
       >
-        <Space gap="1x" flow="column">
+        <Space flow="column">
           <Text weight="600">Pro Plan</Text>
           <Badge type="purple">$19/month</Badge>
         </Space>
@@ -792,7 +792,7 @@ export const WithTextValue: Story = {
         key="enterprise"
         textValue="Enterprise Plan - Custom pricing for large teams"
       >
-        <Space gap="1x" flow="column">
+        <Space flow="column">
           <Text weight="600">Enterprise Plan</Text>
           <Badge type="note">Custom</Badge>
         </Space>
@@ -863,7 +863,7 @@ export const CustomEmptyState: Story = {
     <FilterListBox
       {...args}
       emptyLabel={
-        <Space gap="1x" flow="column" placeItems="center" padding="2x">
+        <Space flow="column" placeItems="center" padding="2x">
           <Text preset="t1">🔍</Text>
           <Text weight="600">No matching countries found</Text>
           <Text preset="t4" color="#dark.60">
@@ -965,7 +965,6 @@ export const ControlledExample: StoryFn<CubeFilterListBoxProps<any>> = () => {
       <FilterListBox
         label="Controlled FilterListBox"
         selectedKey={selectedKey}
-        selectionMode="single"
         searchPlaceholder="Search fruits..."
         onSelectionChange={(key) => setSelectedKey(key as string | null)}
       >
@@ -978,19 +977,11 @@ export const ControlledExample: StoryFn<CubeFilterListBoxProps<any>> = () => {
         Selected: <Text.Strong>{selectedKey || 'None'}</Text.Strong>
       </Text>
 
-      <Space gap="1x" flow="row">
-        <Button
-          size="small"
-          type="outline"
-          onClick={() => setSelectedKey('banana')}
-        >
+      <Space flow="row">
+        <Button size="small" onClick={() => setSelectedKey('banana')}>
           Select Banana
         </Button>
-        <Button
-          size="small"
-          type="outline"
-          onClick={() => setSelectedKey(null)}
-        >
+        <Button size="small" onClick={() => setSelectedKey(null)}>
           Clear Selection
         </Button>
       </Space>
@@ -1031,15 +1022,14 @@ export const MultipleControlledExample: StoryFn<
         </Text.Strong>
       </Text>
 
-      <Space gap="1x" flow="row">
+      <Space flow="row">
         <Button
           size="small"
-          type="outline"
           onClick={() => setSelectedKeys(['read', 'write', 'admin'])}
         >
           Select Admin Set
         </Button>
-        <Button size="small" type="outline" onClick={() => setSelectedKeys([])}>
+        <Button size="small" onClick={() => setSelectedKeys([])}>
           Clear All
         </Button>
       </Space>
@@ -1167,13 +1157,13 @@ export const WithIcons: Story = {
     <FilterListBox {...args}>
       <FilterListBox.Section title="User Management">
         <FilterListBox.Item key="users">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <UserIcon />
             Users
           </Space>
         </FilterListBox.Item>
         <FilterListBox.Item key="permissions">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <CheckIcon />
             Permissions
           </Space>
@@ -1181,13 +1171,13 @@ export const WithIcons: Story = {
       </FilterListBox.Section>
       <FilterListBox.Section title="System">
         <FilterListBox.Item key="database">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <DatabaseIcon />
             Database
           </Space>
         </FilterListBox.Item>
         <FilterListBox.Item key="settings">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <SettingsIcon />
             Settings
           </Space>
@@ -1271,7 +1261,6 @@ export const EscapeKeyHandling: StoryFn<CubeFilterListBoxProps<any>> = () => {
       <FilterListBox
         label="Custom Escape Handling"
         selectedKey={selectedKey}
-        selectionMode="single"
         searchPlaceholder="Search fruits..."
         onSelectionChange={(key) => setSelectedKey(key as string | null)}
         onEscape={() => {

--- a/src/components/fields/FilterListBox/FilterListBox.tsx
+++ b/src/components/fields/FilterListBox/FilterListBox.tsx
@@ -1137,7 +1137,6 @@ export const FilterListBox = forwardRef(function FilterListBox<
         footer={footer}
         footerStyles={footerStyles}
         mods={mods}
-        size="medium"
         styles={listBoxStyles}
         isCheckable={isCheckable}
         items={items as any}

--- a/src/components/fields/FilterPicker/FilterPicker.stories.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.stories.tsx
@@ -922,7 +922,7 @@ export const RenderSummaryBehavior: Story = {
           1. renderSummary={'{false}'} (Icon-only triggers)
         </Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -942,7 +942,7 @@ export const RenderSummaryBehavior: Story = {
             </FilterPicker>
           </Space>
 
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -971,7 +971,7 @@ export const RenderSummaryBehavior: Story = {
       <Space gap="2x" flow="column" placeItems="start">
         <Title preset="h6">2. Custom renderSummary returning null</Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -989,7 +989,7 @@ export const RenderSummaryBehavior: Story = {
             </FilterPicker>
           </Space>
 
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -1016,7 +1016,7 @@ export const RenderSummaryBehavior: Story = {
       <Space gap="2x" flow="column" placeItems="start">
         <Title preset="h6">3. Custom renderSummary with custom text</Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -1037,7 +1037,7 @@ export const RenderSummaryBehavior: Story = {
             </FilterPicker>
           </Space>
 
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -1067,7 +1067,7 @@ export const RenderSummaryBehavior: Story = {
       <Space gap="2x" flow="column" placeItems="start">
         <Title preset="h6">4. Custom renderSummary with JSX</Title>
         <Space gap="2x" flow="row" placeItems="start">
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               No Selection
             </Text>
@@ -1094,7 +1094,7 @@ export const RenderSummaryBehavior: Story = {
             </FilterPicker>
           </Space>
 
-          <Space flow="column" gap="1x">
+          <Space flow="column">
             <Text preset="t4" weight="600">
               With Selection
             </Text>
@@ -1184,7 +1184,7 @@ export const WithHeaderAndFooter: Story = {
       {...args}
       header={
         <>
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <Title level={6}>Programming Languages</Title>
             <Badge type="purple">12</Badge>
           </Space>
@@ -1596,13 +1596,13 @@ export const WithIcons: Story = {
     <FilterPicker {...args}>
       <FilterPicker.Section title="User Management">
         <FilterPicker.Item key="users" textValue="Users">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <UserIcon />
             Users
           </Space>
         </FilterPicker.Item>
         <FilterPicker.Item key="permissions" textValue="Permissions">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <CheckIcon />
             Permissions
           </Space>
@@ -1610,13 +1610,13 @@ export const WithIcons: Story = {
       </FilterPicker.Section>
       <FilterPicker.Section title="System">
         <FilterPicker.Item key="database" textValue="Database">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <DatabaseIcon />
             Database
           </Space>
         </FilterPicker.Item>
         <FilterPicker.Item key="settings" textValue="Settings">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <SettingsIcon />
             Settings
           </Space>
@@ -1686,7 +1686,7 @@ export const WithTextValue: Story = {
         key="basic"
         textValue="Basic Plan - Free with limited features"
       >
-        <Space gap="1x" flow="row" placeItems="center">
+        <Space flow="row" placeItems="center">
           <Text weight="600">Basic Plan</Text>
           <Badge type="disabled">Free</Badge>
         </Space>
@@ -1695,7 +1695,7 @@ export const WithTextValue: Story = {
         key="pro"
         textValue="Pro Plan - Monthly subscription with all features"
       >
-        <Space gap="1x" flow="row" placeItems="center">
+        <Space flow="row" placeItems="center">
           <Text weight="600">Pro Plan</Text>
           <Badge type="purple">$19/month</Badge>
         </Space>
@@ -1704,7 +1704,7 @@ export const WithTextValue: Story = {
         key="enterprise"
         textValue="Enterprise Plan - Custom pricing for large teams"
       >
-        <Space gap="1x" flow="row" placeItems="center">
+        <Space flow="row" placeItems="center">
           <Text weight="600">Enterprise Plan</Text>
           <Badge type="note">Custom</Badge>
         </Space>
@@ -1729,7 +1729,6 @@ export const ControlledExample = () => {
       <FilterPicker
         label="Controlled Single Selection"
         selectedKey={selectedKey}
-        selectionMode="single"
         searchPlaceholder="Search fruits..."
         width="max 30x"
         onSelectionChange={(key) => setSelectedKey(key as string | null)}
@@ -1745,19 +1744,11 @@ export const ControlledExample = () => {
         Selected: <Text.Strong>{selectedKey || 'None'}</Text.Strong>
       </Text>
 
-      <Space gap="1x" flow="row">
-        <Button
-          size="small"
-          type="outline"
-          onClick={() => setSelectedKey('banana')}
-        >
+      <Space flow="row">
+        <Button size="small" onClick={() => setSelectedKey('banana')}>
           Select Banana
         </Button>
-        <Button
-          size="small"
-          type="outline"
-          onClick={() => setSelectedKey(null)}
-        >
+        <Button size="small" onClick={() => setSelectedKey(null)}>
           Clear Selection
         </Button>
       </Space>
@@ -1797,15 +1788,14 @@ export const MultipleControlledExample = () => {
         </Text.Strong>
       </Text>
 
-      <Space gap="1x" flow="row">
+      <Space flow="row">
         <Button
           size="small"
-          type="outline"
           onClick={() => setSelectedKeys(['read', 'write', 'admin'])}
         >
           Select Admin Set
         </Button>
-        <Button size="small" type="outline" onClick={() => setSelectedKeys([])}>
+        <Button size="small" onClick={() => setSelectedKeys([])}>
           Clear All
         </Button>
       </Space>
@@ -1830,7 +1820,6 @@ export const InForm = () => {
         label="Preferred Technology"
         description="Select your preferred technology stack"
         placeholder="Choose technology..."
-        selectionMode="single"
         searchPlaceholder="Search technologies..."
         selectedKey={selectedTechnology}
         onSelectionChange={(key) => setSelectedTechnology(key as string | null)}
@@ -1886,12 +1875,12 @@ export const ComplexExample: Story = {
       {...args}
       header={
         <>
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <FilterIcon />
             <Title level={6}>Filter Options</Title>
             <Badge type="disabled">24 available</Badge>
           </Space>
-          <Space gap="1x" flow="row">
+          <Space flow="row">
             <Button
               data-popover-keep
               type="clear"
@@ -2414,26 +2403,17 @@ export const MultipleControlled: Story = {
           </Text.Strong>
         </Text>
 
-        <Space gap="1x" flow="row">
+        <Space flow="row">
           <Button
             size="small"
-            type="outline"
             onClick={() => setSelectedKeys(['read', 'write', 'admin'])}
           >
             Select Admin Set
           </Button>
-          <Button
-            size="small"
-            type="outline"
-            onClick={() => setSelectedKeys(['read'])}
-          >
+          <Button size="small" onClick={() => setSelectedKeys(['read'])}>
             Read Only
           </Button>
-          <Button
-            size="small"
-            type="outline"
-            onClick={() => setSelectedKeys([])}
-          >
+          <Button size="small" onClick={() => setSelectedKeys([])}>
             Clear All
           </Button>
         </Space>

--- a/src/components/fields/FilterPicker/FilterPicker.tsx
+++ b/src/components/fields/FilterPicker/FilterPicker.tsx
@@ -785,7 +785,6 @@ export const FilterPicker = forwardRef(function FilterPicker<T extends object>(
       {...filterBaseProps(otherProps, { eventProps: true })}
     >
       <DialogTrigger
-        isDismissable
         type="popover"
         placement={placement}
         isOpen={isPopoverOpen}

--- a/src/components/fields/ListBox/ListBox.stories.tsx
+++ b/src/components/fields/ListBox/ListBox.stories.tsx
@@ -464,7 +464,7 @@ export const WithHeaderAndFooter: StoryObj<CubeListBoxProps<any>>['render'] = (
     {...args}
     header={
       <>
-        <Space gap="1x" flow="row" placeItems="center">
+        <Space flow="row" placeItems="center">
           <Title level={6}>Programming Languages</Title>
           <Badge type="purple">12</Badge>
         </Space>
@@ -642,7 +642,7 @@ export const WithTextValue: Story = {
         key="basic"
         textValue="Basic Plan - Free with limited features"
       >
-        <Space gap="1x" flow="column">
+        <Space flow="column">
           <Text weight="600">Basic Plan</Text>
           <Badge type="disabled">Free</Badge>
         </Space>
@@ -651,7 +651,7 @@ export const WithTextValue: Story = {
         key="pro"
         textValue="Pro Plan - Monthly subscription with all features"
       >
-        <Space gap="1x" flow="column">
+        <Space flow="column">
           <Text weight="600">Pro Plan</Text>
           <Badge type="purple">$19/month</Badge>
         </Space>
@@ -660,7 +660,7 @@ export const WithTextValue: Story = {
         key="enterprise"
         textValue="Enterprise Plan - Custom pricing for large teams"
       >
-        <Space gap="1x" flow="column">
+        <Space flow="column">
           <Text weight="600">Enterprise Plan</Text>
           <Badge type="note">Custom</Badge>
         </Space>
@@ -701,7 +701,6 @@ export const Validation: StoryObj<CubeListBoxProps<any>>['render'] = () => (
     <ListBox
       label="Valid Selection"
       isValid
-      selectionMode="single"
       defaultSelectedKey="option1"
       message="Great choice!"
     >
@@ -712,7 +711,6 @@ export const Validation: StoryObj<CubeListBoxProps<any>>['render'] = () => (
     <ListBox
       label="Invalid Selection"
       isInvalid
-      selectionMode="single"
       defaultSelectedKey="option1"
       message="Please select a different option"
     >
@@ -732,7 +730,6 @@ export const ControlledExample: StoryObj<
       <ListBox
         label="Controlled ListBox"
         selectedKey={selectedKey}
-        selectionMode="single"
         onSelectionChange={(key) => setSelectedKey(key as string | null)}
       >
         <ListBox.Item key="apple">Apple</ListBox.Item>
@@ -745,19 +742,11 @@ export const ControlledExample: StoryObj<
         Selected: <Text.Strong>{selectedKey || 'None'}</Text.Strong>
       </Text>
 
-      <Space gap="1x" flow="row">
-        <Button
-          size="small"
-          type="outline"
-          onClick={() => setSelectedKey('banana')}
-        >
+      <Space flow="row">
+        <Button size="small" onClick={() => setSelectedKey('banana')}>
           Select Banana
         </Button>
-        <Button
-          size="small"
-          type="outline"
-          onClick={() => setSelectedKey(null)}
-        >
+        <Button size="small" onClick={() => setSelectedKey(null)}>
           Clear Selection
         </Button>
       </Space>
@@ -796,15 +785,14 @@ export const MultipleControlledExample: StoryObj<
         </Text.Strong>
       </Text>
 
-      <Space gap="1x" flow="row">
+      <Space flow="row">
         <Button
           size="small"
-          type="outline"
           onClick={() => setSelectedKeys(['read', 'write', 'admin'])}
         >
           Select Admin Set
         </Button>
-        <Button size="small" type="outline" onClick={() => setSelectedKeys([])}>
+        <Button size="small" onClick={() => setSelectedKeys([])}>
           Clear All
         </Button>
       </Space>
@@ -825,7 +813,6 @@ export const InForm: StoryObj<CubeListBoxProps<any>>['render'] = () => {
         name="technology"
         label="Preferred Technology"
         description="Select your preferred technology stack"
-        selectionMode="single"
       >
         <ListBox.Section title="Frontend">
           <ListBox.Item
@@ -888,7 +875,6 @@ export const InPopover: StoryObj<CubeListBoxProps<any>>['render'] = () => {
         <Dialog>
           <ListBox
             selectedKey={selectedKey}
-            selectionMode="single"
             styles={{
               height: '300px',
               border: false,
@@ -1084,7 +1070,7 @@ export const WithIcons: Story = {
 export const FocusBehavior: Story = {
   render: (args) => (
     <Space gap="3x" flow="column">
-      <Space flow="column" gap="1x">
+      <Space flow="column">
         <Text preset="t3" weight="600">
           Standard Focus (focusOnHover=true)
         </Text>
@@ -1099,7 +1085,7 @@ export const FocusBehavior: Story = {
         </ListBox>
       </Space>
 
-      <Space flow="column" gap="1x">
+      <Space flow="column">
         <Text preset="t3" weight="600">
           No Focus on Hover (focusOnHover=false)
         </Text>
@@ -1139,7 +1125,6 @@ export const EscapeKeyHandling: StoryObj<
       <ListBox
         label="Custom Escape Handling"
         selectedKey={selectedKey}
-        selectionMode="single"
         onSelectionChange={(key) => setSelectedKey(key as string | null)}
         onEscape={() => {
           setEscapeCount((prev) => prev + 1);
@@ -1232,19 +1217,19 @@ export const WithHotkeys: Story = {
       </Text>
       <ListBox {...args}>
         <ListBox.Item key="new" hotkeys="ctrl+1">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <PlusIcon />
             New Project
           </Space>
         </ListBox.Item>
         <ListBox.Item key="edit" hotkeys="ctrl+2">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <EditIcon />
             Edit Project
           </Space>
         </ListBox.Item>
         <ListBox.Item key="settings" hotkeys="ctrl+3">
-          <Space gap="1x" flow="row" placeItems="center">
+          <Space flow="row" placeItems="center">
             <SettingsIcon />
             Project Settings
           </Space>
@@ -1510,10 +1495,10 @@ export const DifferentShapes: Story = {
   render: () => (
     <Space gap="4x" flow="column">
       <ListBox
+        // oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- DifferentShapes story labels this one "Card Shape (default)"
         shape="card"
         label="Card Shape (default)"
         description="Standard card styling with border and margin"
-        selectionMode="single"
         defaultSelectedKey="apple"
       >
         {fruits.slice(0, 4).map((fruit) => (
@@ -1525,7 +1510,6 @@ export const DifferentShapes: Story = {
         shape="plain"
         label="Plain Shape"
         description="No border, no margin, no radius - suitable for embedded use"
-        selectionMode="single"
         defaultSelectedKey="banana"
       >
         {fruits.slice(0, 4).map((fruit) => (
@@ -1537,7 +1521,6 @@ export const DifferentShapes: Story = {
         shape="popover"
         label="Popover Shape"
         description="No border, but keeps margin and radius - suitable for overlay use"
-        selectionMode="single"
         defaultSelectedKey="cherry"
       >
         {fruits.slice(0, 4).map((fruit) => (
@@ -1549,7 +1532,6 @@ export const DifferentShapes: Story = {
         shape="plain"
         label="Plain Shape with Sections"
         description="Section margins are preserved even with plain shape"
-        selectionMode="single"
         defaultSelectedKey="carrot"
       >
         <ListBox.Section title="Fruits">

--- a/src/components/fields/ListBoxPopover/ListBoxPopover.tsx
+++ b/src/components/fields/ListBoxPopover/ListBoxPopover.tsx
@@ -281,7 +281,6 @@ export const ListBoxPopover = function ListBoxPopover(
             >
               <ListBox
                 ref={listBoxRef}
-                focusOnHover
                 disableSelectionToggle
                 id={listBoxId}
                 aria-label={
@@ -291,7 +290,6 @@ export const ListBoxPopover = function ListBoxPopover(
                     : t('listBoxPopover.options', 'Options'))
                 }
                 selectedKey={selectedKey}
-                selectionMode="single"
                 isDisabled={isDisabled}
                 disabledKeys={disabledKeys}
                 shouldUseVirtualFocus={true}
@@ -303,7 +301,6 @@ export const ListBoxPopover = function ListBoxPopover(
                 sectionStyles={sectionStyles}
                 headingStyles={headingStyles}
                 stateRef={listStateRef}
-                size="medium"
                 shape="popover"
                 emptyLabel={emptyLabel}
                 onSelectionChange={onSelectionChange}

--- a/src/components/fields/Picker/Picker.stories.tsx
+++ b/src/components/fields/Picker/Picker.stories.tsx
@@ -56,7 +56,6 @@ export const IsClearable: Story = {
       <Picker
         placeholder="Select a fruit"
         label="Single Selection (Clearable)"
-        selectionMode="single"
         isClearable={true}
         defaultSelectedKey="apple"
       >
@@ -299,7 +298,6 @@ export const Controlled = () => {
       <Picker
         placeholder="Select a fruit"
         label="Favorite Fruit"
-        selectionMode="single"
         selectedKey={selectedKey}
         onSelectionChange={(key) => setSelectedKey(key as string | null)}
       >
@@ -343,32 +341,17 @@ export const ControlledMultiple = () => {
 export const DifferentSizes: Story = {
   render: () => (
     <Flex flow="column" gap="2x">
-      <Picker
-        placeholder="Select a fruit"
-        label="Small Picker"
-        selectionMode="single"
-        size="small"
-      >
+      <Picker placeholder="Select a fruit" label="Small Picker" size="small">
         {fruits.map((fruit) => (
           <Picker.Item key={fruit.key}>{fruit.label}</Picker.Item>
         ))}
       </Picker>
-      <Picker
-        placeholder="Select a fruit"
-        label="Medium Picker"
-        selectionMode="single"
-        size="medium"
-      >
+      <Picker placeholder="Select a fruit" label="Medium Picker">
         {fruits.map((fruit) => (
           <Picker.Item key={fruit.key}>{fruit.label}</Picker.Item>
         ))}
       </Picker>
-      <Picker
-        placeholder="Select a fruit"
-        label="Large Picker"
-        selectionMode="single"
-        size="large"
-      >
+      <Picker placeholder="Select a fruit" label="Large Picker" size="large">
         {fruits.map((fruit) => (
           <Picker.Item key={fruit.key}>{fruit.label}</Picker.Item>
         ))}

--- a/src/components/fields/Picker/Picker.tsx
+++ b/src/components/fields/Picker/Picker.tsx
@@ -705,7 +705,6 @@ export const Picker = forwardRef(function Picker<T extends object>(
       >)}
     >
       <DialogTrigger
-        isDismissable
         type="popover"
         placement="bottom start"
         isOpen={isPopoverOpen}
@@ -768,7 +767,6 @@ export const Picker = forwardRef(function Picker<T extends object>(
                 stateRef={internalListStateRef}
                 isCheckable={isCheckable}
                 shape="popover"
-                size="medium"
                 showSelectAll={showSelectAll}
                 selectAllLabel={selectAllLabel}
                 header={header}

--- a/src/components/fields/RadioGroup/RadioGroup.docs.mdx
+++ b/src/components/fields/RadioGroup/RadioGroup.docs.mdx
@@ -29,7 +29,7 @@ A radio group allows users to select exactly one option from a set of mutually e
 - **`defaultValue`** `string` — The default selected value (uncontrolled)
 - **`type`** `'radio' | 'button' | 'tabs'` (default: `radio`) — Visual type for all radios in the group (button/tabs default to horizontal)
 - **`orientation`** `undefined | 'vertical' | 'horizontal'` (default: `undefined`) — Orientation of the radio group. When unset it is derived from `type`: `horizontal` for `button` and `tabs`, `vertical` otherwise
-- **`size`** `'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'` (default: `xsmall`) — Size for all radio buttons in the group
+- **`size`** `'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'` (default: `medium`) — Size for all radio buttons in the group
 - **`buttonType`** `'outline' | 'outline-2' | 'clear' | 'primary'` — Button type for button-style radios (ignored in tabs mode). When set to "primary", selected buttons use primary style and non-selected use outline with brand tint. `outline-2` is identical to `outline` but uses `#surface-3` as its base fill, so it stands out when the radio group sits on a `#surface-2` container
 - **`onChange`** `function` — Callback fired when the selected value changes
 - **`onBlur`** `function` — Callback fired when the radio group loses focus
@@ -109,12 +109,10 @@ Controls the size of all radio buttons in the group:
 
 **Size Mapping in Tabs Mode:**
 When `type="tabs"`, sizes are automatically mapped to maintain visual consistency:
-- `small` and `medium` → `xsmall`
 - `large` → `medium`
-- `xlarge` → `large`
-- `xsmall` remains `xsmall`
+- every other size → `xsmall`
 
-This ensures tab groups remain compact and cohesive.
+Only `large` is carried through; `xsmall`, `small`, `medium` and `xlarge` all collapse to `xsmall`. This ensures tab groups remain compact and cohesive.
 
 ### Button Type
 

--- a/src/components/fields/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/fields/RadioGroup/RadioGroup.stories.tsx
@@ -212,7 +212,7 @@ export const Stretched: StoryFn<CubeRadioGroupProps> = (args) => (
 
 // Size demonstrations
 export const ButtonGroupSizes: StoryFn<CubeRadioGroupProps> = () => (
-  <Space flow="column" gap="1x">
+  <Space flow="column">
     <Space flow="column">
       <Title level={6}>XSmall</Title>
       <Radio.Group
@@ -282,7 +282,7 @@ export const ButtonGroupSizes: StoryFn<CubeRadioGroupProps> = () => (
 );
 
 export const TabsGroupSizes: StoryFn<CubeRadioGroupProps> = () => (
-  <Space flow="column" gap="1x">
+  <Space flow="column">
     <Space flow="column">
       <Title level={6}>Large (default, 40px)</Title>
       <Radio.Tabs size="large" defaultValue="yes" aria-label="Large">
@@ -304,7 +304,7 @@ export const TabsGroupSizes: StoryFn<CubeRadioGroupProps> = () => (
 
 // Button type variants
 export const CustomButtonTypes: StoryFn<CubeRadioGroupProps> = () => (
-  <Space flow="column" gap="1x">
+  <Space flow="column">
     <Space flow="column">
       <Title level={6}>
         Primary (selected: primary, non-selected: outline)
@@ -368,7 +368,7 @@ export const CustomButtonTypes: StoryFn<CubeRadioGroupProps> = () => (
 
 // Disabled state
 export const DisabledState: StoryFn<CubeRadioGroupProps> = () => (
-  <Space flow="column" gap="1x">
+  <Space flow="column">
     <Space flow="column">
       <Title level={6}>Radio (Disabled)</Title>
       <Radio.Group

--- a/src/components/fields/Slider/HueSlider.tsx
+++ b/src/components/fields/Slider/HueSlider.tsx
@@ -100,9 +100,7 @@ function HueSlider(
       value={value}
       defaultValue={defaultValue}
       orientation={orientation}
-      minValue={0}
       maxValue={359}
-      step={1}
       thumbStyles={thumbStyles}
       trackStyles={trackStyles}
       thumbTokens={thumbTokens}

--- a/src/components/fields/TextArea/TextArea.stories.tsx
+++ b/src/components/fields/TextArea/TextArea.stories.tsx
@@ -279,7 +279,7 @@ export const ControlledAutoSize = () => {
   const [value, setValue] = useState('Line 1');
 
   return (
-    <Space flow="column" gap="1x" placeItems="start">
+    <Space flow="column" placeItems="start">
       <TextArea
         autoSize
         label="Controlled AutoSize TextArea"

--- a/src/components/fields/TextInputMapper/TextInputMapper.stories.tsx
+++ b/src/components/fields/TextInputMapper/TextInputMapper.stories.tsx
@@ -145,7 +145,6 @@ const Template: StoryFn<CubeTextInputMapperProps> = ({ ...props }) => (
 const FormTemplate: StoryFn<CubeTextInputMapperProps> = ({ ...props }) => (
   <Form
     defaultValues={{ field: { name: 'value' } }}
-    labelPosition="top"
     onSubmit={(data) => console.log('! onSubmit', data)}
   >
     <TextInputMapper
@@ -161,7 +160,6 @@ const FormTemplate: StoryFn<CubeTextInputMapperProps> = ({ ...props }) => (
 const FormTemplateSync: StoryFn<CubeTextInputMapperProps> = ({ ...props }) => (
   <Form
     defaultValues={{ field: { name: 'value' } }}
-    labelPosition="top"
     onSubmit={(data) => console.log('! onSubmit', data)}
   >
     <TextInputMapper

--- a/src/components/form/Form/ComplexForm.stories.tsx
+++ b/src/components/form/Form/ComplexForm.stories.tsx
@@ -338,7 +338,7 @@ const Template: StoryFn<typeof Form> = (args) => {
           name="slider"
           rules={[{ required: true, message: 'This field is required' }]}
         >
-          <Slider minValue={0} maxValue={100} />
+          <Slider />
         </Field>
         <Field
           label="Slider"

--- a/src/components/helpers/DisplayTransition/DisplayTransition.stories.tsx
+++ b/src/components/helpers/DisplayTransition/DisplayTransition.stories.tsx
@@ -276,7 +276,6 @@ export const PreserveContent: Story = {
           {isShown ? 'Hide Card' : 'Show Card'}
         </Button>
         <Button
-          type="outline"
           onPress={() =>
             setContent(`Updated at ${new Date().toLocaleTimeString()}`)
           }

--- a/src/components/helpers/IconSwitch/IconSwitch.stories.tsx
+++ b/src/components/helpers/IconSwitch/IconSwitch.stories.tsx
@@ -126,21 +126,18 @@ export const MultipleStates: Story = {
       <Container>
         <IconContainer>
           <Button
-            type="outline"
             isSelected={state === 'idle'}
             onPress={() => setState('idle')}
           >
             Idle
           </Button>
           <Button
-            type="outline"
             isSelected={state === 'success'}
             onPress={() => setState('success')}
           >
             Success
           </Button>
           <Button
-            type="outline"
             isSelected={state === 'error'}
             onPress={() => setState('error')}
           >

--- a/src/components/navigation/Tabs/TabPicker.tsx
+++ b/src/components/navigation/Tabs/TabPicker.tsx
@@ -65,7 +65,6 @@ export function TabPicker({
 
   return (
     <FilterPicker
-      selectionMode="single"
       selectedKey={selectedKey}
       renderSummary={false}
       icon={<MoreIcon />}

--- a/src/components/navigation/Tabs/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/Tabs.stories.tsx
@@ -498,7 +498,7 @@ export const Controlled: Story = {
 
     return (
       <Space flow="column" gap="2x">
-        <Space gap="1x">
+        <Space>
           <Button onPress={() => setActiveKey('tab1')}>Go to Tab 1</Button>
           <Button onPress={() => setActiveKey('tab2')}>Go to Tab 2</Button>
           <Button onPress={() => setActiveKey('tab3')}>Go to Tab 3</Button>
@@ -1108,7 +1108,7 @@ function RenderCountPanel({
   const count = countsRef.current[tabKey];
 
   return (
-    <Space qa={`panel-${tabKey}`} flow="column" gap="1x">
+    <Space qa={`panel-${tabKey}`} flow="column">
       <Text.Strong>
         {tabKey.charAt(0).toUpperCase() + tabKey.slice(1)} Content
       </Text.Strong>

--- a/src/components/overlays/AlertDialog/AlertDialog.stories.tsx
+++ b/src/components/overlays/AlertDialog/AlertDialog.stories.tsx
@@ -30,7 +30,6 @@ export default {
 const Template: StoryFn<CubeAlertDialogProps> = (args) => {
   return (
     <DialogTrigger
-      isDismissable
       placement="top"
       onDismiss={(action) => console.log('onDismiss event', action)}
     >

--- a/src/components/overlays/Dialog/Dialog.stories.tsx
+++ b/src/components/overlays/Dialog/Dialog.stories.tsx
@@ -442,9 +442,7 @@ export const PopoverWithMenuAndSelect: StoryFn<
         <Content>
           <Space flow="row" gap="2x" placeItems="center">
             <MenuTrigger>
-              <Button type="outline" size="small">
-                Menu
-              </Button>
+              <Button size="small">Menu</Button>
               <Menu>
                 <Menu.Item key="copy">Copy</Menu.Item>
                 <Menu.Item key="cut">Cut</Menu.Item>

--- a/src/components/overlays/Modal/Overlay.tsx
+++ b/src/components/overlays/Modal/Overlay.tsx
@@ -82,7 +82,6 @@ function Overlay(props: CubeOverlayProps, ref) {
   let contents = (
     <Provider ref={ref}>
       <DisplayTransition
-        animateOnMount
         isShown={!!isOpen}
         exposeUnmounted={hideOnClose}
         duration={EXIT_DURATION}

--- a/src/components/overlays/Notifications/Notifications.stories.tsx
+++ b/src/components/overlays/Notifications/Notifications.stories.tsx
@@ -76,7 +76,7 @@ function mockNotification(
  * Static NotificationItem preview showing all themes.
  */
 export const AllTypes = () => (
-  <Space gap="1x" flow="column">
+  <Space flow="column">
     <NotificationItem
       notification={mockNotification({
         theme: 'success',
@@ -121,7 +121,7 @@ export const ImperativeAPI = () => {
   const { notify } = useNotifications();
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button
         onPress={() =>
           notify({
@@ -234,7 +234,7 @@ export const DeclarativeNotification = () => {
   const [showNotification, setShowNotification] = useState(false);
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button onPress={() => setShowNotification(!showNotification)}>
         {showNotification ? 'Hide Notification' : 'Show Notification'}
       </Button>
@@ -278,7 +278,7 @@ export const CustomDismissAction = () => {
   const { notify } = useNotifications();
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button
         onPress={() =>
           notify({
@@ -478,7 +478,7 @@ export const PersistentNotifications = () => {
 
   return (
     <Flex gap="2x" flow="column" width="60x">
-      <Space gap="1x">
+      <Space>
         <Button
           onPress={() => {
             counterRef.current++;
@@ -551,7 +551,7 @@ export const UnreadCountBadge = () => {
 
   return (
     <Flex gap="2x" flow="column" width="60x">
-      <Space gap="1x">
+      <Space>
         <Button
           onPress={() => {
             counterRef.current++;
@@ -604,7 +604,7 @@ export const StackCap = () => {
   const counterRef = useRef(0);
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button
         onPress={() => {
           counterRef.current++;

--- a/src/components/overlays/Notifications/OverlayContainer.tsx
+++ b/src/components/overlays/Notifications/OverlayContainer.tsx
@@ -520,7 +520,6 @@ export function OverlayContainer({
           return (
             <DisplayTransition
               key={itemId}
-              animateOnMount
               isShown={!isExiting}
               onRest={(transition) => {
                 if (transition === 'exit') {

--- a/src/components/overlays/Toast/Toast.stories.tsx
+++ b/src/components/overlays/Toast/Toast.stories.tsx
@@ -81,7 +81,7 @@ export const WithDescription: Story = {
  * All toast themes
  */
 export const AllThemes = () => (
-  <Space gap="1x" flow="column">
+  <Space flow="column">
     <ToastItem title="Default toast" theme="default" />
     <ToastItem title="Success toast" theme="success" />
     <ToastItem title="Danger toast" theme="danger" />
@@ -97,7 +97,7 @@ export const UseToastHook = () => {
   const toast = useToast();
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button onPress={() => toast.success('Success message!')}>
         Show Success
       </Button>
@@ -132,7 +132,7 @@ export const DeclarativeToast = () => {
   const [showToast, setShowToast] = useState(false);
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button onPress={() => setShowToast(!showToast)}>
         {showToast ? 'Hide Toast' : 'Show Toast'}
       </Button>
@@ -238,7 +238,7 @@ export const ProgressStateToggle = () => {
   );
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button
         type={state === 'loading' ? 'primary' : 'outline'}
         onPress={() => setState('loading')}
@@ -283,7 +283,7 @@ export const Deduplication = () => {
   const toast = useToast();
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button
         onPress={() =>
           toast.success({ icon: <CheckIcon />, title: 'Copied to clipboard' })
@@ -312,7 +312,7 @@ export const MultipleToasts = () => {
   const counterRef = useRef(0);
 
   return (
-    <Space gap="1x">
+    <Space>
       <Button
         onPress={() => {
           counterRef.current++;

--- a/src/eslint-plugin/defaults.generated.ts
+++ b/src/eslint-plugin/defaults.generated.ts
@@ -601,7 +601,7 @@ export const DEFAULTS: DefaultsRegistry = {
     },
     RadioGroup: {
       props: {
-        size: { kind: 'default', value: 'xsmall' },
+        size: { kind: 'default', value: 'medium' },
         type: { kind: 'default', value: 'radio' },
       },
     },

--- a/src/eslint-plugin/defaults.generated.ts
+++ b/src/eslint-plugin/defaults.generated.ts
@@ -206,7 +206,11 @@ export const DEFAULTS: DefaultsRegistry = {
     },
     Dialog: {
       props: {
-        isDismissable: { kind: 'default', value: false },
+        isDismissable: {
+          kind: 'skip',
+          reason: 'context',
+          note: 'Redundant in a bare tree but load-bearing under "inside <DialogContext isDismissable>", so removing it would change behaviour there.',
+        },
         role: { kind: 'default', value: 'dialog' },
         size: { kind: 'default', value: 'M', aliases: ['medium'] },
       },
@@ -376,7 +380,11 @@ export const DEFAULTS: DefaultsRegistry = {
     },
     ItemAction: {
       props: {
-        isDisabled: { kind: 'default', value: false },
+        isDisabled: {
+          kind: 'skip',
+          reason: 'context',
+          note: 'Redundant in a bare tree but load-bearing under "inside <ItemActionProvider isDisabled>", so removing it would change behaviour there.',
+        },
         isLoading: { kind: 'default', value: false },
         isSelected: { kind: 'default', value: false },
         theme: {
@@ -384,7 +392,11 @@ export const DEFAULTS: DefaultsRegistry = {
           reason: 'context',
           note: 'Redundant in a bare tree but load-bearing under "inside <ItemActionProvider theme="danger">", so removing it would change behaviour there.',
         },
-        type: { kind: 'default', value: 'clear' },
+        type: {
+          kind: 'skip',
+          reason: 'context',
+          note: 'Redundant in a bare tree but load-bearing under "inside <ItemActionProvider type="primary">", so removing it would change behaviour there.',
+        },
       },
     },
     ItemBadge: {
@@ -395,8 +407,16 @@ export const DEFAULTS: DefaultsRegistry = {
           reason: 'reflected-attribute',
           note: 'Reflected as `aria-selected={isSelected}`, so omitting the prop removes the attribute while `false` emits `aria-selected="false"`. Not safe to strip.',
         },
-        theme: { kind: 'default', value: 'default' },
-        type: { kind: 'default', value: 'clear' },
+        theme: {
+          kind: 'skip',
+          reason: 'context',
+          note: 'Redundant in a bare tree but load-bearing under "inside <ItemActionProvider theme="danger">", so removing it would change behaviour there.',
+        },
+        type: {
+          kind: 'skip',
+          reason: 'context',
+          note: 'Redundant in a bare tree but load-bearing under "inside <ItemActionProvider type="primary">", so removing it would change behaviour there.',
+        },
       },
     },
     ItemButton: {

--- a/src/eslint-plugin/fixtures.tsx
+++ b/src/eslint-plugin/fixtures.tsx
@@ -384,13 +384,26 @@ export const FIXTURES: Fixture[] = [
   },
   {
     name: 'RadioGroup',
+    /**
+     * `size` only reaches the DOM through the radios, and a plain `type="radio"`
+     * radio renders identically at every size — so probed bare, *any* documented
+     * value verifies. That is how `(default: xsmall)` survived in the docs while
+     * `Radio.tsx` resolves `size ?? contextSize ?? 'medium'`: the probe could not
+     * tell the two apart, and the rule then offered to strip `size="xsmall"` from
+     * consumer code. The `type="button"` condition is what makes the size probe
+     * able to fail.
+     */
     render: (props) => (
       <RadioGroup label="Radio" {...props}>
         <Radio value="a">A</Radio>
         <Radio value="b">B</Radio>
       </RadioGroup>
     ),
-    conditions: [insideHorizontalForm],
+    conditions: [
+      insideHorizontalForm,
+      { label: 'type="button"', props: { type: 'button' } },
+      { label: 'type="tabs"', props: { type: 'tabs' } },
+    ],
     ignoreProps: ['label', 'children'],
   },
   {

--- a/src/eslint-plugin/fixtures.tsx
+++ b/src/eslint-plugin/fixtures.tsx
@@ -1,4 +1,5 @@
 import { ItemActionProvider } from '../components/actions/ItemActionContext';
+import { DialogContext } from '../components/overlays/Dialog/context';
 import {
   Alert,
   AlertDialog,
@@ -205,6 +206,23 @@ export const FIXTURES: Fixture[] = [
     // Dialog normalises S/M/L onto small/medium/large through a lookup table
     // (Dialog.tsx), so `medium` really is the `M` default spelled differently.
     curatedAliases: { size: ['medium'] },
+    /**
+     * `Dialog.tsx` resolves `isDismissable = contextProps.isDismissable` with no
+     * literal fallback, and `DialogContainer`/`DialogTrigger` default that context
+     * value to `true`. So bare, `isDismissable={false}` matches the undefined
+     * default; nested in a dismissable container it is what opts the inner dialog
+     * out. Probing under the context is the only way to see the difference.
+     */
+    conditions: [
+      {
+        label: 'inside <DialogContext isDismissable>',
+        wrap: (ui) => (
+          <DialogContext.Provider value={{ isDismissable: true }}>
+            {ui}
+          </DialogContext.Provider>
+        ),
+      },
+    ],
   },
 
   /* ── Content ──────────────────────────────────────────────────────────── */
@@ -222,7 +240,26 @@ export const FIXTURES: Fixture[] = [
   { name: 'InfoBadge', render: (props) => <InfoBadge {...props}>1</InfoBadge> },
   {
     name: 'ItemBadge',
+    /**
+     * Reads `type` and `theme` off `ItemActionContext` the same way `ItemAction`
+     * does, so it needs the same conditions — without them both props probe as
+     * plain defaults while actually being inheritance overrides.
+     */
     render: (props) => <ItemBadge {...props}>1</ItemBadge>,
+    conditions: [
+      {
+        label: 'inside <ItemActionProvider theme="danger">',
+        wrap: (ui) => (
+          <ItemActionProvider theme="danger">{ui}</ItemActionProvider>
+        ),
+      },
+      {
+        label: 'inside <ItemActionProvider type="primary">',
+        wrap: (ui) => (
+          <ItemActionProvider type="primary">{ui}</ItemActionProvider>
+        ),
+      },
+    ],
     curatedSkips: { isSelected: ARIA_SELECTED_SKIP },
   },
   {
@@ -239,6 +276,20 @@ export const FIXTURES: Fixture[] = [
   },
   {
     name: 'ItemAction',
+    /**
+     * Every prop `ItemAction` reads off `ItemActionContext` needs a condition
+     * here, because the fallback chain is `prop ?? context ?? literal`
+     * (`ItemAction.tsx`: `type = contextType ?? 'clear'`,
+     * `isDisabled = isDisabledProp ?? contextIsDisabled`). Probed bare, the
+     * literal wins and the prop looks like a plain default; probed under a
+     * provider that supplies a different value, the prop is what stops the
+     * inherited one from applying. `<Item isDisabled>` renders its `actions` in
+     * exactly such a provider, so `<ItemAction isDisabled={false}>` is the
+     * documented way to keep one action live inside a disabled item.
+     *
+     * The provider rewrites item-ish `type`s to `clear`, so `type="primary"` is
+     * used here — one of the values it passes through untouched.
+     */
     render: (props) => <ItemAction {...props}>Label</ItemAction>,
     conditions: [
       {
@@ -246,6 +297,16 @@ export const FIXTURES: Fixture[] = [
         wrap: (ui) => (
           <ItemActionProvider theme="danger">{ui}</ItemActionProvider>
         ),
+      },
+      {
+        label: 'inside <ItemActionProvider type="primary">',
+        wrap: (ui) => (
+          <ItemActionProvider type="primary">{ui}</ItemActionProvider>
+        ),
+      },
+      {
+        label: 'inside <ItemActionProvider isDisabled>',
+        wrap: (ui) => <ItemActionProvider isDisabled>{ui}</ItemActionProvider>,
       },
     ],
   },

--- a/src/eslint-plugin/index.ts
+++ b/src/eslint-plugin/index.ts
@@ -28,9 +28,12 @@ const plugin = {
  * The rule is `warn` rather than `error` because it is a cleanliness rule, not a
  * correctness one, and it ships with an autofix.
  *
- * Stories and docs are exempt on purpose: a story that enumerates variants side
- * by side has to name the default explicitly to be readable, so linting them
- * buries the real findings.
+ * Stories and docs stay at `warn` rather than dropping to `off`. They are the
+ * code people copy, so redundant props there propagate outward and are worth
+ * surfacing — but a deliberate side-by-side contrast (`<Switch isSelected />`
+ * next to `<Switch isSelected={false} />`) has a real reason to name the default,
+ * and that pattern is common enough in stories that failing a build over it would
+ * be wrong. Silence the individual sites with a disable comment.
  */
 plugin.configs.recommended = [
   {
@@ -42,8 +45,13 @@ plugin.configs.recommended = [
     rules: { 'cube-ui-kit/no-redundant-default-prop': 'warn' },
   },
   {
-    files: ['**/*.stories.tsx', '**/*.stories.jsx', '**/*.docs.mdx'],
-    rules: { 'cube-ui-kit/no-redundant-default-prop': 'off' },
+    files: [
+      '**/*.stories.ts',
+      '**/*.stories.tsx',
+      '**/*.stories.jsx',
+      '**/*.docs.mdx',
+    ],
+    rules: { 'cube-ui-kit/no-redundant-default-prop': 'warn' },
   },
 ];
 

--- a/src/eslint-plugin/rules/no-redundant-default-prop.test.ts
+++ b/src/eslint-plugin/rules/no-redundant-default-prop.test.ts
@@ -68,6 +68,28 @@ const App = () => <Button type="outline" />;`,
       code: `import { Button } from './ui/Button';
 const App = () => <Button type="outline" />;`,
     },
+
+    // ---------------------------------------------------------------------
+    // `relativeImports` — opt-in provenance for linting the ui-kit repo
+    // itself, where components arrive by path and never by package name.
+    // ---------------------------------------------------------------------
+    {
+      name: 'relative import is still ignored when the option is absent',
+      code: `import { Button } from '../../actions/Button';
+const App = () => <Button type="outline" />;`,
+    },
+    {
+      name: 'relativeImports does not widen bare specifiers',
+      code: `import { Button } from '@mui/material';
+const App = () => <Button type="outline" />;`,
+      options: [{ relativeImports: true }],
+    },
+    {
+      name: 'relativeImports still loses to a local binding',
+      code: `const Button = tasty({});
+const App = () => <Button type="outline" />;`,
+      options: [{ relativeImports: true }],
+    },
     {
       name: 'ui-kit import shadowed by an inner binding',
       code: `${IMPORT}
@@ -208,6 +230,20 @@ const render = (Button) => <Button type="outline" />;`,
       name: 'compound component',
       code: `${IMPORT}<Button.Split theme="default" />;`,
       output: `${IMPORT}<Button.Split />;`,
+      errors: [{ messageId: 'redundant' }],
+    },
+    {
+      name: 'relativeImports reaches a deep relative specifier',
+      code: `import { Button } from '../../actions/Button';<Button type="outline" />;`,
+      output: `import { Button } from '../../actions/Button';<Button />;`,
+      options: [{ relativeImports: true }],
+      errors: [{ messageId: 'redundant' }],
+    },
+    {
+      name: 'relativeImports reaches a bare parent-directory barrel',
+      code: `import { Button } from '..';<Button type="outline" />;`,
+      output: `import { Button } from '..';<Button />;`,
+      options: [{ relativeImports: true }],
       errors: [{ messageId: 'redundant' }],
     },
     {

--- a/src/eslint-plugin/rules/no-redundant-default-prop.ts
+++ b/src/eslint-plugin/rules/no-redundant-default-prop.ts
@@ -62,7 +62,7 @@ function isAllowedSource(source: string, packages: string[]): boolean {
 function resolveComponentName(
   nameNode: Node,
   scope: Scope,
-  packages: string[],
+  isAllowed: (source: string) => boolean,
 ): string | null {
   const path: string[] = [];
   let current = nameNode;
@@ -85,7 +85,7 @@ function resolveComponentName(
   if (
     declaration?.type !== 'ImportDeclaration' ||
     typeof declaration.source?.value !== 'string' ||
-    !isAllowedSource(declaration.source.value, packages)
+    !isAllowed(declaration.source.value)
   ) {
     return null;
   }
@@ -174,6 +174,20 @@ export interface RuleOptions {
    * one. Never a wildcard — provenance has to stay provable.
    */
   packages?: string[];
+  /**
+   * Also treat *relative* import specifiers as ui-kit provenance.
+   *
+   * This exists for linting the ui-kit repository itself, where components are
+   * reached by path (`../../layout/Space`, `./Button`, `..`) and never by package
+   * name, so `packages` matches nothing and the rule silently does nothing. The
+   * specifiers share no usable prefix, so `packages` cannot express them either.
+   *
+   * Never enable it in a consumer project: there, a relative import is the
+   * consumer's own component, and trusting it would rewrite props on code this
+   * registry knows nothing about. Shadowing still bails — resolution requires an
+   * `ImportBinding`, so a local `const Badge = tasty({})` is never matched.
+   */
+  relativeImports?: boolean;
 }
 
 export function createRule(registry: DefaultsRegistry = DEFAULTS) {
@@ -194,6 +208,7 @@ export function createRule(registry: DefaultsRegistry = DEFAULTS) {
               items: { type: 'string' },
               minItems: 1,
             },
+            relativeImports: { type: 'boolean' },
           },
           additionalProperties: false,
         },
@@ -207,7 +222,12 @@ export function createRule(registry: DefaultsRegistry = DEFAULTS) {
     create(context: any) {
       const options: RuleOptions = context.options?.[0] ?? {};
       const packages = options.packages ?? [UI_KIT];
+      const relativeImports = options.relativeImports ?? false;
       const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+      const isAllowed = (source: string) =>
+        (relativeImports && source.startsWith('.')) ||
+        isAllowedSource(source, packages);
 
       return {
         // Typed as `any` on purpose: the structural `Node`/`Scope` interfaces
@@ -218,7 +238,7 @@ export function createRule(registry: DefaultsRegistry = DEFAULTS) {
             ? sourceCode.getScope(node)
             : context.getScope();
 
-          const component = resolveComponentName(node.name, scope, packages);
+          const component = resolveComponentName(node.name, scope, isAllowed);
 
           if (!component) return;
 

--- a/src/icons/Icons.stories.tsx
+++ b/src/icons/Icons.stories.tsx
@@ -40,7 +40,7 @@ const Template: StoryFn<CubeIconProps> = (name) => {
           const Icon = Icons[iconName];
 
           return (
-            <Space key={iconName} gap="1x">
+            <Space key={iconName}>
               <Icon size={18} />
               <Text preset="t4">{iconName}</Text>
             </Space>
@@ -60,7 +60,7 @@ const Template: StoryFn<CubeIconProps> = (name) => {
           const Icon = Icons[iconName];
 
           return (
-            <Space key={iconName} gap="1x">
+            <Space key={iconName}>
               <Icon size={24} color="#purple-text" />
               <Text preset="t4">{iconName}</Text>
             </Space>

--- a/src/stories/Theming.stories.tsx
+++ b/src/stories/Theming.stories.tsx
@@ -237,11 +237,7 @@ function StoryPage({
 // ============================================================================
 
 function ResetButton() {
-  return (
-    <Button type="outline" onPress={resetPaletteConfig}>
-      Reset to defaults
-    </Button>
-  );
+  return <Button onPress={resetPaletteConfig}>Reset to defaults</Button>;
 }
 
 function BrandControls() {
@@ -286,8 +282,6 @@ function BrandControls() {
       </Section>
       <Slider
         label={`Saturation — ${palette.saturation}`}
-        minValue={0}
-        maxValue={100}
         value={palette.saturation}
         onChange={(saturation) =>
           setPalette((config) => ({ ...config, saturation }))
@@ -339,8 +333,6 @@ function StatusControls() {
             />
             <Slider
               label={`${name} saturation — ${seed.saturation}`}
-              minValue={0}
-              maxValue={100}
               value={seed.saturation}
               onChange={(saturation) =>
                 setPalette(statusSeed(name, { saturation }))
@@ -380,8 +372,6 @@ function ContrastControls() {
         </Switch>
         <Slider
           label={`Contrast level — ${isManual ? palette.contrastLevel : 'auto'}`}
-          minValue={0}
-          maxValue={100}
           isDisabled={!isManual}
           value={
             isManual ? (palette.contrastLevel as number) : MANUAL_CONTRAST_START
@@ -573,6 +563,7 @@ function ComponentPanel() {
       </Lead>
       <Row>
         <Button type="primary">Primary</Button>
+        {/* oxlint-disable-next-line cube-ui-kit/no-redundant-default-prop -- button type row names every type, the default included */}
         <Button type="outline">Outline</Button>
         <Button type="clear">Clear</Button>
         <Button type="link">Link</Button>
@@ -582,9 +573,7 @@ function ComponentPanel() {
         <Button type="primary" theme="danger">
           Danger
         </Button>
-        <Button type="outline" theme="success">
-          Success
-        </Button>
+        <Button theme="success">Success</Button>
         <Button type="primary" theme="special">
           Special
         </Button>
@@ -817,8 +806,6 @@ function ThemeBuilderControls({
         {levelMode === 'custom' ? (
           <Slider
             label={`Level — ${customLevel}`}
-            minValue={0}
-            maxValue={100}
             value={customLevel}
             onChange={onCustomLevelChange}
           />
@@ -843,7 +830,6 @@ function ThemeBuilderControls({
           {THEME_PRESETS.map((preset) => (
             <Button
               key={preset.label}
-              type="outline"
               size="small"
               onPress={() => {
                 // No reset first — the setter replaces, so the preset config
@@ -886,8 +872,6 @@ function ThemeBuilderControls({
         </Switch>
         <Slider
           label={`Saturation — ${palette.saturation}`}
-          minValue={0}
-          maxValue={100}
           value={palette.saturation}
           onChange={(saturation) =>
             setPalette((config) => ({ ...config, saturation }))
@@ -918,8 +902,6 @@ function ThemeBuilderControls({
         <Note>Hues are fixed; only saturation is tunable.</Note>
         <Slider
           label={`Code saturation — ${palette.themes.code.saturation}`}
-          minValue={0}
-          maxValue={100}
           value={palette.themes.code.saturation}
           onChange={(saturation) =>
             setPalette((config) => ({
@@ -1154,9 +1136,7 @@ function ThemePreview({
         <SwatchLabel styles={{ preset: 't3m' }}>Quarterly Revenue</SwatchLabel>
         <Badge>Draft</Badge>
         <Row styles={{ gap: '1x', marginLeft: 'auto' }}>
-          <Button type="outline" size="small">
-            Share
-          </Button>
+          <Button size="small">Share</Button>
           <Button type="primary" size="small">
             Run
           </Button>


### PR DESCRIPTION
### Describe changes

The plugin this package ships was never applied to the repo that authors it. Two things prevented that, and the second failed silently:

1. **Nothing loaded it.** There is no ESLint config here — linting is `oxlint src` + prettier, and `.oxlintrc.json` registered only `@tenphi/eslint-plugin-tasty`.
2. **The rule could not see our components.** Provenance is gated on the import specifier literally matching `@cube-dev/ui-kit`, and no `.tsx`/`.jsx` file in `src/` imports that way — all 470 component imports in stories are relative, across 210 distinct specifiers that share no usable prefix, so `packages` cannot express them. Loaded as-is, the rule reported **zero** findings on the whole repo.

`pnpm lint` now fails on redundant props anywhere in `src/`, stories included.

#### How

- **`relativeImports` rule option** — also accepts relative specifiers as ui-kit provenance. For this repository only; in a consumer project a relative import is the consumer's own component. Shadowing still bails either way, since resolution requires an `ImportBinding` (a local `const Badge = tasty({})` is never matched).
- **`scripts/oxlint-cube-ui-kit-plugin.mjs`** — a jiti shim loading `src/eslint-plugin/index.ts` directly, so linting is never stale against `dist` and needs no build step in front of it. Oxlint's own loader is a bare `await import()` and cannot resolve the extensionless relative imports in the TS source. `dist/` was rejected as the specifier because it is gitignored and CI lints without building. Adds `jiti` as an explicit devDep — it was only present transitively and failed to resolve.
- **`.oxlintrc.json`** — rule at `error` with `relativeImports: true`. Two deliberate exclusions: `eslint-plugin/fixtures.tsx` (generator input for the prover — autofixing it rewrites the inputs that establish the registry) and `*.test.*` (a test that pins an expected value should keep stating it; strip `cols={12}` and it asserts whatever the default happens to be, so a later change to that default passes instead of failing).
- **`configs.recommended`** — stories and `.docs.mdx` go from `off` to `warn` for consumers, and the glob now covers `*.stories.ts`. Stories are the code people copy, so redundant props there travel outward; a deliberate contrast still warns rather than failing a build.

Findings went **346 → 0**: 19 reclassified as unsafe, 11 suppressed as deliberate, **316 autofixed** across 54 files. `Space gap="1x"` alone was 211 of them.

#### The part worth reviewing

The fix pass would have introduced four behaviour changes, all in one blind spot: props resolved as `prop ?? context ?? literal`. Probed bare, the literal wins and the prop looks redundant; in a real tree it is what stops an inherited value from applying. The prover only sees what a fixture's conditions let it see, and the conditions were incomplete.

| Prop | Why stripping it changed behaviour |
|---|---|
| `ItemAction.isDisabled` | `<Item isDisabled>` renders its `actions` inside `ItemActionProvider`, so `<ItemAction isDisabled={false}>` keeps one action live. [Documented in the story's own prop docs](https://github.com/cube-js/cube-ui-kit/blob/eslint-plugin-self-lint/src/components/actions/ItemAction/ItemAction.stories.tsx#L83) — the autofix would have contradicted it. |
| `ItemAction.type`, `ItemBadge.type`/`theme` | Same context chain; `ItemBadge` had no conditions on its fixture at all. |
| `Dialog.isDismissable` | `contextProps.isDismissable` with no literal fallback, while `DialogContainer`/`DialogTrigger` default that context to `true`. Three call sites in shipped source (`AlertDialog.tsx`, `LayoutPanel.tsx`, `FilterPicker.tsx`). |

I fixed the data rather than suppressing the sites: the fixtures now supply a differing value for each such prop, so the prover derives the skips itself and the sync guard re-proves them on every test run. That is deliberately not `curatedSkips`, which short-circuits `classifyProp` and is never probed again — it would keep asserting its reason after the component stopped behaving that way. Only `ItemAction.theme` was classified correctly before, and only because it happened to be the one prop with a matching condition.

A repo-wide audit for the pattern (`= context`, `?? context`) found no other affected component. `Radio` has it but is not in the registry.

#### Verified

- `pnpm lint` exits 0; `pnpm test` 1856 passed / 1 skipped, 91 files; `pnpm build` clean and the built `configs.recommended` still resolves.
- Oxlint bridge mechanics confirmed empirically before relying on them: `oxlint-disable-next-line` does suppress JS-plugin diagnostics, the `-- reason` suffix is honoured, and `--fix` writes JS-plugin fixes.
- Test-file exclusion is scoped, not a global off — reintroducing a redundant prop in a story is still caught.
- Storybook spot-check of the two behaviour-critical cases: the disabled `Item` keeps exactly one action live (`disabled: false`), and the `isSelected={false}` sibling still renders transparent/muted against its selected neighbours' purple fill.

##### Checklist

- [x] Pipeline is passed
- [x] Tests are added (including unit tests and stories in the storybook)
- [x] Tests are passed successfully
- [x] Changeset(s) is(are) added
- [x] You have passed the threshold of the library size
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Closes: N/A

#

### Other information

Two things to know going forward:

- **`.lintstagedrc` runs `oxlint --fix` on commit**, so an unsuppressed redundant prop is now stripped automatically by the next commit that touches its file. The 11 deliberate cases carry disable comments for exactly this reason.
- **Oxlint's `jsPlugins` is alpha** and explicitly outside semver. An oxlint bump could break plugin loading — loudly (a load error), not silently.

`.docs.mdx` code samples stay unlinted since oxlint does not parse mdx. That is the one place that *does* import by package name, so covering it would need ESLint plus an mdx processor.

Suppression syntax differs by position, which is documented: inside a JSX opening tag a `//` comment works, but in children position only `{/* */}` parses. Getting that wrong is a syntax error that makes oxlint skip the file and silently drop all its findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Autofix and registry classification affect what props get stripped in stories and shipped rule behavior; mitigations include context skips, fixture/test exclusions, and fixture conditions that re-prove on every test run.
> 
> **Overview**
> **Ui-kit now lints its own source** with the shipped `cube-ui-kit/no-redundant-default-prop` rule: Oxlint loads the plugin from `src/` via a **jiti** shim, and **`relativeImports: true`** treats path-based component imports as ui-kit (required here because nothing imports `@cube-dev/ui-kit`). Fixtures and `*.test.*` are excluded so prover inputs and pinned assertions are not autofixed.
> 
> The **defaults registry** is tightened so autofix cannot strip **context overrides** (`ItemAction` / `ItemBadge` `type`, `theme`, `isDisabled`; `Dialog` `isDismissable`) and **`RadioGroup.size`** is corrected to **`medium`** with docs/tabs mapping fixes plus richer prover conditions for button/tabs modes.
> 
> **Consumer-facing plugin tweaks:** `configs.recommended` warns (not silences) on stories/`.docs.mdx`; docs cover self-lint, suppressions, and the `prop ?? context` trap. Hundreds of redundant props were removed from stories and a few components (mostly default `gap`, `type="outline"`, `selectionMode="single"`, etc.), with **oxlint-disable** comments where a prop is intentional for demos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 132526b2a1ef9695170f338d5608527148fbc06b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->