### PR TITLE
chore(audit-docs): honour omitted style props

### DIFF
--- a/.changeset/rude-nails-jog.md
+++ b/.changeset/rude-nails-jog.md
@@ -1,0 +1,4 @@
+---
+---
+
+`audit-docs`: honour style props a component omits from its props interface. A component that repurposes a style prop drops it via `Omit<SomeStyleProps, 'x'>` and destructures it as an ordinary prop, so it never reaches `extractStyles` — `Board`'s `margin` is the grid gap, not a CSS margin. The audit read the style list named in the `extractStyles` call and knew nothing about the `Omit`, so it demanded the docs list a prop the component does not accept. Tooling only; nothing about the published package changes.

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -817,6 +817,31 @@ async function readTsxFile(filePath) {
   return null;
 }
 
+/**
+ * Style props the component's own props interface drops via
+ * `Omit<SomeStyleProps, 'a' | 'b'>`.
+ *
+ * A component that repurposes a style prop for something else omits it from the
+ * style-prop interface and destructures it as an ordinary prop, so it never
+ * reaches `extractStyles` — `Board`'s `margin` is the grid gap, not a CSS
+ * margin. The `extractStyles` call still names the full style list, so without
+ * this the audit would demand the docs list a prop the component does not
+ * accept.
+ */
+function extractOmittedStyleProps(fileContent) {
+  const omitted = new Set();
+  const omitRe = /Omit<\s*(?:\w+\s*\|\s*)*?(\w*(?:StyleProps|BaseProps))\s*,\s*([^>]+?)>/g;
+  let m;
+  while ((m = omitRe.exec(fileContent)) !== null) {
+    const nameRe = /'([^']+)'|"([^"]+)"/g;
+    let n;
+    while ((n = nameRe.exec(m[2])) !== null) {
+      omitted.add(n[1] ?? n[2]);
+    }
+  }
+  return omitted;
+}
+
 async function detectStyleProps(componentDir, componentName, verbose) {
   const mainFile = path.join(componentDir, `${componentName}.tsx`);
   let content;
@@ -826,8 +851,17 @@ async function detectStyleProps(componentDir, componentName, verbose) {
     return null;
   }
 
+  const omitted = extractOmittedStyleProps(content);
+  const finish = (props) => {
+    const unique = [...new Set(props)].filter((prop) => !omitted.has(prop));
+    if (verbose && omitted.size > 0) {
+      console.log(`  [${componentName}] Omitted style props: ${[...omitted].join(', ')}`);
+    }
+    return unique;
+  };
+
   let result = extractStylePropsFromFile(content);
-  if (result) return [...new Set(result)];
+  if (result) return finish(result);
 
   const entries = await fs.readdir(componentDir, { withFileTypes: true });
   for (const entry of entries) {
@@ -841,7 +875,7 @@ async function detectStyleProps(componentDir, componentName, verbose) {
     result = extractStylePropsFromFile(fileContent);
     if (result) {
       if (verbose) console.log(`  [${componentName}] Found extractStyles in ${entry.name}`);
-      return [...new Set(result)];
+      return finish(result);
     }
   }
 
@@ -853,7 +887,7 @@ async function detectStyleProps(componentDir, componentName, verbose) {
     result = extractStylePropsFromFile(file.content);
     if (result) {
       if (verbose) console.log(`  [${componentName}] Found extractStyles via import ${path.relative(ROOT, file.path)}`);
-      return [...new Set(result)];
+      return finish(result);
     }
 
     const reExportRe = /export\s+\*\s+from\s+'([^']+)'/g;
@@ -865,7 +899,7 @@ async function detectStyleProps(componentDir, componentName, verbose) {
       result = extractStylePropsFromFile(reFile.content);
       if (result) {
         if (verbose) console.log(`  [${componentName}] Found extractStyles via re-export ${path.relative(ROOT, reFile.path)}`);
-        return [...new Set(result)];
+        return finish(result);
       }
     }
   }


### PR DESCRIPTION
## What

`detectStyleProps` in `scripts/audit-docs.mjs` derives a component's expected style props from the list named in its `extractStyles(...)` call. It had no awareness of the props interface *dropping* entries from that list.

`Board` declares `Omit<ContainerStyleProps, 'margin'>` and destructures `margin` as the grid gap — so `margin` never reaches `extractStyles` and is not a style prop on `Board`. The audit still reported:

```
Board (src/components/layout/Board/Board.docs.mdx)
  - Style props in code, not in docs: margin
```

which would push the docs into listing a prop the component does not accept. This surfaced while correcting `Board.docs.mdx` in fa0e4670.

## How

Collect the names removed by an `Omit<…StyleProps | …BaseProps, …>` in the component's own file and subtract them from the detected list. Non-style names in an `Omit` (`children`, `onDrag`, …) are simply absent from the list, so filtering them is a no-op.

## Verification

Diffed the full audit output across every component, before and after:

- issues removed: `Style props in code, not in docs: margin` (Board) — exactly one
- issues introduced: none

Tooling only — nothing about the published package changes, hence an empty changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the internal audit-docs script; runtime components and published APIs are unchanged.
> 
> **Overview**
> The **audit-docs** script no longer treats every name from an `extractStyles(...)` style list as a documented style prop when the component’s props type **drops** those names via `Omit<…StyleProps | …BaseProps, …>`.
> 
> It adds **`extractOmittedStyleProps`** to collect omitted keys from the main component file and **`detectStyleProps`** filters them out before comparing docs to code. That fixes false positives such as **`Board`**, where `margin` is omitted from `ContainerStyleProps` and used as grid gap instead of a CSS margin—the audit had incorrectly required `margin` in **Style Properties**.
> 
> **Verbose** mode logs which props were treated as omitted. **Tooling only**; no published package API change (empty changeset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 788053c1adc057e75edc7fc23d4654857c9e21d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->