### PR TITLE
fix(Tooltip): wrap unbreakable content

### DIFF
--- a/.changeset/tooltip-force-wrapping.md
+++ b/.changeset/tooltip-force-wrapping.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Tooltip: force wrapping of unbreakable content (URLs, tokens, identifiers) so it no longer overflows the tooltip.

--- a/src/components/overlays/Tooltip/Tooltip.docs.mdx
+++ b/src/components/overlays/Tooltip/Tooltip.docs.mdx
@@ -151,6 +151,20 @@ Control where the tooltip appears relative to its trigger:
 
 <Story of={TooltipStories.Side} />
 
+### Long Content
+
+The tooltip is capped at `36x` wide (or the viewport minus `4x`, whichever is smaller) and wraps
+its content to stay inside that cap. Runs with no spaces — URLs, tokens, identifiers, error strings —
+are broken mid-word rather than allowed to overflow the bubble.
+
+```jsx
+<TooltipProvider title="https://cubecloud.example.com/deployments/12345/schema/files/model/cubes/very_long_cube_name.yml">
+  <Button>Hover me</Button>
+</TooltipProvider>
+```
+
+<Story of={TooltipStories.UnbreakableContent} />
+
 ### Light Theme
 
 Use the light theme for tooltips on dark backgrounds:

--- a/src/components/overlays/Tooltip/Tooltip.stories.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.stories.tsx
@@ -100,6 +100,30 @@ export const Light: typeof Template = Template.bind({});
 Light.args = { isLight: true };
 Light.play = Default.play;
 
+const UnbreakableContentTemplate: Story<CubeTooltipTriggerProps> = (args) => (
+  <TooltipTrigger {...args}>
+    <Button qa="UnbreakableTrigger">Hover to show a tooltip</Button>
+    <Tooltip>
+      https://cubecloud.example.com/deployments/12345/schema/files/model/cubes/very_long_cube_name.yml
+    </Tooltip>
+  </TooltipTrigger>
+);
+
+export const UnbreakableContent: typeof UnbreakableContentTemplate =
+  UnbreakableContentTemplate.bind({});
+UnbreakableContent.args = { delay: 0 };
+UnbreakableContent.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await timeout(250);
+
+  const button = await canvas.findByTestId('UnbreakableTrigger');
+  // this is a weird hack that makes tooltip working properly on page load
+  await userEvent.unhover(button);
+  await userEvent.hover(button);
+
+  await waitFor(() => expect(canvas.getByRole('tooltip')).toBeVisible());
+};
+
 const FunctionPatternTemplate: Story<CubeTooltipProviderProps> = (args) => (
   <Block padding="2.5x">
     <Paragraph>This should show a div with tooltip below:</Paragraph>

--- a/src/components/overlays/Tooltip/Tooltip.tsx
+++ b/src/components/overlays/Tooltip/Tooltip.tsx
@@ -55,6 +55,11 @@ const TooltipElement = tasty({
     preset: 't4',
     backdropFilter: 'blur(.5x)',
     whiteSpace: 'pre-line',
+    // The tooltip is width-capped (`min(36x, …)`) with `max-width: max-content`,
+    // so a run with no spaces — a URL, a token, an identifier, an error string —
+    // stays on one line and spills straight out of the bubble. `anywhere` breaks
+    // it at the cap instead. It inherits, so tooltip children wrap too.
+    overflowWrap: 'anywhere',
     pointerEvents: {
       '': 'none',
       material: 'auto',


### PR DESCRIPTION
Fixes [CUB-4036](https://linear.app/cube-d3/issue/CUB-4036).

## Problem

`Tooltip` caps its width at `min(36x, 100dvw - 4x)` with `max-width: max-content`, but never allowed a break inside a word. A run with no spaces — a URL, a token, an identifier, an error string — stayed on one line and spilled straight out of the bubble.

Measured with `pnpm probe:browser` on a 106-character identifier: the content box was **304px** wide while its text ran **673.8px** — ~370px of overflow.

## Fix

`overflow-wrap: anywhere` on the tooltip root. Same property `PrismCode` already uses for its wrapped mode. It inherits, so tooltip children wrap too.

After the fix, the same case measures 287.9px of text inside a 288px content box (3 lines). Short tooltips are unchanged — they still shrink to `max-content` (66px for `"Short tip"`).

## Changes

- `Tooltip.tsx` — `overflowWrap: 'anywhere'`
- `Tooltip.stories.tsx` — `UnbreakableContent` story with a `play` function, so Chromatic captures the open tooltip
- `Tooltip.docs.mdx` — "Long Content" section documenting the width cap and the mid-word break
- changeset (patch)

`pnpm test`: 2093 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only wrapping change on Tooltip plus docs/story coverage; short tooltips still shrink to content.
> 
> **Overview**
> Stops Tooltip overflow when the title is a long unbreakable string (URL, token, identifier, error). The bubble already caps at `min(36x, 100dvw - 4x)` with `max-content`, but `white-space: pre-line` never broke inside a word.
> 
> Sets `overflowWrap: 'anywhere'` on the tooltip root (inherits to children). Short copy still shrinks to `max-content`. Adds an `UnbreakableContent` story and a Long Content docs section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fb2525bb2ec01cae713cbce3f2a10da5273252b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->