### PR TITLE
docs(RadioGroup): scope Radio.Tabs to form fields

### DIFF
--- a/src/components/fields/RadioGroup/RadioGroup.docs.mdx
+++ b/src/components/fields/RadioGroup/RadioGroup.docs.mdx
@@ -16,6 +16,18 @@ A radio group allows users to select exactly one option from a set of mutually e
 - Display filter options where only one can be active
 - Provide clear selection options in surveys or questionnaires
 
+Every variant of this component — `Radio.Tabs` included — is a **form control**: it runs through `useFieldProps` / `wrapWithField`, publishes `role="radiogroup"` semantics, and takes part in `Form` validation. Reach for one when the selection is a _value the user is setting_.
+
+### When not to use
+
+If the control is not a field — a toolbar that swaps which view is on screen, a segmented control over page content — use [Tabs](/docs/navigation-tabs--docs) instead, with `type="radio"` when the connected-button look was the point. It renders the same chrome without the field wiring, and it owns the panels it switches between.
+
+| In a `Form`? | Switches which controls render? | Use |
+| --- | --- | --- |
+| yes | yes | `Radio.Tabs` |
+| yes | no | `Radio.Group type="button"` |
+| no | — | `Tabs` (with `type="radio"` when the radio look was wanted) |
+
 ## Component
 
 <Story of={RadioGroupStories.Default} />
@@ -189,8 +201,10 @@ When using `type="button"`, you can customize the button appearance:
 
 ### Tabs Group
 
+Only inside a `Form`, and only when the choice changes which fields follow it — see [When not to use](#when-not-to-use). A toolbar switcher is `Tabs type="radio"`.
+
 ```jsx
-<Radio.Tabs label="Status">
+<Radio.Tabs name="status" label="Status">
   <Radio value="active">Active</Radio>
   <Radio value="inactive">Inactive</Radio>
   <Radio value="pending">Pending</Radio>
@@ -318,14 +332,20 @@ When using `type="button"`, you can customize the button appearance:
    </Radio.Group>
    ```
 
-3. **Visual Type**: Use `Radio.Tabs` for compact toolbars, `type="button"` for spaced selections, traditional radios for forms
+3. **Visual Type**: pick by the shape of the choice, not by the look you want — `Radio.Tabs` for a compact connected group _inside a form_, `type="button"` for spaced selections, traditional radios for longer or descriptive option lists
 
    ```jsx
-   {/* Good for compact toolbars */}
-   <Radio.Tabs label="View">
-     <Radio value="list">List</Radio>
-     <Radio value="grid">Grid</Radio>
+   {/* Good for a compact form field that gates the fields below it */}
+   <Radio.Tabs name="mode" label="Mode">
+     <Radio value="basic">Basic</Radio>
+     <Radio value="advanced">Advanced</Radio>
    </Radio.Tabs>
+
+   {/* Don't: a toolbar view switcher is not a field — use Tabs */}
+   <Tabs type="radio" defaultActiveKey="list">
+     <Tab key="list" title="List">...</Tab>
+     <Tab key="grid" title="Grid">...</Tab>
+   </Tabs>
 
    {/* Good for button selections */}
    <Radio.Group type="button" label="Priority">
@@ -333,7 +353,7 @@ When using `type="button"`, you can customize the button appearance:
      <Radio value="high">High</Radio>
    </Radio.Group>
 
-   {/* Good for forms */}
+   {/* Good for a longer or descriptive option list */}
    <Radio.Group label="Gender">
      <Radio value="male">Male</Radio>
      <Radio value="female">Female</Radio>
@@ -345,7 +365,7 @@ When using `type="button"`, you can customize the button appearance:
 6. **Grouping**: Use meaningful group labels that describe the choice
 7. **Options**: Keep option labels concise and mutually exclusive
 8. **Layout**: Use horizontal layout only when space permits and options are short
-9. **Tabs Mode**: Use `Radio.Tabs` for compact, connected button groups in limited space
+9. **Tabs Mode**: `Radio.Tabs` is for compact, connected button groups in limited space _that are form fields_. Outside a `Form` — or inside one, when the choice doesn't change which controls render — reach for `Tabs type="radio"` or `type="button"` instead
 
 ## Integration with Forms
 

--- a/src/components/navigation/Tabs/Tabs.docs.mdx
+++ b/src/components/navigation/Tabs/Tabs.docs.mdx
@@ -121,7 +121,7 @@ For individual tabs:
 - `default` - Standard tabs with selection indicator below (default)
 - `narrow` - Same as default but with collapsed horizontal label padding for compact layouts
 - `file` - File-style tabs with border bottom highlight on selection, delimiter between tabs
-- `radio` - Radio button style for tab selection
+- `radio` - Radio button style for tab selection. This is the right choice for a compact switcher that is _not_ a form field — a view toolbar, a segmented control over page content. [`Radio.Tabs`](/docs/forms-radiogroup--docs) looks the same but is a form control, so keep it for choices inside a `Form`
 
 <Story of={TabsStories.DefaultType} />
 


### PR DESCRIPTION
### Describe changes

Settles [CUB-4129](https://linear.app/cube-d3/issue/CUB-4129) — a docs-vs-guidance conflict, not a bug.

The RadioGroup Best Practices section said:

> **Visual Type**: Use `Radio.Tabs` for compact toolbars, `type="button"` for spaced selections, traditional radios for forms

with a `label="View"` list/grid toolbar switcher as the example. Cloud's `ui-review` ruleset (`radio-tabs-only-in-forms`) says the opposite for exactly that case, so authors kept landing on PRs where a live doc line supported the choice the reviewer was asking them to change — it happened on two PRs the same day.

**Resolved in favour of the Cloud rule**, because the code backs it rather than the doc:

- Every `RadioGroup` variant — `tabs` included — runs through `useFieldProps` (`RadioGroup.tsx:91`) and `wrapWithField` (`RadioGroup.tsx:178`). `Radio.Tabs` is unavoidably a **form control**, carrying field wiring, `role="radiogroup"` semantics, and `Form` validation.
- `Tabs` already ships `type="radio"` (`Tabs/types.ts:12`), which renders the same chrome, owns the panels it switches between, and carries none of the field machinery.

A toolbar view switcher pays for wiring it never uses, so the doc line was the thing that was wrong.

**Changes**

`RadioGroup.docs.mdx`
- New **When not to use** section after *When to Use*, stating the form-control fact and carrying the ticket's decision matrix (in a Form + gates other controls → `Radio.Tabs`; in a Form otherwise → `type="button"`; not a Form → `Tabs`).
- Best Practice #3 rewritten — the `label="View"` list/grid example that triggered this is now the explicit *don't*, shown beside its `Tabs type="radio"` replacement.
- Best Practice #9 ("Tabs Mode") scoped to form fields.
- The *Tabs Group* example gained a one-line caveat and a `name` prop, since it is a field.

`Tabs.docs.mdx`
- The `radio` type bullet now names itself as the non-form choice and points back at `Radio.Tabs`, so the guidance holds from whichever doc an author lands on first.

##### Checklist

- [x] Pipeline is passed
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

Not applicable — docs-only change, no runtime code touched: tests/stories, changeset (matching the precedent of `fa0e4670`, a docs-only `.docs.mdx` commit), library size threshold.

Closes: CUB-4129

#

### Other information

- The ticket refers to `docs/components/fields/RadioGroup.md`; that file is generated from the `.docs.mdx` sources by `scripts/prepare-docs.mjs` at `prepack`, so the sources are what changed here. Regeneration was verified locally — the Storybook `/docs/...--docs` links rewrite to relative paths as intended.
- Worth a separate look: running `scripts/prepare-docs.mjs` outside `prepack` silently dirties the working tree. `docs/glaze` and `docs/tasty` are tracked as **symlinks** into `node_modules`, and the script replaces them with real copied directories (`prepare-docs.mjs:439`). Restored here, but it will catch out anyone who runs the script by hand.
- The other half of CUB-4129 is on the Cloud side: cubedevinc/cubejs-enterprise#14380 recorded a note that this doc line needed a caveat, and that note can now point at the doc instead of restating the decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `.docs.mdx` files; no runtime or API behavior is modified.
> 
> **Overview**
> **Aligns Storybook docs with Cloud’s `radio-tabs-only-in-forms` guidance** so authors aren’t steered toward `Radio.Tabs` for toolbar-style view switchers.
> 
> In **RadioGroup** docs, it adds that every variant (including `Radio.Tabs`) is a form control, a **When not to use** section with a decision table (`Form` + gates fields → `Radio.Tabs`; in `Form` otherwise → `type="button"`; outside `Form` → `Tabs` with `type="radio"`), and rewrites Best Practices #3 and #9 so the old list/grid `Radio.Tabs` example is the explicit anti-pattern beside `Tabs type="radio"`. The Tabs Group example now includes a `name` prop and a caveat about form-only use.
> 
> In **Tabs** docs, the `radio` type bullet now describes non-form compact switchers and cross-links to `Radio.Tabs` for form values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e0916fbcd79455eb1dafba2a4cbb42ee5be290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->