### PR TITLE
chore: update Tasty ESLint plugin to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "@statoscope/cli": "^5.20.1",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",
-    "@tenphi/eslint-plugin-tasty": "^1.0.3",
+    "@tenphi/eslint-plugin-tasty": "^1.0.5",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^10.3.6
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
-        specifier: ^1.0.3
-        version: 1.0.3(@tenphi/tasty@3.3.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        specifier: ^1.0.5
+        version: 1.0.5(@tenphi/tasty@3.3.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2172,8 +2172,8 @@ packages:
   '@tanstack/virtual-core@3.13.12':
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
-  '@tenphi/eslint-plugin-tasty@1.0.3':
-    resolution: {integrity: sha512-BZ0ntsUktLz/G89wlfEDRDSbLKriT1Fz5f/64iZ70HmrupwHm3vLPDzesecgA3FwqQo0h+MXsMveEJ99NeWfrw==}
+  '@tenphi/eslint-plugin-tasty@1.0.5':
+    resolution: {integrity: sha512-51804zy6fczQ7CWGQr1vy+tD9wBGAWDDUMGT8po9wGSIsa9erBJRA22012K9J997KJ8YoIykEeZnB4iQEwJHmA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@tenphi/tasty': '>=3'
@@ -8282,7 +8282,7 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.3(@tenphi/tasty@3.3.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@3.3.1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)


### PR DESCRIPTION
## Summary

- update `@tenphi/eslint-plugin-tasty` from 1.0.3 to 1.0.5
- refresh the pnpm lockfile

## Validation

- `pnpm oxlint`
- `pnpm prettier`
- `pnpm test`
- `pnpm build`

No changeset is needed because this is a development-only linting dependency update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only ESLint plugin version bump with no production bundle or API changes.
> 
> **Overview**
> Bumps the dev dependency **`@tenphi/eslint-plugin-tasty`** from **1.0.3** to **1.0.5** in `package.json` and updates **`pnpm-lock.yaml`** to match.
> 
> This only affects local/CI linting (e.g. via the Tasty plugin in oxlint); it does not change published library code or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37768dadadbb80e91d5674a8cbf8cedc33aa1633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->