### PR TITLE
chore(deps): update @tenphi/tasty to 3.0.2

### DIFF
--- a/.changeset/tasty-3-0-2.md
+++ b/.changeset/tasty-3-0-2.md
@@ -1,0 +1,9 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Update `@tenphi/tasty` to `3.0.2`. A patch release with no public API change — the export surface is byte-for-byte the same set of names as `3.0.1` — so nothing in the UI Kit needed migrating and the full suite passes unchanged.
+
+Two clarifications in Tasty's docs are worth knowing if you write custom tokens: token names are case-sensitive and should start lowercase (a leading capital folds, so `$Foo` resolves to `--foo`), and `preset` / `transition` take token *names* rather than values, so a bare `$name` there warns in dev and is ignored. Neither affects this package — no capitalized token name is used anywhere in `src`.
+
+The tree-shaking size budget goes from 123 kB to 124 kB. Tasty's core grew ~0.56 kB in this release, which put the old budget 31 bytes over; the `All` entry moved by the same amount and stays inside its 501 kB budget.

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -92,13 +92,20 @@ module.exports = [
     path: './dist/index.js',
     webpack: true,
     import: '{ Button }',
-    // 121.79 kB at the time of writing, measured on this branch merged with main.
+    // 123.03 kB at the time of writing, 31 bytes over the previous 123 kB. That
+    // is `@tenphi/tasty` 3.0.1 -> 3.0.2 and nothing of ours: both sides rebuilt
+    // on this Linux box read 122.47 kB on 3.0.1 and 123.03 kB on 3.0.2, +0.56 kB,
+    // and the `All` entry moved by the same 0.55 kB (499.12 -> 499.67 kB), which
+    // is what a change inside Tasty's always-included core looks like. The old
+    // budget only had ~530 B of headroom. Raised to 124 kB.
+    //
+    // Before this: 121.79 kB, measured on that branch merged with main.
     // Raised from main's 119 kB for Tasty v3. Two increases stack here: main had
     // already gone 118 -> 119 kB for the ~400 B that `@tenphi/tasty` 2.11.0 ->
     // 2.11.2 added, and v3 costs a further ~3.8 kB — its new dev diagnostics
     // (directional syntax, handler displacement, chunk conflicts) ship in every
     // bundle, because `isDevEnv()` is evaluated at runtime so one build serves
     // dev and production. Headroom stays small so real bloat still trips.
-    limit: '123kB',
+    limit: '124kB',
   },
 ];

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "1.3.0",
-    "@tenphi/tasty": "^3.0.0",
+    "@tenphi/tasty": "^3.0.2",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0
       '@tenphi/tasty':
-        specifier: ^3.0.0
-        version: 3.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: ^3.0.2
+        version: 3.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -158,7 +158,7 @@ importers:
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^1.0.3
-        version: 1.0.3(@tenphi/tasty@3.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        version: 1.0.3(@tenphi/tasty@3.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2186,8 +2186,8 @@ packages:
     resolution: {integrity: sha512-zZMl4BTw5bTJhkxO+OemtHT1YirDqZf1f4dPhRmocSIOljDsQLJ+GDdjn6j2QqLpl/HRfG9gQBNNs+s9XXFbQQ==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@3.0.1':
-    resolution: {integrity: sha512-s7DGVHQKD+uZDMvOwCT7QjYtkcbnOYawAay7/y2J3fG3cytp3yai3zFvfgXmOJs/1Wwaj104SSkwmlc1WNBTKw==}
+  '@tenphi/tasty@3.0.2':
+    resolution: {integrity: sha512-05zT9Y7b9j4Byl8VczFLKPXkJ4CFSuhtWA4krsEVeLwj5DYVB1g/0IJfjNflMTH+D+v07nYotUgSqX+/936AvA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -8282,20 +8282,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.3(@tenphi/tasty@3.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.3(@tenphi/tasty@3.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)
       jiti: 2.6.1
     optionalDependencies:
-      '@tenphi/tasty': 3.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+      '@tenphi/tasty': 3.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@tenphi/glaze@1.3.0': {}
 
-  '@tenphi/tasty@3.0.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@3.0.2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:


### PR DESCRIPTION
### Describe changes

Bumps `@tenphi/tasty` from `3.0.1` to `3.0.2` (the current `latest`) via `pnpm run update-tasty`, per the workflow documented in `AGENTS.md`.

**No migration was needed.** I diffed the published `3.0.1` and `3.0.2` tarballs: the public export surface is the same set of names, so nothing in `src` had to change. The release is internal work plus doc clarifications.

Two of those doc clarifications are worth flagging for anyone writing custom tokens, though neither affects this package:

- Token names are case-sensitive and should start lowercase — a leading capital folds, so `$Foo` resolves to `--foo` and `#Purple` to `--purple-color`. Checked: there is no capitalized token name anywhere in `src`.
- `preset` and `transition` take token *names*, not values, so a bare `$name` there warns in dev and is ignored.

**Size budget.** The tree-shaking entry goes from 123 kB to 124 kB. Tasty's core grew ~0.56 kB in this release, which put the old budget 31 bytes over. Measured with both sides freshly rebuilt on Linux (same platform as CI, so the zlib caveat in `.size-limit.cjs` doesn't apply here):

| Entry | 3.0.1 | 3.0.2 | Budget |
|---|---|---|---|
| `All` | 499.12 kB | 499.67 kB | 501 kB — unchanged, passes |
| Tree shaking (just a `Button`) | 122.47 kB | 123.03 kB | 123 kB → **124 kB** |

Both entries moving by the same ~0.55 kB is what a change inside Tasty's always-included core looks like, rather than anything component-specific. The `All` budget still has ~1.3 kB of headroom, so it is left alone.

##### Checklist

- [x] Pipeline is passed
- [x] Tests are passed successfully — full suite green, 1870 passed / 1 skipped across 91 files, unchanged from before the bump
- [x] Changeset(s) is(are) added
- [x] You have passed the threshold of the library size
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

No tests or stories are added: this is a dependency bump with no behavior change of our own to cover.

Closes: N/A

#

### Other information

`npx tsc --noEmit` output is byte-identical before and after the bump — the 42 lines it reports are pre-existing (the intentional `src/eslint-plugin/fixtures.tsx` lint fixtures and the `NodeListOf` iterator errors in the probe harnesses), not introduced here. `pnpm lint` is clean; oxlint emits only the same pre-existing warnings as on `main`.

`package.json` keeps the caret range style it has carried since the v3 upgrade (#1275) — `^3.0.0` → `^3.0.2`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H4ie7kwKPfbsXnP7KriNCD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch dependency bump with unchanged public API and no application code edits; only lockfile, changeset, and size budget documentation.
> 
> **Overview**
> **Dependency bump only:** `@tenphi/tasty` is updated from `^3.0.0` (resolved `3.0.1`) to `^3.0.2` in `package.json`, with matching `pnpm-lock.yaml` updates. There are **no changes under `src`** — the published export surface matches `3.0.1`, so no migration work.
> 
> A **patch changeset** documents the release. **`.size-limit.cjs`** raises the “Tree shaking (just a Button)” budget from **123 kB to 124 kB** and adds comments attributing ~0.56 kB growth to Tasty’s core; the full `All` bundle budget stays at 501 kB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed79b8c68130c315e8fc5fb5dfb51345b8099ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->