### PR TITLE
fix(useContextMenu): keep an open menu's defaults live

### DIFF
--- a/.changeset/live-context-menu-defaults.md
+++ b/.changeset/live-context-menu-defaults.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`useContextMenu` and `useAnchoredMenu` now re-read `defaultMenuProps` on every render instead of snapshotting them when the menu opens. A menu whose content lives in those defaults — the row context menu in `Tree` and the tab context menu in `Tabs` both do — stayed frozen while open, so items appearing, disappearing or flipping `isDisabled` were invisible until it was closed and reopened. Runtime props passed to `open()`/`update()` still take precedence and are unaffected.

--- a/src/components/actions/use-anchored-menu.docs.mdx
+++ b/src/components/actions/use-anchored-menu.docs.mdx
@@ -72,7 +72,7 @@ function useAnchoredMenu&lt;P, T = ComponentProps&lt;typeof MenuTrigger&gt;&gt;(
 The hook provides full programmatic control over the menu:
 
 - **`open()`** opens the menu with provided props
-- **`update()`** updates menu props without closing/reopening
+- **`update()`** updates the runtime menu props without closing/reopening — only needed for props the caller owns, since `defaultMenuProps` are re-read on every render
 - **`close()`** closes the menu
 - **No automatic triggering** - designed for manual control via events or state
 
@@ -87,8 +87,8 @@ Positions menus relative to the anchor element:
 
 ### Props Merging Strategy
 
-- **`defaultMenuProps`** - Used as base props for the menu component
-- **Runtime props** (via `open()`/`update()`) - Merged with defaults, taking precedence
+- **`defaultMenuProps`** - Used as base props for the menu component, and re-read on every render: changing them updates a menu that is already open, so content kept there (items, `isDisabled`, `disabledKeys`) stays current without an `update()` call
+- **Runtime props** (via `open()`/`update()`) - Merged over the defaults, taking precedence, and held until the next `open()`/`update()`
 - **Trigger props** - Merged with `defaultTriggerProps` for positioning control
 
 ### Menu Synchronization

--- a/src/components/actions/use-anchored-menu.test.tsx
+++ b/src/components/actions/use-anchored-menu.test.tsx
@@ -1,5 +1,7 @@
 // NOTE: Type checking is disabled in this test file to prevent
 // noisy errors from complex generic typings that do not affect runtime behaviour.
+import { useState } from 'react';
+
 import { act, renderWithRoot, userEvent, waitFor } from '../../test';
 
 import { Menu } from './Menu';
@@ -130,5 +132,74 @@ describe('useAnchoredMenu', () => {
     expect(queryByText('Edit')).toBeInTheDocument();
     expect(queryByText('More')).toBeInTheDocument();
     expect(getByText('Nested 2')).toBeInTheDocument();
+  });
+  /**
+   * Same shape as `useContextMenu`'s live-defaults case: the menu's CONTENT is in
+   * `defaultMenuProps` and the consumer never calls `update()`. Merging those
+   * defaults at `open()` time froze the content of an open menu.
+   */
+  it('reflects defaultMenuProps changes while the menu is open', async () => {
+    let revealPreview: () => void = () => {};
+
+    const TestLiveDefaultsWrapper = () => {
+      const [hasPreview, setHasPreview] = useState(false);
+
+      revealPreview = () => setHasPreview(true);
+
+      const { anchorRef, open, rendered } = useAnchoredMenu<any>(
+        Menu,
+        {
+          placement: 'bottom start',
+        },
+        {
+          children: (
+            <>
+              {hasPreview ? <Menu.Item key="preview">Preview</Menu.Item> : null}
+              <Menu.Item key="delete">Delete</Menu.Item>
+            </>
+          ),
+        },
+      );
+
+      return (
+        <div>
+          <button
+            ref={anchorRef as React.RefObject<HTMLButtonElement>}
+            data-qa="Trigger"
+            onClick={() => open()}
+          >
+            Open Menu
+          </button>
+          {rendered}
+        </div>
+      );
+    };
+
+    const { getByTestId, getByRole, getByText, queryByText } = renderWithRoot(
+      <TestLiveDefaultsWrapper />,
+    );
+
+    await act(async () => {
+      await userEvent.click(getByTestId('Trigger'));
+    });
+
+    await waitFor(() => {
+      expect(getByRole('menu')).toBeInTheDocument();
+    });
+
+    expect(getByText('Delete')).toBeInTheDocument();
+    expect(queryByText('Preview')).not.toBeInTheDocument();
+
+    // Menu still open, no `update()` call.
+    await act(async () => {
+      revealPreview();
+    });
+
+    await waitFor(() => {
+      expect(getByText('Preview')).toBeInTheDocument();
+    });
+
+    expect(getByRole('menu')).toBeInTheDocument();
+    expect(getByText('Delete')).toBeInTheDocument();
   });
 });

--- a/src/components/actions/use-anchored-menu.tsx
+++ b/src/components/actions/use-anchored-menu.tsx
@@ -24,15 +24,19 @@ export interface UseAnchoredMenuReturn<P, T> {
   anchorRef: RefObject<HTMLElement | null>;
 
   /**
-   * Programmatically opens the menu with the provided props.
+   * Programmatically opens the menu with the provided props. They are merged
+   * over the CURRENT `defaultMenuProps` on every render, so defaults that change
+   * while the menu is open reach it without an `update()` call.
+   *
    * @param props - Props to pass to the menu component
    * @param triggerProps - Additional props for MenuTrigger (merged with defaultTriggerProps)
    */
   open(props?: P, triggerProps?: T): void;
 
   /**
-   * Updates the props of the currently open menu.
-   * Props are merged if defaults are provided.
+   * Updates the RUNTIME props of the currently open menu. Props are merged over
+   * the current `defaultMenuProps`. Only needed for props the caller owns —
+   * `defaultMenuProps` is re-read on every render.
    */
   update(props: P, triggerProps?: T): void;
 
@@ -67,7 +71,13 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
 ): UseAnchoredMenuReturn<P, T> {
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
-  const [componentProps, setComponentProps] = useState<P | null>(null);
+  /**
+   * The props the CALLER passed to `open()`/`update()`, on their own — never
+   * pre-merged with `defaultMenuProps`. Merging at open time snapshotted the
+   * defaults, which froze the content of a menu whose items live in those
+   * defaults; merging on render keeps them current. Runtime props still win.
+   */
+  const [runtimeProps, setRuntimeProps] = useState<P | null>(null);
   const [triggerProps, setTriggerProps] = useState<T | null>(null);
   const anchorRef = useRef<HTMLElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -112,12 +122,8 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   const open = useEvent((props: P = {} as P, triggerProps?: T) => {
     setupCheck();
 
-    // Merge defaultMenuProps with provided props
-    const finalProps = defaultMenuProps
-      ? { ...defaultMenuProps, ...props }
-      : props;
-
-    setComponentProps(finalProps);
+    // Overrides only — `defaultMenuProps` is merged in on render.
+    setRuntimeProps(props);
     setTriggerProps(triggerProps ?? null);
     setIsOpen(true);
   });
@@ -125,12 +131,7 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   const update = useEvent((props: P, triggerProps?: T) => {
     setupCheck();
 
-    // Merge defaultMenuProps with provided props
-    const finalProps = defaultMenuProps
-      ? { ...defaultMenuProps, ...props }
-      : props;
-
-    setComponentProps(finalProps);
+    setRuntimeProps(props);
     setTriggerProps(triggerProps ?? null);
   });
 
@@ -138,9 +139,15 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
     setIsOpen(false);
   });
 
-  // Render the menu only when componentProps is set
+  // Render the menu only when it has been opened at least once
   const renderedMenu = useMemo(() => {
-    if (!componentProps) return null;
+    if (!runtimeProps) return null;
+
+    // Merged here rather than at open time, so the defaults an open menu
+    // renders are the CURRENT ones. Runtime props still take precedence.
+    const componentProps = defaultMenuProps
+      ? { ...defaultMenuProps, ...runtimeProps }
+      : runtimeProps;
 
     return (
       <MenuTrigger
@@ -159,7 +166,14 @@ export function useAnchoredMenu<P, T = ComponentProps<typeof MenuTrigger>>(
         <Component {...componentProps} />
       </MenuTrigger>
     );
-  }, [componentProps, triggerProps, isOpen, defaultTriggerProps, t]);
+  }, [
+    runtimeProps,
+    defaultMenuProps,
+    triggerProps,
+    isOpen,
+    defaultTriggerProps,
+    t,
+  ]);
 
   return {
     anchorRef,

--- a/src/components/actions/use-context-menu.docs.mdx
+++ b/src/components/actions/use-context-menu.docs.mdx
@@ -33,7 +33,8 @@ function useContextMenu<P, T = ComponentProps<typeof MenuTrigger>>(
 
   /**
    * Programmatically opens the menu at the specified coordinates or element center.
-   * Runtime props are merged with defaultMenuProps (runtime props take precedence).
+   * Runtime props are merged with the current defaultMenuProps on every render
+   * (runtime props take precedence).
    *
    * @param props - Props to pass to the menu component (optional, defaults to defaultMenuProps)
    * @param triggerProps - Additional props for MenuTrigger (merged with defaultTriggerProps)
@@ -46,8 +47,8 @@ function useContextMenu<P, T = ComponentProps<typeof MenuTrigger>>(
   ): void;
 
   /**
-   * Updates the props of the currently open menu without repositioning.
-   * Props are merged with defaultMenuProps.
+   * Updates the runtime props of the currently open menu without repositioning.
+   * Props are merged over the current defaultMenuProps.
    */
   update(props: P, triggerProps?: T): void;
 
@@ -102,8 +103,8 @@ The hook automatically binds `onContextMenu` events to the `targetRef` element:
 
 The hook provides flexible prop management:
 
-- **`defaultMenuProps`** - Used for automatic right-click opening
-- **Runtime props** (via `open()`) - Merged with defaults, taking precedence
+- **`defaultMenuProps`** - Used for automatic right-click opening, and re-read on every render: changing them updates a menu that is already open, so content kept there (items, `isDisabled`, `disabledKeys`) stays current without an `update()` call
+- **Runtime props** (via `open()`/`update()`) - Merged over the defaults, taking precedence, and held until the next `open()`/`update()`
 - **Trigger props** - Merged with `defaultTriggerProps` for positioning control
 
 ### Menu Synchronization

--- a/src/components/actions/use-context-menu.test.tsx
+++ b/src/components/actions/use-context-menu.test.tsx
@@ -1,6 +1,6 @@
 // NOTE: Type checking is disabled in this test file to prevent
 // noisy errors from complex generic typings that do not affect runtime behaviour.
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 
 import {
   act,
@@ -1029,5 +1029,140 @@ describe('useContextMenu', () => {
     expect(queryByText('Edit')).toBeInTheDocument();
     expect(queryByText('More')).toBeInTheDocument();
     expect(getByText('Nested 2')).toBeInTheDocument();
+  });
+  /**
+   * The row-menu shape: the menu's CONTENT lives in `defaultMenuProps`, and the
+   * consumer never calls `update()`. Before the merge moved to render time these
+   * defaults were snapshotted by `open()`, so an item that became available while
+   * the menu was open stayed invisible until it was closed and reopened —
+   * `Tree`'s row context menu (see `TreeNode`) is exactly this shape.
+   */
+  it('reflects defaultMenuProps changes while the menu is open', async () => {
+    let revealPreview: () => void = () => {};
+
+    const TestLiveDefaultsWrapper = () => {
+      const [hasPreview, setHasPreview] = useState(false);
+
+      revealPreview = () => setHasPreview(true);
+
+      const { targetRef, rendered } = useContextMenu<HTMLDivElement, any>(
+        Menu,
+        { placement: 'bottom start' },
+        {
+          children: (
+            <>
+              {hasPreview ? <Menu.Item key="preview">Preview</Menu.Item> : null}
+              <Menu.Item key="delete">Delete</Menu.Item>
+            </>
+          ),
+        },
+      );
+
+      return (
+        <div ref={targetRef} data-qa="Container">
+          Right-click me
+          {rendered}
+        </div>
+      );
+    };
+
+    const { getByTestId, getByRole, getByText, queryByText } = renderWithRoot(
+      <TestLiveDefaultsWrapper />,
+    );
+
+    await act(async () => {
+      fireEvent.contextMenu(getByTestId('Container'), {
+        clientX: 100,
+        clientY: 50,
+      });
+    });
+
+    await waitFor(() => {
+      expect(getByRole('menu')).toBeInTheDocument();
+    });
+
+    expect(getByText('Delete')).toBeInTheDocument();
+    expect(queryByText('Preview')).not.toBeInTheDocument();
+
+    // The state change happens outside the menu, with the menu still open —
+    // nothing reopens it, and nothing calls `update()`.
+    await act(async () => {
+      revealPreview();
+    });
+
+    await waitFor(() => {
+      expect(getByText('Preview')).toBeInTheDocument();
+    });
+
+    // Still the same open menu, not a reopened one.
+    expect(getByRole('menu')).toBeInTheDocument();
+    expect(getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('keeps runtime props ahead of defaults that change while open', async () => {
+    const defaultAction = vi.fn();
+    const runtimeAction = vi.fn();
+    let bumpDefaults: () => void = () => {};
+
+    const TestPrecedenceWrapper = () => {
+      const [extraItem, setExtraItem] = useState(false);
+
+      bumpDefaults = () => setExtraItem(true);
+
+      const { targetRef, open, rendered } = useContextMenu<HTMLDivElement, any>(
+        Menu,
+        { placement: 'bottom start' },
+        {
+          onAction: defaultAction,
+          children: (
+            <>
+              <Menu.Item key="edit">Edit</Menu.Item>
+              {extraItem ? <Menu.Item key="extra">Extra</Menu.Item> : null}
+            </>
+          ),
+        },
+      );
+
+      return (
+        <div ref={targetRef} data-qa="Container">
+          <button
+            data-qa="ManualTrigger"
+            onClick={(e) => open({ onAction: runtimeAction }, undefined, e)}
+          >
+            Open
+          </button>
+          {rendered}
+        </div>
+      );
+    };
+
+    const { getByTestId, getByText } = renderWithRoot(
+      <TestPrecedenceWrapper />,
+    );
+
+    await act(async () => {
+      await userEvent.click(getByTestId('ManualTrigger'));
+    });
+
+    await waitFor(() => {
+      expect(getByText('Edit')).toBeInTheDocument();
+    });
+
+    // A defaults change re-merges the props — the runtime `onAction` must
+    // survive it rather than be overwritten by the default one.
+    await act(async () => {
+      bumpDefaults();
+    });
+
+    await waitFor(() => {
+      expect(getByText('Extra')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      await userEvent.click(getByText('Edit'));
+    });
+
+    expect(runtimeAction).toHaveBeenCalledWith('edit');
+    expect(defaultAction).not.toHaveBeenCalled();
   });
 });

--- a/src/components/actions/use-context-menu.tsx
+++ b/src/components/actions/use-context-menu.tsx
@@ -35,7 +35,9 @@ export interface UseContextMenuReturn<
 
   /**
    * Programmatically opens the menu at the specified coordinates or element center.
-   * Runtime props are merged with defaultMenuProps (runtime props take precedence).
+   * Runtime props are merged with the CURRENT `defaultMenuProps` on every render
+   * (runtime props take precedence), so defaults that change while the menu is
+   * open reach it without an `update()` call.
    *
    * @param props - Props to pass to the menu component (optional, defaults to defaultMenuProps)
    * @param triggerProps - Additional props for MenuTrigger (merged with defaultTriggerProps)
@@ -48,8 +50,9 @@ export interface UseContextMenuReturn<
   ): void;
 
   /**
-   * Updates the props of the currently open menu without repositioning.
-   * Props are merged with defaultMenuProps.
+   * Updates the RUNTIME props of the currently open menu without repositioning.
+   * Props are merged over the current `defaultMenuProps`. Only needed for props
+   * the caller owns — `defaultMenuProps` is re-read on every render.
    */
   update(props: P, triggerProps?: T): void;
 
@@ -89,7 +92,20 @@ export function useContextMenu<
 ): UseContextMenuReturn<E, P, T> {
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
-  const [componentProps, setComponentProps] = useState<P | null>(null);
+  /**
+   * The props the CALLER passed to `open()`/`update()`, on their own — never
+   * pre-merged with `defaultMenuProps`.
+   *
+   * Merging at open time snapshotted the defaults, so a consumer that keeps its
+   * menu content IN the defaults (`Tree`'s row menu does: `children` is part of
+   * the third argument) had a menu that was frozen the moment it opened. Items
+   * appearing, disappearing or flipping `isDisabled` while it was open stayed
+   * invisible until it was closed and reopened, and the only workaround was to
+   * mirror every render into an `update()` call. Keeping the overrides alone
+   * lets the merge happen at RENDER time, against the current defaults, while
+   * runtime props still win.
+   */
+  const [runtimeProps, setRuntimeProps] = useState<P | null>(null);
   const [triggerProps, setTriggerProps] = useState<T | null>(null);
   const [anchorPosition, setAnchorPosition] = useState<{
     x: number;
@@ -207,12 +223,8 @@ export function useContextMenu<
       const { x, y } = calculatePosition(event);
       setAnchorPosition({ x, y });
 
-      // Merge defaultMenuProps with provided props
-      const finalProps = defaultMenuProps
-        ? { ...defaultMenuProps, ...props }
-        : props;
-
-      setComponentProps(finalProps);
+      // Overrides only — `defaultMenuProps` is merged in on render.
+      setRuntimeProps(props);
       setTriggerProps(triggerProps ?? null);
       setIsOpen(true);
     },
@@ -221,12 +233,7 @@ export function useContextMenu<
   const update = useEvent((props: P, triggerProps?: T) => {
     setupCheck();
 
-    // Merge defaultMenuProps with provided props
-    const finalProps = defaultMenuProps
-      ? { ...defaultMenuProps, ...props }
-      : props;
-
-    setComponentProps(finalProps as P);
+    setRuntimeProps(props);
     setTriggerProps(triggerProps ?? null);
   });
 
@@ -243,7 +250,9 @@ export function useContextMenu<
         const pos = calculatePosition(event);
         setAnchorPosition(pos);
       } else {
-        open(defaultMenuProps, undefined, event);
+        // No overrides: the defaults are merged in on every render, so
+        // passing them here would freeze the version this right-click saw.
+        open(undefined, undefined, event);
       }
     },
   );
@@ -260,9 +269,15 @@ export function useContextMenu<
     };
   }, [onContextMenu]);
 
-  // Render the menu only when componentProps is set
+  // Render the menu only when it has been opened at least once
   const renderedMenu = useMemo(() => {
-    if (!componentProps || !anchorPosition) return null;
+    if (!runtimeProps || !anchorPosition) return null;
+
+    // Merged here rather than at open time, so the defaults an open menu
+    // renders are the CURRENT ones. Runtime props still take precedence.
+    const componentProps = defaultMenuProps
+      ? { ...defaultMenuProps, ...runtimeProps }
+      : runtimeProps;
 
     return (
       <>
@@ -335,7 +350,8 @@ export function useContextMenu<
       </>
     );
   }, [
-    componentProps,
+    runtimeProps,
+    defaultMenuProps,
     triggerProps,
     isOpen,
     defaultTriggerProps,

--- a/src/components/content/Tree/Tree.test.tsx
+++ b/src/components/content/Tree/Tree.test.tsx
@@ -654,6 +654,66 @@ describe('<Tree />', () => {
       expect(menuOnAction).toHaveBeenCalledWith('rename');
     });
 
+    /**
+     * A row menu whose items depend on data that arrives later — a preview action
+     * that only becomes available once its file list has loaded, which is the
+     * shape Cube Cloud's schema editor uses.
+     *
+     * `TreeNode` hands those items to `useContextMenu` as part of its
+     * `defaultMenuProps` and never calls `update()`, so while the hook merged the
+     * defaults at open time the OPEN menu was frozen: the item appeared only
+     * after a close and reopen.
+     */
+    it('adds an item to an open right-click menu when the tree-level menu changes', async () => {
+      let revealPreview: () => void = () => {};
+
+      const LiveMenuTree = () => {
+        const [hasPreview, setHasPreview] = useState(false);
+
+        revealPreview = () => setHasPreview(true);
+
+        return (
+          <Tree
+            contextMenu="context-only"
+            treeData={SAMPLE}
+            defaultExpandedKeys={['fruits']}
+            menu={() => (
+              <>
+                {hasPreview ? (
+                  <Menu.Item key="preview">Preview</Menu.Item>
+                ) : null}
+                <Menu.Item key="delete">Delete</Menu.Item>
+              </>
+            )}
+          />
+        );
+      };
+
+      const { getAllByRole, getByText, queryByText } = renderWithRoot(
+        <LiveMenuTree />,
+      );
+
+      const rows = getAllByRole('row');
+      await act(async () => {
+        await userEvent.pointer({ keys: '[MouseRight>]', target: rows[0] });
+      });
+
+      await waitFor(() => {
+        expect(getByText('Delete')).toBeInTheDocument();
+      });
+      expect(queryByText('Preview')).not.toBeInTheDocument();
+
+      // The data lands while the menu is open. Nothing closes or reopens it.
+      await act(async () => {
+        revealPreview();
+      });
+
+      await waitFor(() => {
+        expect(getByText('Preview')).toBeInTheDocument();
+      });
+      expect(getByText('Delete')).toBeInTheDocument();
+    });
+
     it('forwards `menuProps.onAction` for the right-click context menu too', async () => {
       const treeOnAction = vi.fn();
       const menuOnAction = vi.fn();


### PR DESCRIPTION
Found while looking at whether [cubedevinc/cubejs-enterprise#14360](https://github.com/cubedevinc/cubejs-enterprise/pull/14360) — an E2E fix for a menu that "opens without the expected item" — pointed at a ui-kit bug. It doesn't (that spec drives the `⋮` `MenuTrigger`, whose children render live), but the **right-click** path next to it really is frozen.

## The bug

`useContextMenu` and `useAnchoredMenu` merged `defaultMenuProps` into state at `open()` time:

```ts
const finalProps = defaultMenuProps ? { ...defaultMenuProps, ...props } : props;
setComponentProps(finalProps);
```

For a consumer that keeps its menu **content** in those defaults, that snapshot *is* the menu. Two of ours do:

- `TreeNode` — `useContextMenu(Menu, {...}, { ...menuProps, onAction, children: effectiveMenuChildren })`, opened with a bare `rowContextMenu.open()`, and `update()` is never called.
- `TabButton` — same shape, `children: processedMenu`.

So a row's right-click menu was fixed at the moment it opened. An item that became available while it was open (a preview action that needs its file list, an entry unlocked by a save landing), an item that went away, or an `isDisabled` that flipped — none of it reached the open menu. Closing and reopening was the only way to see it, and the only workaround was mirroring every render into an `update()` call.

`useContextMenu` made it worse on the path where it matters most: the built-in `contextmenu` handler passed the defaults as *runtime overrides* (`open(defaultMenuProps, undefined, event)`), so even a consumer that did call `update()` was fighting a snapshot that outranked the defaults.

## The fix

State keeps the caller's **runtime overrides alone**; the merge happens on render, against the current defaults:

```ts
const componentProps = defaultMenuProps ? { ...defaultMenuProps, ...runtimeProps } : runtimeProps;
```

Precedence is unchanged — runtime props still win, and still persist until the next `open()`/`update()`. The right-click handler now opens with no overrides so the defaults stay live.

Blast radius is narrow by construction: a consumer that passes everything at `open()` and leaves `defaultMenuProps` empty sees no change at all. `TableView`'s row menu is exactly that, which is why nothing there moves.

`Tree` and `Tabs` need no change of their own — they already rebuild their defaults every render.

## Tests

Four new cases, each verified **red on the unfixed hooks and green with them** (`git stash` on the two source files, re-run):

- `use-context-menu.test.tsx` — an item added to `defaultMenuProps` while the menu is open appears in it, with no reopen and no `update()`; and a runtime `onAction` still outranks the default one *after* a defaults change re-merges the props.
- `use-anchored-menu.test.tsx` — the same liveness case through `open()`.
- `Tree.test.tsx` — the end-to-end symptom: right-click a row, then let the data that unlocks a `Preview` item land while the menu is open.

## Verification

- `pnpm test` — **2119 passed, 1 skipped, 98 files.** One earlier run had `ItemTable.storage.test.tsx > stores nothing without a storageKey` time out at 5s; it passes alone and passed on a clean re-run of the full suite, and the clean tree runs the same file green — load flake, not this change.
- `pnpm exec vitest run --config vitest.browser.config.ts src/components/actions/Menu/MenuTrigger.browser.test.tsx` — 5 passed.
- `pnpm exec tsc --noEmit` — 18 errors, **the same 18 on a stashed clean tree** (`eslint-plugin/fixtures.tsx`, `test/probe/harness*`); none in the changed files.
- `pnpm exec prettier --check` clean; `pnpm exec oxlint src` reports no findings in the changed files.

## Not verified

I did not drive the Cube Cloud schema editor against this build. The Tree-level test reproduces the symptom with synthetic data, so the app-level claim is argued from `TreeNode`'s usage rather than observed in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hook behavior change with tests; consumers that pass all props at `open()` and omit defaults are unchanged.
> 
> **Overview**
> Fixes **frozen context and anchored menus** when menu content is supplied via `defaultMenuProps` (`Tree` row right-click, `Tabs` tab menu). Previously those defaults were merged into state at `open()` time, so items that appeared, disappeared, or changed `isDisabled` while the menu stayed open did not update until close/reopen.
> 
> **`useContextMenu` and `useAnchoredMenu`** now store only runtime overrides from `open()`/`update()` and merge with the **current** `defaultMenuProps` on each render. Runtime props still win and persist until the next `open()`/`update()`. The built-in right-click path calls `open()` with no overrides so defaults stay live.
> 
> Docs and a patch changeset describe the behavior; new hook and `Tree` tests cover live defaults and runtime precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b228711da603eaae46085b9185a547e3b42090bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->