### PR TITLE
docs(Board): say that it measures itself, and pin the no-paint-before-measurement gate

### DIFF
--- a/.changeset/board-sizing-docs.md
+++ b/.changeset/board-sizing-docs.md
@@ -1,0 +1,11 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+`Board`: document that it measures itself, and pin the no-paint-before-measurement guarantee with a test.
+
+Two behaviours were already true and nowhere written down, which is enough to make a consumer rebuild both: a board observes its own container and derives the column width from it, and it renders **no widgets at all** until it has a width. The second is what makes the first look unreliable — at width 0 a column works out negative, so a board that painted then would flash every widget at a nonsense size, and a consumer who saw that would reasonably conclude the board cannot size itself.
+
+The result is a recognisable workaround: measure the box yourself, feed it back in as `width`, and gate your own render on `measured > 0` — a `ResizeObserver` and an extra DOM node reimplementing what the board already does, plus a guaranteed empty first frame from the redundant gate.
+
+No behaviour change. A new **Sizing** section says what `width` is actually for (SSR, tests, forced-size exports — not everyday use), and a browser test now fails if the gate is removed. It has to be a browser test: jsdom reports every box as 0, so the situation under test cannot arise there.

--- a/src/components/layout/Board/Board.browser.test.tsx
+++ b/src/components/layout/Board/Board.browser.test.tsx
@@ -1,3 +1,5 @@
+import { useLayoutEffect, useRef } from 'react';
+
 import { renderWithRoot, screen, userEvent } from '../../../test';
 
 import { Board } from './index';
@@ -1109,6 +1111,83 @@ describe('a fixed cols × rows matrix', () => {
     // single row its one widget needs.
     await vi.waitFor(() =>
       expect(board().getBoundingClientRect().height).toBeCloseTo(400, 0),
+    );
+  });
+});
+
+describe('self-measurement', () => {
+  /**
+   * A board with no `width` prop measures its own container. Both halves of that
+   * contract are load-bearing for consumers — and a consumer that doubts either
+   * ends up hand-measuring the box and feeding `width` back in, which is a lot
+   * of machinery to replace something that already works.
+   *
+   * Only answerable in a browser: jsdom reports every box as 0, so the very
+   * thing under test cannot happen there.
+   */
+  it('renders no widget until it has a width, rather than painting a bad one', async () => {
+    const framesWithHost: number[] = [];
+    const Probe = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      // Runs before the board's own measurement effect on mount, so the first
+      // entry is the pre-measurement frame.
+      useLayoutEffect(() => {
+        framesWithHost.push(
+          ref.current?.querySelectorAll('[data-board-widget-host]').length ??
+            -1,
+        );
+      });
+      return (
+        <div ref={ref} style={{ width: '600px' }}>
+          <Board
+            cols={12}
+            rowHeight={ROW}
+            defaultLayout={[{ i: 'a', x: 0, y: 0, w: 6, h: 1 }]}
+          >
+            <Board.Widget id="a" qa="A">
+              a
+            </Board.Widget>
+          </Board>
+        </div>
+      );
+    };
+
+    renderWithRoot(<Probe />);
+
+    // The probe really did observe the first frame...
+    expect(framesWithHost.length).toBeGreaterThan(0);
+    // ...and the board had painted no widget in it. At width 0 a column works
+    // out NEGATIVE (`(0 - margin*(cols-1) - padding*2) / cols`), so rendering
+    // then would put every widget at a nonsense size for a frame.
+    expect(framesWithHost[0]).toBe(0);
+
+    // Once measured, the widget appears at its real size.
+    await vi.waitFor(() =>
+      expect(widget('a').getBoundingClientRect().width).toBeGreaterThan(0),
+    );
+  });
+
+  it('resolves its own width without an explicit `width` prop', async () => {
+    renderWithRoot(
+      <div style={{ width: '800px' }}>
+        <Board
+          cols={4}
+          rowHeight={ROW}
+          margin={[0, 0]}
+          containerPadding={[0, 0]}
+          defaultLayout={[{ i: 'a', x: 0, y: 0, w: 1, h: 1 }]}
+        >
+          <Board.Widget id="a" qa="A">
+            a
+          </Board.Widget>
+        </Board>
+      </div>,
+    );
+
+    // 800 / 4 columns = 200. A board that failed to measure would fall back to
+    // width 0 and never reach this.
+    await vi.waitFor(() =>
+      expect(widget('a').getBoundingClientRect().width).toBeCloseTo(200, 0),
     );
   });
 });

--- a/src/components/layout/Board/Board.docs.mdx
+++ b/src/components/layout/Board/Board.docs.mdx
@@ -68,7 +68,7 @@ Dragging and resizing are powered by React Aria's `useMove`, so they work with m
 - **`allowMarqueeSelection`** `boolean` (default: `selectionMode === 'multiple'`) — Draw a rubber-band selection when a drag starts on empty board space. A press on a widget selects and drags instead, so the lasso owns empty canvas only. Hold <kbd>Shift</kbd> or <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> to add to the existing selection rather than replacing it. A board sized to its content has no empty space left once the grid fills up, which makes the lasso undiscoverable — use `extraRows` to keep a band of it.
 - **`onWidgetsDelete`** `(keys: string[]) => void` — Called when <kbd>Delete</kbd>/<kbd>Backspace</kbd> is pressed with a non-empty selection and focus is not in an editable field. **Board never mutates the layout itself** — removing the widgets is yours to do, which is what lets you make it undoable. Board only handles these keys when this handler is set.
 - **`constraints`** `LayoutConstraint[]` — Grid/item layout constraints.
-- **`width`** `number` — Explicit width (disables measurement; useful for SSR/tests).
+- **`width`** `number` — Explicit width, which **disables the board's own measurement**. Only needed for SSR, tests, or a forced-size export — see [Sizing](#sizing); a board in the document measures itself and does not need this.
 - **`widgetProps`** `Partial<Board.Widget props>` — Default props applied to every widget this board hosts (per-widget `Board.Widget` props override these). Use it to add a card border to every widget (`widgetProps={{ isCard: true }}`) or set shared `styles`/sizing defaults without repeating them on each widget.
 - **`place`** `Styles['place']` — Style prop shorthand for `place-items`/`place-content`.
 - **`scrollMargin`** `Styles['scrollMargin']` — Style prop for scroll margin.
@@ -326,6 +326,16 @@ An app that persists every commit without looking writes those normalizations ba
 ### Restyling the selection
 
 <Story of={BoardStories.RestyledSelection} />
+
+## Sizing
+
+**A board measures its own container. You do not need to measure it for it.**
+
+It observes its container with a `ResizeObserver` and derives the column width from that, so the only reason to pass `width` is to _prevent_ measurement — SSR, a test, or an export forced to a fixed size.
+
+The part worth knowing, because it is what makes hand-measuring look necessary: **a board renders no widgets at all until it has a width.** At width 0 a column works out negative (`(0 - margin × (cols - 1) - containerPadding × 2) / cols`), so painting then would put every widget at a nonsense size for a frame. Instead the board renders its own box and nothing inside it, and the widgets appear on the first measured frame. A board briefly hidden (an inactive tab, say) keeps its last non-zero measurement rather than dropping back to zero, so its widgets stay mounted — which is what keeps an in-flight drag alive.
+
+So a consumer that mirrors this — measuring the box itself, feeding the result back in as `width`, and gating its own render on `measured > 0` — is reimplementing behaviour it already has, and pays a `ResizeObserver` and an extra DOM node for it.
 
 ## Accessibility
 

--- a/src/components/layout/Board/Board.tsx
+++ b/src/components/layout/Board/Board.tsx
@@ -1353,6 +1353,12 @@ function BoardInner(
   const styles: Styles = extractStyles(otherProps, CONTAINER_STYLES);
 
   const dragState = registry.dragState;
+  // No widgets until the board has a width. At width 0 a column works out
+  // NEGATIVE (`(0 - margin*(cols-1) - containerPadding*2) / cols`), so rendering
+  // then would paint every widget at a nonsense size for a frame — and a
+  // consumer who sees that concludes the board cannot measure itself and starts
+  // measuring it for them. Pinned by a browser test ("renders no widget until it
+  // has a width"), since jsdom reports every box as 0 and cannot see this.
   const ready = width > 0;
 
   // Gate widget position transitions off until the widgets have been painted at


### PR DESCRIPTION
Follow-up to #1348 / #1350, from the last workaround left in Cube Cloud's Grid container ([cubedevinc/cubejs-enterprise#13919](https://github.com/cubedevinc/cubejs-enterprise/pull/13919)).

**This turned out not to be a missing feature.** I went in expecting to add one — "Board shouldn't paint widgets at 0 width before its first measurement" — and found `const ready = width > 0` already doing exactly that, plus self-measurement working fine. So the change is documentation and a regression test, not behaviour.

## What was undocumented

Two things, both already true, neither written down anywhere:

1. **A board measures its own container.** It observes it with a `ResizeObserver` and derives the column width from that.
2. **It renders no widgets until it has a width.**

The second is what makes the first *look* unreliable. At width 0 a column works out **negative** — `(0 - margin × (cols - 1) - containerPadding × 2) / cols` — so a board that painted then would flash every widget at a nonsense size. A consumer who saw that would reasonably conclude the board cannot size itself.

The workaround that follows is recognisable, and Cloud shipped it twice (builder and published renderer, byte-for-byte):

```jsx
const ref = useRef(null);
const [w, h] = useResizeObserverValue(ref);      // a second ResizeObserver
const rowHeight = h > 0 ? (h - gaps) / rows : undefined;
return <div ref={ref} style={FILL}>              // an extra DOM node to hang it on
  {w > 0 ? <Board width={w} rowHeight={rowHeight} …/> : null}   {/* a redundant gate */}
</div>;
```

Every line of that is the board's own behaviour, reimplemented — and the `w > 0` gate *adds* the empty first frame it was written to avoid, because the board would have rendered its box and simply held the widgets back.

## What's in the PR

- A **Sizing** section saying the board measures itself, that `width` exists to *disable* measurement (SSR, tests, forced-size exports) rather than for everyday use, and that widgets are held back until the first measured frame — including the hidden-container case, where the last non-zero measurement is kept so an in-flight drag survives a tab switch.
- The `width` prop entry rewritten to point at it.
- A comment on `ready` saying it is load-bearing and why, so it doesn't read as a redundant guard to simplify away.
- **A browser test pinning it.** I verified it actually catches a regression: forcing `ready = true` fails it with `expected 1 to be +0`.

It has to be a browser test — jsdom reports every box as `0`, so the situation under test cannot arise there. My first attempt at it passed *vacuously* (the probe observed no frames at all and the loop over an empty array trivially succeeded); the committed version asserts the probe actually observed the first frame before asserting what was in it.

## Verification

232 unit tests and 38 browser tests pass. No production behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, comments, and regression tests only; no production behavior changes.
> 
> **Overview**
> **Documents existing `Board` sizing behavior** (no runtime changes): self-measurement via `ResizeObserver`, widgets withheld until `width > 0`, and when to use the `width` prop (SSR/tests/forced exports only).
> 
> Adds a **Sizing** section in `Board.docs.mdx` and rewrites the `width` prop blurb to point there, including why painting at zero width would flash nonsense layouts and why redundant consumer `ResizeObserver` + `measured > 0` gates are unnecessary.
> 
> Adds an inline comment on `const ready = width > 0` in `Board.tsx` explaining the guarantee, plus a **changeset** patch note for `@cube-dev/ui-kit`.
> 
> Adds **browser tests** in `self-measurement`: first frame has zero widget hosts before measurement, and column width resolves from container size without an explicit `width` prop (jsdom cannot cover this).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb3e7c24dbaa14b61d0c4b51c8a755fd81a39da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->