### PR TITLE
feat: add precompiled Tasty styles

### DIFF
--- a/.changeset/auto-tooltip-commit-reflow.md
+++ b/.changeset/auto-tooltip-commit-reflow.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Stop `useAutoTooltip` from measuring label overflow inside its callback ref. React invokes callback refs during `commitAttachRef`, so reading `scrollWidth`/`clientWidth` there forced a style recalc and layout per element, mid-commit — every tooltip-bearing `Button`, `Item`, `TextItem`, `LayoutHeader` and `InlineInput` paying its own reflow. The `ResizeObserver` already delivers an initial callback on `observe()`, after layout but before paint, so the measurement lands in the same frame and is batched across every observed label.

--- a/.changeset/calm-kits-precompile.md
+++ b/.changeset/calm-kits-precompile.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': minor
 ---
 
-Add an opt-in precompiled Tasty stylesheet and manifest entry that reuses cataloged component classes while retaining runtime styles for dynamic globals and uncovered overrides.
+Add an opt-in precompiled Tasty stylesheet side-effect entry that reuses cataloged component classes while retaining runtime styles for dynamic globals and uncovered overrides.

--- a/.changeset/calm-kits-precompile.md
+++ b/.changeset/calm-kits-precompile.md
@@ -1,0 +1,5 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add an opt-in precompiled Tasty stylesheet and manifest entry that reuses cataloged component classes while retaining runtime styles for dynamic globals and uncovered overrides.

--- a/.changeset/calm-kits-precompile.md
+++ b/.changeset/calm-kits-precompile.md
@@ -2,4 +2,4 @@
 '@cube-dev/ui-kit': minor
 ---
 
-Add an opt-in precompiled Tasty stylesheet side-effect entry that reuses cataloged component classes while retaining runtime styles for dynamic globals and uncovered overrides.
+Add an opt-in precompiled Tasty stylesheet side-effect entry that reuses cataloged component classes while retaining runtime styles for dynamic globals and uncovered overrides, plus a Node-only application catalog compiler that runs project cases under UI Kit's exact configuration and Root providers.

--- a/.changeset/precompile-kit-catalog-recompile.md
+++ b/.changeset/precompile-kit-catalog-recompile.md
@@ -1,0 +1,11 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+`precompileStyles()` now re-renders UI Kit's own component catalog under the application's Tasty configuration and folds it into the same artifact, so one asset covers both layers.
+
+A chunk's lookup key hashes the style _source_, not the CSS it produced, so an application that redefines a unit, recipe, state or handler a kit chunk relies on still hits the shipped chunk for that key while the CSS behind it no longer matches. Recompiling removes the divergence at build time instead of leaving the runtime to detect it and fall back.
+
+Pass `recompileKitCatalog: false` to skip the work when the application makes no compilation-affecting configuration change. It skips the recompilation, not the coverage: pair it with `@cube-dev/ui-kit/precompiled-styles`, which registers alongside the app artifact. Catalogs stack rather than replace — Tasty keys manifests by id and merges their lookup tables, and identical chunks compile to identical class names, so overlap costs only duplicated CSS bytes. The README said to use one "instead of" the other, which was wrong.
+
+UI Kit's catalog cases now ship with the package so consumers can render them.

--- a/.changeset/precompile-record-kit-config.md
+++ b/.changeset/precompile-record-kit-config.md
@@ -1,0 +1,7 @@
+---
+'@cube-dev/ui-kit': patch
+---
+
+Apply UI Kit's own Tasty configuration before compiling the shipped catalog, so the manifest records it.
+
+The catalog imports the kit lazily inside each case, so the configuration snapshot Tasty now takes was captured before `Root` had registered UI Kit's units, states and recipes. The shipped manifest recorded 6 entries instead of 14, and a consumer overriding one of UI Kit's own recipes would not have been detected as a divergence. The generated CSS is unchanged.

--- a/.changeset/precompile-register-entry.md
+++ b/.changeset/precompile-register-entry.md
@@ -1,0 +1,9 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+Add `@cube-dev/ui-kit/precompile/register`, the browser half of the app-owned catalog API.
+
+`@cube-dev/ui-kit/precompile` compiles a catalog but is Node-only, so registering the result meant importing `@tenphi/tasty/precompile/register` directly — an undeclared dependency for most consumers, and a second Tasty instance with its own registry if the versions ever drifted. UI Kit now provides both halves.
+
+It is a separate entry rather than a root re-export: the registry and its configuration comparison ship with whoever imports it, and an application that builds no catalog should not carry them.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Run the browser tests
         run: pnpm test:browser
 
+      - name: Verify precompiled style parity
+        run: pnpm test:precompiled
+
   deploy-chromatic:
     name: 'Prepare Storybook for review & tests'
     runs-on: ubuntu-latest

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -20,6 +20,13 @@ module.exports = [
         }),
       );
     },
+    // Raised to 520 kB for the precompiled Tasty runtime support. The fresh
+    // local build is 515.26 kB, while the Button-only entry is 124.40 kB; both
+    // moved by roughly the same amount from the Tasty 3.5.0 measurements below,
+    // which pins the increase to Tasty's always-included manifest fast path.
+    // The 714 kB catalog stylesheet is opt-in and is not part of either normal
+    // JavaScript bundle. Rounded to the next 5 kB step as required below.
+    //
     // Still 515 kB on `@tenphi/tasty` 3.5.0: 513.60 kB against `main`'s
     // 512.39 kB with both sides rebuilt here, i.e. +1.21 kB. The Button entry
     // below moved by the same +1.21 kB, and matching deltas on both entries is
@@ -169,7 +176,7 @@ module.exports = [
     //
     // Note when checking locally: `size-limit` bundles the built `./dist`, it
     // does not build. Run `pnpm build` first or you will measure a stale bundle.
-    limit: '515kB',
+    limit: '520kB',
   },
   {
     name: 'Tree shaking (just a Button)',

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -183,7 +183,26 @@ module.exports = [
     path: './dist/index.js',
     webpack: true,
     import: '{ Button }',
-    // Still 125 kB on `@tenphi/tasty` 3.5.0: 123.02 kB against `main`'s
+    // Raised to 126 kB for the Tasty snapshot that records a precompiled
+    // catalog's compilation configuration. 125.03 kB against 124.97 kB on the
+    // previous snapshot, both sides rebuilt here — +0.06 kB, matched by the
+    // same +0.06 kB on `All` above (515.83 -> 515.89 kB), so all of it is
+    // Tasty's always-included core and none of it ours. What ships there is
+    // small on purpose: `configure()` now records which style handlers and
+    // props middleware the host configured, and the precompile store holds a
+    // reference to the check, so the comparison itself lives in
+    // `precompile/register` and only an app that registers a catalog loads it.
+    //
+    // Raised rather than shaved, as the note below asks: the previous entry
+    // left 30 B and this needs 60 B. The alternative was dropping the guard
+    // that keeps a catalog from serving CSS the host's configuration would
+    // never produce, which is not padding.
+    //
+    // CI agreed with the local reading exactly on this one — its report showed
+    // 122.1 KB binary, which is 125.03 kB decimal, the same figure measured
+    // here. Second data point for the calibration note in `All`.
+    //
+    // Before this: 125 kB on `@tenphi/tasty` 3.5.0: 123.02 kB against `main`'s
     // 121.81 kB, both sides rebuilt here — +1.21 kB, matched by the same
     // +1.21 kB on `All` above, so all of it is Tasty's always-included core and
     // none of it ours. See that entry for what the release changed there, and
@@ -244,6 +263,6 @@ module.exports = [
     // (directional syntax, handler displacement, chunk conflicts) ship in every
     // bundle, because `isDevEnv()` is evaluated at runtime so one build serves
     // dev and production. Headroom stays small so real bloat still trips.
-    limit: '125kB',
+    limit: '126kB',
   },
 ];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Each component lives in `src/components/{category}/{ComponentName}/` and ships `
 - `pnpm storybook` — start Storybook on port 6060
 - `pnpm build` — build library (`tsdown`, unbundled ESM), then generate the opt-in precompiled Tasty CSS, manifest, and report
 - `pnpm precompile:tasty` — regenerate the precompiled Tasty artifact from the already-built `dist/`
+- `@cube-dev/ui-kit/precompile` — Node-only helper for application-owned catalogs; it wraps cases in UI Kit's configured `Root` unless passed `root: false`
 - `pnpm bench:precompiled` — benchmark the actual generated artifact's registration and browser installation strategies
 - `pnpm test` — run all tests (Vitest); add `-- ComponentName` to filter, `-u` to update snapshots
 - `pnpm test:browser` — run the `*.browser.test.tsx` specs in real Chromium (layout, pointer, observers)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,12 @@ Each component lives in `src/components/{category}/{ComponentName}/` and ships `
 ## Commands
 
 - `pnpm storybook` — start Storybook on port 6060
-- `pnpm build` — build library (`tsdown`, unbundled ESM)
+- `pnpm build` — build library (`tsdown`, unbundled ESM), then generate the opt-in precompiled Tasty CSS, manifest, and report
+- `pnpm precompile:tasty` — regenerate the precompiled Tasty artifact from the already-built `dist/`
+- `pnpm bench:precompiled` — benchmark the actual generated artifact's registration and browser installation strategies
 - `pnpm test` — run all tests (Vitest); add `-- ComponentName` to filter, `-u` to update snapshots
 - `pnpm test:browser` — run the `*.browser.test.tsx` specs in real Chromium (layout, pointer, observers)
+- `pnpm test:precompiled` — build the UI Kit artifact and compare representative normal and precompiled computed styles in Chromium
 - `pnpm probe` — print the HTML, CSS or tokens a snippet actually produces, with the real config loaded. `pnpm probe:browser` for computed values, geometry and screenshots. See [Inspecting Rendered HTML & CSS](#inspecting-rendered-html--css--pnpm-probe)
 - `pnpm fix` — lint + format (Oxlint + Prettier)
 - `pnpm size` — check bundle size limits

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ To ship your own brand color, tune the palette seeds — every token, in every s
 setPaletteConfig((config) => ({ ...config, hue: 235 }));
 ```
 
+## Precompiled Tasty Styles
+
+Applications can opt into the UI Kit's precompiled component stylesheet by changing the package entry they import from:
+
+```tsx
+import { Root, Button } from '@cube-dev/ui-kit/precompiled';
+```
+
+This entry registers the generated Tasty manifest, imports the static CSS asset, and re-exports the normal UI Kit API. Keep rendering `Root`: palette variables, body styles, fonts, and application globals remain dynamic and are intentionally not part of the component artifact. Styles or style props that are not covered by the catalog continue through Tasty's runtime path.
+
+Frameworks that load stylesheets explicitly can link `@cube-dev/ui-kit/precompiled.css` and execute the registration-only entry before rendering:
+
+```ts
+import '@cube-dev/ui-kit/precompiled/register';
+```
+
+Consumer overrides to Tasty parser functions, units, states, handlers, recipes, or chunk assignments invalidate the shared artifact. Keep using the normal `@cube-dev/ui-kit` entry or generate a project-specific artifact in those applications.
+
 ## Components
 
 | Category | Components |

--- a/README.md
+++ b/README.md
@@ -67,19 +67,25 @@ setPaletteConfig((config) => ({ ...config, hue: 235 }));
 
 ## Precompiled Tasty Styles
 
-Applications can opt into the UI Kit's precompiled component stylesheet by changing the package entry they import from:
+Applications can opt into the UI Kit's precompiled component stylesheet with one side-effect import. Keep component imports on the normal entry:
 
 ```tsx
-import { Root, Button } from '@cube-dev/ui-kit/precompiled';
+import '@cube-dev/ui-kit/precompiled-styles';
+import { Root, Button } from '@cube-dev/ui-kit';
 ```
 
-This entry registers the generated Tasty manifest, imports the static CSS asset, and re-exports the normal UI Kit API. Keep rendering `Root`: palette variables, body styles, fonts, and application globals remain dynamic and are intentionally not part of the component artifact. Styles or style props that are not covered by the catalog continue through Tasty's runtime path.
+Import it once in the application entry or framework root, before anything renders. It registers the generated Tasty manifest and imports the static CSS asset through the application's bundler. Keep rendering `Root`: palette variables, body styles, fonts, and application globals remain dynamic and are intentionally not part of the component artifact. Styles or style props that are not covered by the catalog continue through Tasty's runtime path.
 
-Frameworks that load stylesheets explicitly can link `@cube-dev/ui-kit/precompiled.css` and execute the registration-only entry before rendering:
+Frameworks that require explicit global CSS imports can split those two side effects in their root entry:
 
 ```ts
-import '@cube-dev/ui-kit/precompiled/register';
+import '@cube-dev/ui-kit/precompiled-styles/register';
+import '@cube-dev/ui-kit/precompiled-styles.css';
 ```
+
+SSR deployments that emit a stylesheet `<link>` can resolve or copy the same `@cube-dev/ui-kit/precompiled-styles.css` package asset into the document head, then execute `@cube-dev/ui-kit/precompiled-styles/register` before rendering. RSC applications must make that registration module execute in both the server render graph and a client entry/provider; a stylesheet link alone does not install the runtime lookup map. Build integrations that need to inspect the catalog can import `@cube-dev/ui-kit/precompiled-styles/manifest`; registration is still required at runtime, and the CSS must still be delivered separately.
+
+Environments that cannot deliver a static stylesheet but can load an asset as text may combine `@cube-dev/ui-kit/precompiled-styles/manifest` with `installTastyPrecompiled()` from `@tenphi/tasty/precompile/register`. This is the fallback path: it puts the CSS in the JavaScript bundle, must run before the first Tasty render, and may require a CSP nonce.
 
 Consumer overrides to Tasty parser functions, units, states, handlers, recipes, or chunk assignments invalidate the shared artifact. Keep using the normal `@cube-dev/ui-kit` entry or generate a project-specific artifact in those applications.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Import it once in the application entry or framework root, before anything rende
 
 Use `tastyDebug.summary()` during representative navigation before adopting the shared asset. The summary separates runtime-active and precompiled-active classes, reports registered classes that are currently inactive, and shows how many distinct precompiled classes were used since metrics were reset. A high precompiled hit count alone can come from repeated renders of a small set and does not imply broad coverage.
 
-Applications with substantial `styles`, `style`, style-prop, or application-component usage should generate an app-owned artifact instead. The Node-only `@cube-dev/ui-kit/precompile` entry runs cases under UI Kit's exact Tasty configuration and normal `Root` providers while collecting both UI Kit and application chunks:
+Applications with substantial `styles`, `style`, style-prop, or application-component usage should generate an app-owned artifact. The Node-only `@cube-dev/ui-kit/precompile` entry runs cases under UI Kit's exact Tasty configuration and normal `Root` providers while collecting both UI Kit and application chunks:
 
 ```tsx
 import { writeFile } from 'node:fs/promises';
@@ -103,7 +103,18 @@ await Promise.all([
 ]);
 ```
 
-Cases should render representative application routes, data shapes, variants, and controlled subtrees. Import the application's Tasty configuration before invoking the compiler. Pass `root: false` when each case already returns the application's complete `Root` tree. Deliver the resulting CSS and register its manifest before rendering, using `registerTastyPrecompiled()` or `installTastyPrecompiled()` from `@tenphi/tasty/precompile/register`. Use the app-owned artifact instead of the broad shared asset, not in addition to it.
+Cases should render representative application routes, data shapes, variants, and controlled subtrees. Import the application's Tasty configuration before invoking the compiler. Pass `root: false` when each case already returns the application's complete `Root` tree. Deliver the resulting CSS and register its manifest before rendering, using `registerTastyPrecompiled()` or `installTastyPrecompiled()` from `@tenphi/tasty/precompile/register`.
+
+By default the compiler also re-renders UI Kit's own component catalog under the application's configuration and folds it into the same artifact, so one asset covers both layers. That default exists because a chunk's lookup key hashes the style _source_, not the CSS it produced: an application that redefines a unit, recipe, state or handler a kit chunk relies on still hits the shipped chunk for that key, while the CSS behind it no longer matches. Recompiling removes the divergence rather than leaving Tasty to detect it and fall back to runtime generation.
+
+Pass `recompileKitCatalog: false` to skip that work when the application makes no compilation-affecting configuration change. It skips the _recompilation_, not the coverage — pair it with the shipped asset:
+
+```ts
+import '@cube-dev/ui-kit/precompiled-styles';
+import './app-precompiled-styles';
+```
+
+Catalogs stack rather than replace: Tasty keys registered manifests by id and merges their lookup tables, and identical chunks compile to identical class names, so an overlap between the two artifacts costs nothing but the duplicated CSS bytes.
 
 Frameworks that require explicit global CSS imports can split those two side effects in their root entry:
 
@@ -116,7 +127,7 @@ SSR deployments that emit a stylesheet `<link>` can resolve or copy the same `@c
 
 Environments that cannot deliver a static stylesheet but can load an asset as text may combine `@cube-dev/ui-kit/precompiled-styles/manifest` with `installTastyPrecompiled()` from `@tenphi/tasty/precompile/register`. This is the fallback path: it puts the CSS in the JavaScript bundle, must run before the first Tasty render, and may require a CSP nonce.
 
-Consumer overrides to Tasty parser functions, units, states, handlers, recipes, or chunk assignments invalidate the shared artifact. Keep using runtime generation or generate an application-owned artifact under that exact configuration.
+Consumer overrides to Tasty parser functions, units, states, handlers, recipes, or chunk assignments invalidate the shared artifact. Tasty enforces this: a manifest records the configuration it was compiled under, and a catalog whose record no longer matches the host is dropped with a warning naming the differing entries, falling back to runtime generation rather than serving CSS the configuration would not produce. Adding names the catalog never compiled — extra states or recipes of the application's own — is not a divergence and keeps the catalog. To keep coverage under a real override, generate an application-owned artifact, which recompiles the kit catalog under that exact configuration by default.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ setPaletteConfig((config) => ({ ...config, hue: 235 }));
 
 ## Precompiled Tasty Styles
 
-Applications can opt into the UI Kit's precompiled component stylesheet with one side-effect import. Keep component imports on the normal entry:
+Tasty precompilation uses exact style-chunk keys. Choose between the shared UI Kit catalog and an application-owned catalog based on how closely the application renders stock UI Kit styles.
+
+The shared catalog is a convenient opt-in for applications with broad, mostly stock UI Kit usage. It loads the entire generated stylesheet on every page, so it is not a blanket performance default. Keep component imports on the normal entry:
 
 ```tsx
 import '@cube-dev/ui-kit/precompiled-styles';
@@ -75,6 +77,33 @@ import { Root, Button } from '@cube-dev/ui-kit';
 ```
 
 Import it once in the application entry or framework root, before anything renders. It registers the generated Tasty manifest and imports the static CSS asset through the application's bundler. Keep rendering `Root`: palette variables, body styles, fonts, and application globals remain dynamic and are intentionally not part of the component artifact. Styles or style props that are not covered by the catalog continue through Tasty's runtime path.
+
+Use `tastyDebug.summary()` during representative navigation before adopting the shared asset. The summary separates runtime-active and precompiled-active classes, reports registered classes that are currently inactive, and shows how many distinct precompiled classes were used since metrics were reset. A high precompiled hit count alone can come from repeated renders of a small set and does not imply broad coverage.
+
+Applications with substantial `styles`, `style`, style-prop, or application-component usage should generate an app-owned artifact instead. The Node-only `@cube-dev/ui-kit/precompile` entry runs cases under UI Kit's exact Tasty configuration and normal `Root` providers while collecting both UI Kit and application chunks:
+
+```tsx
+import { writeFile } from 'node:fs/promises';
+import { precompileUIKitStyles } from '@cube-dev/ui-kit/precompile';
+
+import { DashboardRoute, QueryRoute } from './catalog-routes';
+
+const artifact = await precompileUIKitStyles({
+  id: '@cube-dev/console-ui',
+  cases: [
+    { id: 'dashboard', render: () => <DashboardRoute /> },
+    { id: 'query', render: () => <QueryRoute /> },
+  ],
+});
+
+await Promise.all([
+  writeFile('dist/tasty.css', artifact.css),
+  writeFile('dist/tasty.manifest.json', JSON.stringify(artifact.manifest)),
+  writeFile('dist/tasty.report.json', JSON.stringify(artifact.report)),
+]);
+```
+
+Cases should render representative application routes, data shapes, variants, and controlled subtrees. Import the application's Tasty configuration before invoking the compiler. Pass `root: false` when each case already returns the application's complete `Root` tree. Deliver the resulting CSS and register its manifest before rendering, using `registerTastyPrecompiled()` or `installTastyPrecompiled()` from `@tenphi/tasty/precompile/register`. Use the app-owned artifact instead of the broad shared asset, not in addition to it.
 
 Frameworks that require explicit global CSS imports can split those two side effects in their root entry:
 
@@ -87,7 +116,7 @@ SSR deployments that emit a stylesheet `<link>` can resolve or copy the same `@c
 
 Environments that cannot deliver a static stylesheet but can load an asset as text may combine `@cube-dev/ui-kit/precompiled-styles/manifest` with `installTastyPrecompiled()` from `@tenphi/tasty/precompile/register`. This is the fallback path: it puts the CSS in the JavaScript bundle, must run before the first Tasty render, and may require a CSP nonce.
 
-Consumer overrides to Tasty parser functions, units, states, handlers, recipes, or chunk assignments invalidate the shared artifact. Keep using the normal `@cube-dev/ui-kit` entry or generate a project-specific artifact in those applications.
+Consumer overrides to Tasty parser functions, units, states, handlers, recipes, or chunk assignments invalidate the shared artifact. Keep using runtime generation or generate an application-owned artifact under that exact configuration.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Applications with substantial `styles`, `style`, style-prop, or application-comp
 
 ```tsx
 import { writeFile } from 'node:fs/promises';
-import { precompileUIKitStyles } from '@cube-dev/ui-kit/precompile';
+import { precompileStyles } from '@cube-dev/ui-kit/precompile';
 
 import { DashboardRoute, QueryRoute } from './catalog-routes';
 
-const artifact = await precompileUIKitStyles({
+const artifact = await precompileStyles({
   id: '@cube-dev/console-ui',
   cases: [
     { id: 'dashboard', render: () => <DashboardRoute /> },

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "2.0.0",
-    "@tenphi/tasty": "0.0.0-snapshot.b9638e2",
+    "@tenphi/tasty": "0.0.0-snapshot.b77b972",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "2.0.0",
-    "@tenphi/tasty": "0.0.0-snapshot.04629d1",
+    "@tenphi/tasty": "0.0.0-snapshot.edd6af3",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/precompiled/index.js",
+    "./dist/precompiled/register.js",
+    "./dist/precompiled/styles.css"
+  ],
   "packageManager": "pnpm@10.34.5",
   "exports": {
     ".": {
@@ -23,10 +27,25 @@
     "./probe": {
       "import": "./dist/probe/index.js",
       "types": "./dist/probe/index.d.ts"
+    },
+    "./precompiled": {
+      "import": "./dist/precompiled/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./precompiled/register": {
+      "import": "./dist/precompiled/register.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./precompiled.css": "./dist/precompiled/styles.css",
+    "./precompiled/manifest": {
+      "import": "./dist/precompiled/manifest.js",
+      "types": "./dist/precompiled/manifest.d.ts"
     }
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.css",
+    "dist/**/*.json",
     "dist/**/*.d.ts",
     "dist/**/*.map",
     "dist/README.md",
@@ -39,12 +58,15 @@
   ],
   "scripts": {
     "start": "pnpm storybook",
-    "build": "tsdown",
+    "build": "tsdown && pnpm precompile:tasty",
     "watch": "tsdown --watch",
     "test": "vitest run",
     "test:browser": "vitest run --config vitest.browser.config.ts",
+    "test:precompiled": "pnpm build && vitest run --config vitest.precompiled.config.ts",
     "probe": "node scripts/probe.mjs",
     "probe:browser": "PROBE_TIER=browser node scripts/probe.mjs",
+    "precompile:tasty": "node scripts/precompile-tasty.mjs",
+    "bench:precompiled": "pnpm build && vitest bench --config vitest.browser.config.ts scripts/precompile-startup.bench.js",
     "test-cover": "vitest run --coverage",
     "test-watch": "vitest",
     "prettier": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\" \"**/*.{md,mdx}\"",
@@ -96,7 +118,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "2.0.0",
-    "@tenphi/tasty": "^3.5.0",
+    "@tenphi/tasty": "0.0.0-snapshot.94660d8",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "docs/tasty",
     "docs/glaze",
     "docs/*.md",
-    "tasty.config.ts"
+    "tasty.config.ts",
+    "scripts/precompile-tasty-catalog.mjs"
   ],
   "scripts": {
     "start": "pnpm storybook",

--- a/package.json
+++ b/package.json
@@ -28,16 +28,19 @@
       "import": "./dist/probe/index.js",
       "types": "./dist/probe/index.d.ts"
     },
-    "./precompiled": {
+    "./precompiled-styles": {
       "import": "./dist/precompiled/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/precompiled/index.d.ts"
     },
-    "./precompiled/register": {
+    "./precompiled-styles/register": {
       "import": "./dist/precompiled/register.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/precompiled/register.d.ts"
     },
-    "./precompiled.css": "./dist/precompiled/styles.css",
-    "./precompiled/manifest": {
+    "./precompiled-styles.css": {
+      "types": "./dist/precompiled/styles.d.ts",
+      "default": "./dist/precompiled/styles.css"
+    },
+    "./precompiled-styles/manifest": {
       "import": "./dist/precompiled/manifest.js",
       "types": "./dist/precompiled/manifest.d.ts"
     }
@@ -118,7 +121,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "2.0.0",
-    "@tenphi/tasty": "0.0.0-snapshot.94660d8",
+    "@tenphi/tasty": "0.0.0-snapshot.b9638e2",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "import": "./dist/probe/index.js",
       "types": "./dist/probe/index.d.ts"
     },
+    "./precompile": {
+      "import": "./dist/precompile/index.js",
+      "types": "./dist/precompile/index.d.ts"
+    },
     "./precompiled-styles": {
       "import": "./dist/precompiled/index.js",
       "types": "./dist/precompiled/index.d.ts"
@@ -121,7 +125,7 @@
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@tenphi/glaze": "2.0.0",
-    "@tenphi/tasty": "0.0.0-snapshot.b77b972",
+    "@tenphi/tasty": "0.0.0-snapshot.04629d1",
     "clipboard-copy": "^4.0.1",
     "clsx": "^1.1.1",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
       "import": "./dist/precompile/index.js",
       "types": "./dist/precompile/index.d.ts"
     },
+    "./precompile/register": {
+      "import": "./dist/precompile/register.js",
+      "types": "./dist/precompile/register.d.ts"
+    },
     "./precompiled-styles": {
       "import": "./dist/precompiled/index.js",
       "types": "./dist/precompiled/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "watch": "tsdown --watch",
     "test": "vitest run",
     "test:browser": "vitest run --config vitest.browser.config.ts",
-    "test:precompiled": "pnpm build && vitest run --config vitest.precompiled.config.ts",
+    "test:precompiled": "pnpm build && node scripts/precompile-app-parity.mjs && vitest run --config vitest.precompiled.config.ts",
     "probe": "node scripts/probe.mjs",
     "probe:browser": "PROBE_TIER=browser node scripts/probe.mjs",
     "precompile:tasty": "node scripts/precompile-tasty.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.04629d1
-        version: 0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 0.0.0-snapshot.edd6af3
+        version: 0.0.0-snapshot.edd6af3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -158,7 +158,7 @@ importers:
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^1.0.5
-        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.edd6af3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2186,8 +2186,8 @@ packages:
     resolution: {integrity: sha512-entP+7nsScY87maev/rA6HS/qQy3YwHeywAsWTT9LGhovMp3/cj/Zb1jctlc37FWLim+mkYMwTGOk7ZfJBLLWg==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@0.0.0-snapshot.04629d1':
-    resolution: {integrity: sha512-BW/oYXG2zS/BwOpqgTHXI1yQ48AnWvEAYD9SDcaPjyT9tljJo/yD5Jm0K5HtNfuRVjw6k8ud6eucsjFpUpX/fw==}
+  '@tenphi/tasty@0.0.0-snapshot.edd6af3':
+    resolution: {integrity: sha512-VyFdw4bMA6KSqy9kc2PZuCLmrtkPSk4mTKJnuW5o+8a+EXI2bTwnoKrGpbFt6dAm8CkUP9H8FzyYZxPAp0t2eg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -8285,20 +8285,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.edd6af3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)
       jiti: 2.6.1
     optionalDependencies:
-      '@tenphi/tasty': 0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tenphi/tasty': 0.0.0-snapshot.edd6af3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@tenphi/glaze@2.0.0': {}
 
-  '@tenphi/tasty@0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.edd6af3(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.94660d8
-        version: 0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.b9638e2
+        version: 0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -158,7 +158,7 @@ importers:
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^1.0.5
-        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2186,8 +2186,8 @@ packages:
     resolution: {integrity: sha512-entP+7nsScY87maev/rA6HS/qQy3YwHeywAsWTT9LGhovMp3/cj/Zb1jctlc37FWLim+mkYMwTGOk7ZfJBLLWg==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@0.0.0-snapshot.94660d8':
-    resolution: {integrity: sha512-sapZdsxygjwhDDwL85ja3aCZ9u4yhki0rlfSVChZL8faLTDzFlxt6Li1s74LN7eLpfXuyhKqtax8vV25qHQQVg==}
+  '@tenphi/tasty@0.0.0-snapshot.b9638e2':
+    resolution: {integrity: sha512-8ujScxg82iqBrNtwL9ciu4XpkbAqoUmYIQN2RvQ+CvPvn6GcRy1SDEuNUwMv59m4fvQkqvLJQzFaxb7KGbjH8w==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -8282,20 +8282,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)
       jiti: 2.6.1
     optionalDependencies:
-      '@tenphi/tasty': 0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+      '@tenphi/tasty': 0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@tenphi/glaze@2.0.0': {}
 
-  '@tenphi/tasty@0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.b9638e2
-        version: 0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.b77b972
+        version: 0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -158,7 +158,7 @@ importers:
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^1.0.5
-        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2186,8 +2186,8 @@ packages:
     resolution: {integrity: sha512-entP+7nsScY87maev/rA6HS/qQy3YwHeywAsWTT9LGhovMp3/cj/Zb1jctlc37FWLim+mkYMwTGOk7ZfJBLLWg==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@0.0.0-snapshot.b9638e2':
-    resolution: {integrity: sha512-8ujScxg82iqBrNtwL9ciu4XpkbAqoUmYIQN2RvQ+CvPvn6GcRy1SDEuNUwMv59m4fvQkqvLJQzFaxb7KGbjH8w==}
+  '@tenphi/tasty@0.0.0-snapshot.b77b972':
+    resolution: {integrity: sha512-zV0dfi7rqqk8PU64VD6QpguMbCeBRQnoGRgeoInXZWnXe9w2n1ZSlftd+syxOzk7OwUaMAuge0G6bMxZ8753sw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -2196,6 +2196,7 @@ packages:
       jiti: ^2.6.1
       next: '>=14.0.0'
       react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -2208,6 +2209,8 @@ packages:
       next:
         optional: true
       react:
+        optional: true
+      react-dom:
         optional: true
 
   '@testing-library/dom@10.4.1':
@@ -8282,20 +8285,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)
       jiti: 2.6.1
     optionalDependencies:
-      '@tenphi/tasty': 0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+      '@tenphi/tasty': 0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@tenphi/glaze@2.0.0': {}
 
-  '@tenphi/tasty@0.0.0-snapshot.b9638e2(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:
@@ -8304,6 +8307,7 @@ snapshots:
       '@babel/types': 7.29.0
       jiti: 2.6.1
       react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@tenphi/tasty':
-        specifier: ^3.5.0
-        version: 3.5.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+        specifier: 0.0.0-snapshot.94660d8
+        version: 0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -158,7 +158,7 @@ importers:
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^1.0.5
-        version: 1.0.5(@tenphi/tasty@3.5.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2186,8 +2186,8 @@ packages:
     resolution: {integrity: sha512-entP+7nsScY87maev/rA6HS/qQy3YwHeywAsWTT9LGhovMp3/cj/Zb1jctlc37FWLim+mkYMwTGOk7ZfJBLLWg==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@3.5.0':
-    resolution: {integrity: sha512-qNdeeiMR1RnQY+yVGR3U1AGqlJBcRYFIGeoemiDZnDXdwVL4NdvTSEw864sj89az0o+47lfWZ2OTwkwOrdy0dw==}
+  '@tenphi/tasty@0.0.0-snapshot.94660d8':
+    resolution: {integrity: sha512-sapZdsxygjwhDDwL85ja3aCZ9u4yhki0rlfSVChZL8faLTDzFlxt6Li1s74LN7eLpfXuyhKqtax8vV25qHQQVg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -8282,20 +8282,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@3.5.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)
       jiti: 2.6.1
     optionalDependencies:
-      '@tenphi/tasty': 3.5.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
+      '@tenphi/tasty': 0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@tenphi/glaze@2.0.0': {}
 
-  '@tenphi/tasty@3.5.0(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.94660d8(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@tenphi/tasty':
-        specifier: 0.0.0-snapshot.b77b972
-        version: 0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 0.0.0-snapshot.04629d1
+        version: 0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
@@ -158,7 +158,7 @@ importers:
         version: 10.3.6(esbuild@0.27.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.2.5)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.6.3)(vite@8.0.0(@types/node@24.13.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.1)(yaml@2.9.0))(webpack@5.76.1(esbuild@0.27.3))
       '@tenphi/eslint-plugin-tasty':
         specifier: ^1.0.5
-        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
+        version: 1.0.5(@tenphi/tasty@0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -2186,8 +2186,8 @@ packages:
     resolution: {integrity: sha512-entP+7nsScY87maev/rA6HS/qQy3YwHeywAsWTT9LGhovMp3/cj/Zb1jctlc37FWLim+mkYMwTGOk7ZfJBLLWg==}
     engines: {node: '>=20'}
 
-  '@tenphi/tasty@0.0.0-snapshot.b77b972':
-    resolution: {integrity: sha512-zV0dfi7rqqk8PU64VD6QpguMbCeBRQnoGRgeoInXZWnXe9w2n1ZSlftd+syxOzk7OwUaMAuge0G6bMxZ8753sw==}
+  '@tenphi/tasty@0.0.0-snapshot.04629d1':
+    resolution: {integrity: sha512-BW/oYXG2zS/BwOpqgTHXI1yQ48AnWvEAYD9SDcaPjyT9tljJo/yD5Jm0K5HtNfuRVjw6k8ud6eucsjFpUpX/fw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@babel/core': ^7.24.0
@@ -8285,20 +8285,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+  '@tenphi/eslint-plugin-tasty@1.0.5(@tenphi/tasty@0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       eslint: 10.8.0(jiti@2.6.1)
       jiti: 2.6.1
     optionalDependencies:
-      '@tenphi/tasty': 0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tenphi/tasty': 0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   '@tenphi/glaze@2.0.0': {}
 
-  '@tenphi/tasty@0.0.0-snapshot.b77b972(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@tenphi/tasty@0.0.0-snapshot.04629d1(@babel/core@7.28.5)(@babel/helper-plugin-utils@7.25.7)(@babel/types@7.29.0)(jiti@2.6.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       csstype: 3.1.2
     optionalDependencies:

--- a/scripts/precompile-app-parity.mjs
+++ b/scripts/precompile-app-parity.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * `precompileStyles()` folds UI Kit's catalog in by default, and must render it
+ * exactly as `precompile-tasty.mjs` does — otherwise an application artifact
+ * would ship different class names for the same kit components than the
+ * published asset, and the two could not be stacked.
+ *
+ * Lives here rather than in the vitest suites because it needs `dist/`: the
+ * catalog imports the built kit, and `pnpm test` does not build.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const shipped = JSON.parse(
+  readFileSync(resolve(ROOT, 'dist/precompiled/manifest.json'), 'utf8'),
+);
+const { precompileStyles } = await import(
+  resolve(ROOT, 'dist/precompile/index.js')
+);
+
+const result = await precompileStyles({ id: '@cube-dev/ui-kit', cases: [] });
+
+const mine = new Map(
+  result.manifest.chunks.map(({ lookupKey, className }) => [
+    lookupKey,
+    className,
+  ]),
+);
+const problems = [];
+
+if (mine.size !== shipped.chunks.length) {
+  problems.push(
+    `chunk count ${mine.size} vs shipped ${shipped.chunks.length}`,
+  );
+}
+for (const { lookupKey, className } of shipped.chunks) {
+  if (mine.get(lookupKey) !== className) {
+    problems.push(
+      `chunk "${lookupKey}" -> ${mine.get(lookupKey) ?? '(missing)'}, shipped ${className}`,
+    );
+  }
+}
+if (result.manifest.cssHash !== shipped.cssHash) {
+  problems.push(
+    `cssHash ${result.manifest.cssHash} vs shipped ${shipped.cssHash}`,
+  );
+}
+
+if (problems.length > 0) {
+  console.error(
+    'precompileStyles() no longer reproduces the shipped catalog:\n  ' +
+      problems.slice(0, 10).join('\n  ') +
+      (problems.length > 10 ? `\n  …and ${problems.length - 10} more` : ''),
+  );
+  process.exit(1);
+}
+
+console.log(
+  `precompileStyles() reproduces the shipped catalog (${mine.size} chunks).`,
+);

--- a/scripts/precompile-parity.browser.jsx
+++ b/scripts/precompile-parity.browser.jsx
@@ -1,10 +1,9 @@
-import { destroy, getCSSText } from '@tenphi/tasty';
-import { registerTastyPrecompiled } from '@tenphi/tasty/precompile/register';
+import css from '@cube-dev/ui-kit/precompiled-styles.css?raw';
+import manifest from '@cube-dev/ui-kit/precompiled-styles/manifest';
+import { destroy, getCSSText, tastyDebug } from '@tenphi/tasty';
 import { cleanup, render } from '@testing-library/react';
 import { afterAll, describe, expect, test } from 'vitest';
 
-import manifest from '../dist/precompiled/manifest.js';
-import css from '../dist/precompiled/styles.css?raw';
 import { Button, Checkbox, Placeholder, Root, TextInput } from '../src/index';
 
 function Example({ marker }) {
@@ -56,17 +55,14 @@ describe('UI Kit precompiled Tasty artifact', () => {
     runtime.unmount();
     destroy();
 
-    const style = document.createElement('style');
-    style.dataset.tastyPrecompiled = manifest.id;
-    style.textContent = css;
-    document.head.append(style);
-    registerTastyPrecompiled(manifest);
+    await import('@cube-dev/ui-kit/precompiled-styles');
 
     const precompiled = render(<Example marker="precompiled" />);
     await settle();
 
     const precompiledStyles = capture(precompiled.container);
     const precompiledCSS = getCSSText();
+    const debugSummary = tastyDebug.summary({ raw: true });
     const buttonClasses = precompiled.container
       .querySelector('[data-parity="button"]')
       .className.split(/\s+/);
@@ -78,16 +74,19 @@ describe('UI Kit precompiled Tasty artifact', () => {
     expect(precompiledStyles).toEqual(runtimeStyles);
     expect(precompiledCSS).toContain('--precompile-parity: precompiled');
     expect(precompiledCSS.length).toBeLessThan(runtimeCSS.length);
+    expect(debugSummary.precompiledCSSSize).toBe(css.length);
+    expect(debugSummary.precompiledRuleCount).toBe(manifest.stats.ruleCount);
     expect(placeholderAnimation).toMatch(/^placeholder-sweep-[a-z0-9]+$/);
     expect(css).toContain(`@keyframes ${placeholderAnimation}`);
-    expect(css).toMatch(/animation-name: refresh-sweep-[a-z0-9]+/);
+    expect(css).toMatch(
+      /animation: refresh-sweep-[a-z0-9]+ 1\.4s linear infinite/,
+    );
     for (const className of buttonClasses) {
       expect(runtimeCSS).toContain(`.${className}`);
       expect(precompiledCSS).not.toContain(`.${className}`);
     }
 
     precompiled.unmount();
-    style.remove();
   });
 });
 

--- a/scripts/precompile-parity.browser.jsx
+++ b/scripts/precompile-parity.browser.jsx
@@ -1,0 +1,97 @@
+import { destroy, getCSSText } from '@tenphi/tasty';
+import { registerTastyPrecompiled } from '@tenphi/tasty/precompile/register';
+import { cleanup, render } from '@testing-library/react';
+import { afterAll, describe, expect, test } from 'vitest';
+
+import manifest from '../dist/precompiled/manifest.js';
+import css from '../dist/precompiled/styles.css?raw';
+import { Button, Checkbox, Placeholder, Root, TextInput } from '../src/index';
+
+function Example({ marker }) {
+  return (
+    <Root fonts={false} bodyStyles={{ '--precompile-parity': marker }}>
+      <Button data-parity="button" theme="danger">
+        Delete
+      </Button>
+      <TextInput data-parity="input" label="Name" defaultValue="Ada" />
+      <Checkbox data-parity="checkbox" defaultSelected>
+        Enabled
+      </Checkbox>
+      <Placeholder data-parity="placeholder" />
+    </Root>
+  );
+}
+
+function capture(container) {
+  return Array.from(container.querySelectorAll('[class]'), (element) => {
+    const computed = getComputedStyle(element);
+
+    return {
+      tag: element.tagName,
+      qa: element.getAttribute('data-qa'),
+      parity: element.getAttribute('data-parity'),
+      className: element.className,
+      display: computed.display,
+      position: computed.position,
+      height: computed.height,
+      padding: computed.padding,
+      borderRadius: computed.borderRadius,
+      animationName: computed.animationName,
+    };
+  });
+}
+
+async function settle() {
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe('UI Kit precompiled Tasty artifact', () => {
+  test('matches runtime computed styles while keeping globals dynamic', async () => {
+    const runtime = render(<Example marker="runtime" />);
+    await settle();
+
+    const runtimeStyles = capture(runtime.container);
+    const runtimeCSS = getCSSText();
+
+    runtime.unmount();
+    destroy();
+
+    const style = document.createElement('style');
+    style.dataset.tastyPrecompiled = manifest.id;
+    style.textContent = css;
+    document.head.append(style);
+    registerTastyPrecompiled(manifest);
+
+    const precompiled = render(<Example marker="precompiled" />);
+    await settle();
+
+    const precompiledStyles = capture(precompiled.container);
+    const precompiledCSS = getCSSText();
+    const buttonClasses = precompiled.container
+      .querySelector('[data-parity="button"]')
+      .className.split(/\s+/);
+
+    const placeholderAnimation = precompiledStyles.find(
+      (item) => item.parity === 'placeholder',
+    ).animationName;
+
+    expect(precompiledStyles).toEqual(runtimeStyles);
+    expect(precompiledCSS).toContain('--precompile-parity: precompiled');
+    expect(precompiledCSS.length).toBeLessThan(runtimeCSS.length);
+    expect(placeholderAnimation).toMatch(/^placeholder-sweep-[a-z0-9]+$/);
+    expect(css).toContain(`@keyframes ${placeholderAnimation}`);
+    expect(css).toMatch(/animation-name: refresh-sweep-[a-z0-9]+/);
+    for (const className of buttonClasses) {
+      expect(runtimeCSS).toContain(`.${className}`);
+      expect(precompiledCSS).not.toContain(`.${className}`);
+    }
+
+    precompiled.unmount();
+    style.remove();
+  });
+});
+
+afterAll(() => {
+  cleanup();
+  destroy();
+});

--- a/scripts/precompile-startup.bench.js
+++ b/scripts/precompile-startup.bench.js
@@ -1,0 +1,42 @@
+import { registerTastyPrecompiled } from '@tenphi/tasty/precompile/register';
+import { bench, describe } from 'vitest';
+
+import manifest from '../dist/precompiled/manifest.js';
+import css from '../dist/precompiled/styles.css?raw';
+
+const parsed = new CSSStyleSheet();
+parsed.replaceSync(css);
+const rules = Array.from(parsed.cssRules, (rule) => rule.cssText);
+
+const registrationStart = performance.now();
+registerTastyPrecompiled(manifest);
+const registrationDuration = performance.now() - registrationStart;
+
+console.log(
+  `Precompiled Tasty manifest registration: ${registrationDuration.toFixed(3)} ms (${manifest.chunks.length} chunks).`,
+);
+
+describe('UI Kit precompiled stylesheet startup', () => {
+  bench('adopt an already parsed static stylesheet', () => {
+    const previous = document.adoptedStyleSheets;
+    document.adoptedStyleSheets = [...previous, parsed];
+    document.adoptedStyleSheets = previous;
+  });
+
+  bench('assign one style.textContent block', () => {
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.append(style);
+    style.remove();
+  });
+
+  bench('CSSStyleSheet.replaceSync', () => {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(css);
+  });
+
+  bench('CSSStyleSheet.insertRule loop', () => {
+    const sheet = new CSSStyleSheet();
+    for (const rule of rules) sheet.insertRule(rule, sheet.cssRules.length);
+  });
+});

--- a/scripts/precompile-tasty-catalog.mjs
+++ b/scripts/precompile-tasty-catalog.mjs
@@ -1,0 +1,730 @@
+import { Fragment, createElement as h } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const BUTTON_THEMES = [
+  'current',
+  'default',
+  'danger',
+  'success',
+  'warning',
+  'note',
+  'special',
+];
+const BUTTON_TYPES = ['primary', 'outline', 'outline-2', 'clear', 'link'];
+const ITEM_ACTION_TYPES = ['primary', 'outline', 'clear'];
+
+function group(...children) {
+  return h(Fragment, null, ...children);
+}
+
+function matrix(Component, values, props = {}) {
+  return values.map((value) =>
+    h(Component, { ...props, ...value, key: JSON.stringify(value) }, 'Example'),
+  );
+}
+
+function item(Component, key, label = String(key)) {
+  return h(Component.Item, { key }, label);
+}
+
+function catalogCase(id, components, render, structuralReason) {
+  return {
+    id,
+    components,
+    structuralReason,
+    async render() {
+      try {
+        const ui = await import('../dist/index.js');
+        return renderToStaticMarkup(
+          h(
+            ui.I18nProvider,
+            null,
+            h(ui.Provider, null, h(ui.OverlayProvider, null, render(ui))),
+          ),
+        );
+      } catch (error) {
+        throw new Error(`UI Kit precompile case "${id}" failed.`, {
+          cause: error,
+        });
+      }
+    },
+  };
+}
+
+export const runtimeOnlyComponents = {
+  AlertDialog:
+    'Its styled subtree is mounted only after the imperative dialog state opens.',
+  Board:
+    'Its external store has no server snapshot and its layout is finalized from browser measurements.',
+  BoardResponsive:
+    'Its breakpoint selection requires ResizeObserver measurements.',
+  BoardWidget:
+    'It renders only inside Board, whose external store and geometry are runtime-only.',
+  DialogContainer:
+    'It mounts a portal only after controlled client state creates a dialog.',
+  DialogForm:
+    'It is covered structurally by Dialog and Form; submission state is runtime-only.',
+  DialogTrigger:
+    'Its dialog subtree is interaction-mounted; the trigger itself is supplied by the caller.',
+  MenuTrigger:
+    'Its menu subtree is interaction-mounted; Menu is cataloged directly.',
+  Notification:
+    'The declarative component registers with the notification store and returns null.',
+  OverlayProvider:
+    'It is a state provider; its styled overlay subtree is covered by notification cases.',
+  Portal: 'It has no styles and needs a browser portal target.',
+  Root: 'It intentionally renders dynamic GlobalStyles, which are excluded from this artifact.',
+  SubMenuTrigger:
+    'Its submenu subtree is interaction-mounted; Menu is cataloged directly.',
+  Toast: 'The imperative component writes to the toast store and returns null.',
+  TooltipProvider:
+    'Its tooltip subtree is interaction-mounted; Tooltip is cataloged directly.',
+  TooltipTrigger:
+    'Its tooltip subtree is interaction-mounted; Tooltip is cataloged directly.',
+};
+
+export const publicStyledComponents = [
+  'Action',
+  'ActiveZone',
+  'Alert',
+  'AlertDialog',
+  'Avatar',
+  'Badge',
+  'Banner',
+  'BannerAction',
+  'BannerLink',
+  'Block',
+  'Board',
+  'BoardResponsive',
+  'BoardWidget',
+  'Button',
+  'ButtonGroup',
+  'ButtonSplit',
+  'Card',
+  'Checkbox',
+  'CheckboxGroup',
+  'ColorInput',
+  'ColorPicker',
+  'ColorSwatch',
+  'ColorSwatchGroup',
+  'ComboBox',
+  'CommandMenu',
+  'CommandTextArea',
+  'Content',
+  'CopyPasteBlock',
+  'CopySnippet',
+  'CubeFullLogo',
+  'CubeLogo',
+  'DataTable',
+  'DateInput',
+  'DatePicker',
+  'DateRangePicker',
+  'DateRangeSeparatedPicker',
+  'Dialog',
+  'DialogContainer',
+  'DialogForm',
+  'DialogTrigger',
+  'Disclosure',
+  'DisplayTransition',
+  'Divider',
+  'FileInput',
+  'FilterListBox',
+  'FilterPicker',
+  'Flex',
+  'Flow',
+  'Footer',
+  'Form',
+  'Grid',
+  'GridLayout',
+  'GridProvider',
+  'Header',
+  'HotKeys',
+  'HueSlider',
+  'IconSwitch',
+  'InfoBadge',
+  'InlineInput',
+  'Input',
+  'Item',
+  'ItemAction',
+  'ItemBadge',
+  'ItemButton',
+  'ItemCard',
+  'ItemTable',
+  'Layout',
+  'Link',
+  'ListBox',
+  'LoadingAnimation',
+  'Menu',
+  'MenuTrigger',
+  'MonthPicker',
+  'NoDataIcon',
+  'Notification',
+  'NotificationAction',
+  'NotificationCard',
+  'NotificationItem',
+  'NumberInput',
+  'OverlayProvider',
+  'Pagination',
+  'Panel',
+  'Paragraph',
+  'PasswordInput',
+  'PeriodPicker',
+  'PersistentNotificationsList',
+  'Picker',
+  'Placeholder',
+  'Portal',
+  'Prefix',
+  'PrismCode',
+  'PrismDiffCode',
+  'QuarterPicker',
+  'Radio',
+  'RadioGroup',
+  'RangeSlider',
+  'ResizablePanel',
+  'Result',
+  'Root',
+  'SearchComboBox',
+  'SearchInput',
+  'Select',
+  'Skeleton',
+  'Slider',
+  'Space',
+  'Spin',
+  'StatsCard',
+  'SubMenuTrigger',
+  'Suffix',
+  'Switch',
+  'Tab',
+  'Tabs',
+  'TabsAction',
+  'Tag',
+  'Text',
+  'TextArea',
+  'TextInput',
+  'TextInputMapper',
+  'TextItem',
+  'TimeInput',
+  'Title',
+  'Toast',
+  'ToastItem',
+  'Tooltip',
+  'TooltipProvider',
+  'TooltipTrigger',
+  'Tree',
+  'WeekPicker',
+  'YearPicker',
+];
+
+export const cases = [
+  catalogCase(
+    'layout/primitives',
+    [
+      'Block',
+      'Grid',
+      'GridProvider',
+      'Flex',
+      'Space',
+      'Flow',
+      'Panel',
+      'Prefix',
+      'Suffix',
+    ],
+    (ui) =>
+      group(
+        h(ui.Block, null, 'Block'),
+        h(ui.Grid, { columns: 2 }, h('span', null, 'A'), h('span', null, 'B')),
+        h(ui.GridProvider, { initialWidth: '400px' }, 'Grid provider'),
+        h(ui.Flex, null, 'Flex'),
+        h(ui.Space, null, 'Space'),
+        h(ui.Flow, null, 'Flow'),
+        h(ui.Panel, null, 'Panel'),
+        h(ui.Prefix, null, 'Prefix'),
+        h(ui.Suffix, null, 'Suffix'),
+      ),
+  ),
+  catalogCase(
+    'layout/content',
+    ['Content', 'Header', 'Footer', 'GridLayout', 'Layout'],
+    (ui) =>
+      group(
+        h(ui.Content, null, 'Content'),
+        h(ui.Header, null, 'Header'),
+        h(ui.Footer, null, 'Footer'),
+        h(ui.GridLayout, null, 'Grid layout'),
+        h(
+          ui.Layout,
+          null,
+          h(ui.Layout.Header, null, 'Header'),
+          h(ui.Layout.Toolbar, null, 'Toolbar'),
+          h(ui.Layout.Content, null, 'Content'),
+          h(ui.Layout.Footer, null, 'Footer'),
+        ),
+      ),
+  ),
+  catalogCase(
+    'typography/all',
+    ['Text', 'TextItem', 'Title', 'Paragraph'],
+    (ui) =>
+      group(
+        h(ui.Text, null, 'Text'),
+        h(ui.TextItem, null, 'Text item'),
+        h(ui.Title, null, 'Title'),
+        h(ui.Paragraph, null, 'Paragraph'),
+      ),
+  ),
+  catalogCase('action/base', ['Action', 'Link'], (ui) =>
+    group(h(ui.Action, null, 'Action'), h(ui.Link, { href: '#' }, 'Link')),
+  ),
+  catalogCase('button/variants', ['Button'], (ui) =>
+    group(
+      ...matrix(
+        ui.Button,
+        BUTTON_THEMES.flatMap((theme) =>
+          BUTTON_TYPES.map((type) => ({ theme, type })),
+        ),
+      ),
+      ...matrix(ui.Button, [
+        { size: 'xsmall' },
+        { size: 'small' },
+        { size: 'medium' },
+        { size: 'large' },
+        { size: 'xlarge' },
+        { size: 'inline' },
+        { isLoading: true },
+        { isSelected: true },
+      ]),
+    ),
+  ),
+  catalogCase('button/compound', ['ButtonGroup', 'ButtonSplit'], (ui) =>
+    group(
+      h(
+        ui.ButtonGroup,
+        null,
+        h(ui.Button, null, 'One'),
+        h(ui.Button, null, 'Two'),
+      ),
+      h(ui.ButtonSplit, null, h(ui.Button, null, 'Split')),
+    ),
+  ),
+  catalogCase('item-action/variants', ['ItemAction'], (ui) =>
+    group(
+      ...matrix(
+        ui.ItemAction,
+        BUTTON_THEMES.flatMap((theme) =>
+          ITEM_ACTION_TYPES.map((type) => ({ theme, type })),
+        ),
+      ),
+      h(ui.ItemAction, { icon: 'checkmark', isSelected: true }, 'Selected'),
+      h(ui.ItemAction, { isLoading: true }, 'Loading'),
+    ),
+  ),
+  catalogCase('item-badge/variants', ['ItemBadge'], (ui) =>
+    group(
+      ...matrix(
+        ui.ItemBadge,
+        ['current', 'default', 'danger', 'success', 'special'].flatMap(
+          (theme) => ITEM_ACTION_TYPES.map((type) => ({ theme, type })),
+        ),
+      ),
+    ),
+  ),
+  catalogCase('item/content', ['Item', 'ItemCard', 'ItemButton'], (ui) =>
+    group(
+      h(ui.Item, null, 'Item'),
+      h(
+        ui.Item,
+        { icon: h(ui.InfoIcon), description: 'Description' },
+        'Detailed',
+      ),
+      h(ui.ItemCard, null, 'Card item'),
+      h(ui.ItemButton, null, 'Button item'),
+    ),
+  ),
+  catalogCase(
+    'banner/variants',
+    ['Banner', 'BannerAction', 'BannerLink'],
+    (ui) =>
+      group(
+        ...['note', 'success', 'warning', 'danger'].map((theme) =>
+          h(
+            ui.Banner,
+            { key: theme, theme },
+            `${theme} banner`,
+            h(ui.BannerAction, null, 'Action'),
+            h(ui.BannerLink, { href: '#' }, 'Link'),
+          ),
+        ),
+      ),
+  ),
+  catalogCase('content/surfaces', ['Card', 'ActiveZone', 'Divider'], (ui) =>
+    group(
+      h(ui.Card, null, 'Card'),
+      h(ui.ActiveZone, null, 'Active zone'),
+      h(ui.Divider),
+    ),
+  ),
+  catalogCase('content/status', ['Alert', 'Badge', 'Tag', 'Result'], (ui) =>
+    group(
+      ...['note', 'success', 'warning', 'danger'].flatMap((theme) => [
+        h(ui.Alert, { key: `alert-${theme}`, theme }, `${theme} alert`),
+        h(ui.Badge, { key: `badge-${theme}`, theme }, theme),
+        h(ui.Tag, { key: `tag-${theme}`, theme }, theme),
+      ]),
+      h(ui.Alert, { shape: 'sharp' }, 'Sharp alert'),
+      h(ui.Result, { status: 'success', title: 'Complete' }),
+    ),
+  ),
+  catalogCase(
+    'content/feedback',
+    ['Avatar', 'InfoBadge', 'Placeholder', 'Skeleton'],
+    (ui) =>
+      group(
+        h(ui.Avatar, { name: 'Ada Lovelace' }),
+        h(ui.InfoBadge, null, 'Information'),
+        h(ui.Placeholder),
+        h(ui.Placeholder, { circle: true, isStatic: true }),
+        h(ui.Skeleton, null, h(ui.Skeleton.Text, { lines: 2 })),
+      ),
+  ),
+  catalogCase('content/code', ['PrismCode', 'PrismDiffCode'], (ui) =>
+    group(
+      h(ui.PrismCode, { code: 'const value = 1;', language: 'javascript' }),
+      h(ui.PrismDiffCode, {
+        original: 'const value = 1;',
+        modified: 'const value = 2;',
+        language: 'javascript',
+      }),
+    ),
+  ),
+  catalogCase('content/copy', ['CopySnippet', 'CopyPasteBlock'], (ui) =>
+    group(
+      h(ui.CopySnippet, { text: 'copy me' }),
+      h(ui.CopyPasteBlock, { value: 'copy me' }),
+    ),
+  ),
+  catalogCase('content/inline', ['InlineInput', 'HotKeys'], (ui) =>
+    group(
+      h(ui.InlineInput, { defaultValue: 'Editable' }),
+      h(ui.HotKeys, null, '⌘ K'),
+    ),
+  ),
+  catalogCase('content/disclosure', ['Disclosure'], (ui) =>
+    h(
+      ui.Disclosure.Group,
+      { defaultExpandedKeys: ['one'] },
+      h(ui.Disclosure, { id: 'one', title: 'Details' }, 'Expanded content'),
+      h(ui.Disclosure, { id: 'two', title: 'More' }, 'More content'),
+    ),
+  ),
+  catalogCase('content/tree', ['Tree'], (ui) =>
+    h(ui.Tree, {
+      treeData: [
+        {
+          key: 'src',
+          title: 'src',
+          children: [
+            { key: 'index', title: 'index.ts' },
+            { key: 'button', title: 'Button.tsx' },
+          ],
+        },
+      ],
+      defaultExpandedKeys: ['src'],
+      isCheckable: true,
+    }),
+  ),
+  catalogCase(
+    'field/text',
+    ['Input', 'TextInput', 'TextArea', 'PasswordInput'],
+    (ui) =>
+      group(
+        h(ui.Input, { 'aria-label': 'Input', defaultValue: 'Value' }),
+        h(ui.TextInput, { label: 'Text input', defaultValue: 'Value' }),
+        h(ui.TextArea, { label: 'Text area', defaultValue: 'Value' }),
+        h(ui.PasswordInput, { label: 'Password', defaultValue: 'secret' }),
+      ),
+  ),
+  catalogCase('field/search-number', ['SearchInput', 'NumberInput'], (ui) =>
+    group(
+      h(ui.SearchInput, { 'aria-label': 'Search', defaultValue: 'Query' }),
+      h(ui.NumberInput, { label: 'Count', defaultValue: 42 }),
+    ),
+  ),
+  catalogCase(
+    'field/choice',
+    ['Checkbox', 'CheckboxGroup', 'Radio', 'RadioGroup', 'Switch'],
+    (ui) =>
+      group(
+        h(ui.Checkbox, { defaultSelected: true }, 'Checkbox'),
+        h(
+          ui.CheckboxGroup,
+          { label: 'Checkbox group', defaultValue: ['one'] },
+          h(ui.Checkbox, { value: 'one' }, 'One'),
+          h(ui.Checkbox, { value: 'two' }, 'Two'),
+        ),
+        h(
+          ui.RadioGroup,
+          { label: 'Radio group', defaultValue: 'one' },
+          h(ui.Radio, { value: 'one' }, 'One'),
+          h(ui.Radio, { value: 'two' }, 'Two'),
+        ),
+        h(ui.Switch, { defaultSelected: true }, 'Switch'),
+      ),
+  ),
+  catalogCase('field/slider', ['Slider', 'RangeSlider', 'HueSlider'], (ui) =>
+    group(
+      h(ui.Slider, { label: 'Slider', defaultValue: 40 }),
+      h(ui.RangeSlider, { label: 'Range', defaultValue: [20, 80] }),
+      h(ui.HueSlider, { 'aria-label': 'Hue', defaultValue: 180 }),
+    ),
+  ),
+  catalogCase('field/select', ['Select', 'ListBox'], (ui) =>
+    group(
+      h(
+        ui.Select,
+        { label: 'Select', defaultSelectedKey: 'one' },
+        item(ui.Select, 'one', 'One'),
+        item(ui.Select, 'two', 'Two'),
+      ),
+      h(
+        ui.ListBox,
+        { 'aria-label': 'List box', selectionMode: 'single' },
+        item(ui.ListBox, 'one', 'One'),
+        item(ui.ListBox, 'two', 'Two'),
+      ),
+    ),
+  ),
+  catalogCase(
+    'field/combo',
+    ['ComboBox', 'SearchComboBox'],
+    (ui) =>
+      group(
+        h(
+          ui.ComboBox,
+          { label: 'Combo box' },
+          item(ui.ComboBox, 'one', 'One'),
+          item(ui.ComboBox, 'two', 'Two'),
+        ),
+        h(
+          ui.SearchComboBox,
+          { label: 'Search combo' },
+          item(ui.SearchComboBox, 'one', 'One'),
+          item(ui.SearchComboBox, 'two', 'Two'),
+        ),
+      ),
+    'Retained as the required public defaults; their styled input and list primitives are already introduced by earlier field cases.',
+  ),
+  catalogCase(
+    'field/pickers',
+    ['Picker', 'FilterPicker', 'FilterListBox'],
+    (ui) =>
+      group(
+        h(
+          ui.Picker,
+          { label: 'Picker', defaultSelectedKey: 'one' },
+          item(ui.Picker, 'one', 'One'),
+          item(ui.Picker, 'two', 'Two'),
+        ),
+        h(
+          ui.FilterPicker,
+          { label: 'Filter picker', defaultSelectedKeys: ['one'] },
+          item(ui.FilterPicker, 'one', 'One'),
+          item(ui.FilterPicker, 'two', 'Two'),
+        ),
+        h(
+          ui.FilterListBox,
+          { 'aria-label': 'Filter list', defaultSelectedKeys: ['one'] },
+          item(ui.FilterListBox, 'one', 'One'),
+          item(ui.FilterListBox, 'two', 'Two'),
+        ),
+      ),
+  ),
+  catalogCase(
+    'field/color',
+    ['ColorInput', 'ColorPicker', 'ColorSwatch', 'ColorSwatchGroup'],
+    (ui) =>
+      group(
+        h(ui.ColorInput, { label: 'Color', defaultValue: '#7a4dbf' }),
+        h(ui.ColorPicker, { label: 'Color picker', defaultValue: '#7a4dbf' }),
+        h(ui.ColorSwatch, { color: '#7a4dbf' }),
+        h(
+          ui.ColorSwatchGroup,
+          { 'aria-label': 'Colors', defaultValue: '#7a4dbf' },
+          h(ui.ColorSwatch, { color: '#7a4dbf' }),
+          h(ui.ColorSwatch, { color: '#26fcb2' }),
+        ),
+      ),
+  ),
+  catalogCase('field/date-inputs', ['DateInput', 'TimeInput'], (ui) => {
+    const date = new ui.CalendarDate(2026, 8, 30);
+    return group(
+      h(ui.DateInput, { label: 'Date', defaultValue: date }),
+      h(ui.TimeInput, { label: 'Time' }),
+    );
+  }),
+  catalogCase(
+    'field/date-pickers',
+    ['DatePicker', 'DateRangePicker', 'DateRangeSeparatedPicker'],
+    (ui) => {
+      const start = new ui.CalendarDate(2026, 8, 30);
+      const end = new ui.CalendarDate(2026, 9, 2);
+      return group(
+        h(ui.DatePicker, { label: 'Date picker', defaultValue: start }),
+        h(ui.DateRangePicker, { label: 'Range', defaultValue: { start, end } }),
+        h(ui.DateRangeSeparatedPicker, {
+          label: 'Separated range',
+          defaultValue: { start, end },
+        }),
+      );
+    },
+  ),
+  catalogCase(
+    'field/period-pickers',
+    [
+      'PeriodPicker',
+      'MonthPicker',
+      'QuarterPicker',
+      'WeekPicker',
+      'YearPicker',
+    ],
+    (ui) => {
+      const date = new ui.CalendarDate(2026, 8, 30);
+      return group(
+        h(ui.PeriodPicker, { label: 'Period', defaultValue: date }),
+        h(ui.MonthPicker, { label: 'Month', defaultValue: date }),
+        h(ui.QuarterPicker, { label: 'Quarter', defaultValue: date }),
+        h(ui.WeekPicker, { label: 'Week', defaultValue: date }),
+        h(ui.YearPicker, { label: 'Year', defaultValue: date }),
+      );
+    },
+  ),
+  catalogCase('field/file-command', ['FileInput', 'CommandTextArea'], (ui) =>
+    group(
+      h(ui.FileInput, { label: 'File' }),
+      h(ui.CommandTextArea, { label: 'Command', commands: [] }),
+    ),
+  ),
+  catalogCase('field/mapper', ['TextInputMapper'], (ui) =>
+    h(ui.TextInputMapper, { label: 'Mapper', defaultValue: [] }),
+  ),
+  catalogCase('form/default', ['Form'], (ui) =>
+    h(ui.Form, null, h(ui.TextInput, { name: 'name', label: 'Name' })),
+  ),
+  catalogCase('navigation/tabs', ['Tabs', 'Tab', 'TabsAction'], (ui) =>
+    h(
+      ui.Tabs,
+      { defaultSelectedKey: 'one' },
+      h(ui.Tab, { id: 'one', title: 'One' }, 'First panel'),
+      h(ui.Tab, { id: 'two', title: 'Two' }, 'Second panel'),
+      h(ui.TabsAction, null, 'Action'),
+    ),
+  ),
+  catalogCase('navigation/pagination', ['Pagination'], (ui) =>
+    h(ui.Pagination, { page: 2, total: 10, onChange: () => {} }),
+  ),
+  catalogCase('overlay/menu', ['Menu', 'CommandMenu'], (ui) =>
+    group(
+      h(
+        ui.Menu,
+        { 'aria-label': 'Menu' },
+        item(ui.Menu, 'one', 'One'),
+        item(ui.Menu, 'two', 'Two'),
+      ),
+      h(ui.CommandMenu, { items: [{ id: 'one', name: 'One' }] }),
+    ),
+  ),
+  catalogCase('overlay/dialog', ['Dialog'], (ui) =>
+    h(ui.Dialog, { title: 'Dialog' }, 'Dialog content'),
+  ),
+  catalogCase('overlay/tooltip', ['Tooltip'], (ui) =>
+    group(
+      h(ui.Tooltip, null, 'Tooltip'),
+      h(ui.Tooltip, { type: 'light' }, 'Light tooltip'),
+    ),
+  ),
+  catalogCase(
+    'notification/cards',
+    [
+      'NotificationCard',
+      'NotificationItem',
+      'NotificationAction',
+      'PersistentNotificationsList',
+      'ToastItem',
+    ],
+    (ui) =>
+      group(
+        h(ui.NotificationCard, {
+          id: 'notice',
+          title: 'Notification',
+          description: 'Description',
+        }),
+        h(ui.NotificationItem, {
+          notification: {
+            id: 'item',
+            internalId: 'item',
+            title: 'Item',
+            description: 'Description',
+          },
+          onDismiss: () => {},
+        }),
+        h(ui.NotificationAction, null, 'Action'),
+        h(ui.PersistentNotificationsList, { emptyState: 'No notifications' }),
+        h(ui.ToastItem, { title: 'Toast', description: 'Description' }),
+      ),
+  ),
+  catalogCase('status/all', ['Spin', 'LoadingAnimation'], (ui) =>
+    group(h(ui.Spin), h(ui.LoadingAnimation)),
+  ),
+  catalogCase('other/logos', ['CubeLogo', 'CubeFullLogo', 'NoDataIcon'], (ui) =>
+    group(h(ui.CubeLogo), h(ui.CubeFullLogo), h(ui.NoDataIcon)),
+  ),
+  catalogCase(
+    'helpers/all',
+    ['DisplayTransition', 'IconSwitch'],
+    (ui) =>
+      group(
+        h(
+          ui.DisplayTransition,
+          { isShown: true, animateOnMount: false },
+          ({ phase, ref }) => h('div', { ref, 'data-phase': phase }, 'Visible'),
+        ),
+        h(ui.IconSwitch, null, h(ui.InfoIcon)),
+      ),
+    'Retained as the required public defaults; DisplayTransition is style-free and IconSwitch is already covered inside earlier components.',
+  ),
+  catalogCase('organism/stats-card', ['StatsCard'], (ui) =>
+    h(ui.StatsCard, { title: 'Revenue', value: '$42k' }),
+  ),
+  catalogCase('layout/resizable-panel', ['ResizablePanel'], (ui) =>
+    h(ui.ResizablePanel, { size: 240 }, 'Resizable'),
+  ),
+  catalogCase('data/tables', ['DataTable', 'ItemTable'], (ui) => {
+    const data = [
+      { id: 'one', name: 'Alpha', count: 42 },
+      { id: 'two', name: 'Beta', count: 7 },
+    ];
+    const columns = [
+      { key: 'name', title: 'Name', isRowHeader: true },
+      { key: 'count', title: 'Count', dataType: 'number' },
+    ];
+    return group(
+      h(ui.DataTable, {
+        data,
+        columns,
+        ariaLabel: 'Data table',
+        isLoading: true,
+      }),
+      h(ui.ItemTable, { data, columns, ariaLabel: 'Item table' }),
+    );
+  }),
+];
+
+const coveredComponents = new Set(cases.flatMap((item) => item.components));
+const missingComponents = publicStyledComponents.filter(
+  (name) => !coveredComponents.has(name) && !(name in runtimeOnlyComponents),
+);
+
+if (missingComponents.length > 0) {
+  throw new Error(
+    `Precompiled catalog coverage is missing: ${missingComponents.join(', ')}`,
+  );
+}

--- a/scripts/precompile-tasty-catalog.mjs
+++ b/scripts/precompile-tasty-catalog.mjs
@@ -1,5 +1,4 @@
 import { Fragment, createElement as h } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 
 const BUTTON_THEMES = [
   'current',
@@ -35,12 +34,10 @@ function catalogCase(id, components, render, structuralReason) {
     async render() {
       try {
         const ui = await import('../dist/index.js');
-        return renderToStaticMarkup(
-          h(
-            ui.I18nProvider,
-            null,
-            h(ui.Provider, null, h(ui.OverlayProvider, null, render(ui))),
-          ),
+        return h(
+          ui.I18nProvider,
+          null,
+          h(ui.Provider, null, h(ui.OverlayProvider, null, render(ui))),
         );
       } catch (error) {
         throw new Error(`UI Kit precompile case "${id}" failed.`, {

--- a/scripts/precompile-tasty.mjs
+++ b/scripts/precompile-tasty.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { precompileTastyStyles } from '@tenphi/tasty/precompile';
+
+import {
+  cases,
+  publicStyledComponents,
+  runtimeOnlyComponents,
+} from './precompile-tasty-catalog.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const OUTPUT = resolve(ROOT, 'dist/precompiled');
+
+function json(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+const result = await precompileTastyStyles({
+  id: '@cube-dev/ui-kit',
+  cases,
+});
+
+const report = {
+  tastyVersion: result.manifest.tastyVersion,
+  catalogCases: result.report.map((item, index) => ({
+    ...item,
+    structuralReason: cases[index].structuralReason,
+  })),
+  catalogedComponents: publicStyledComponents.filter(
+    (name) => !(name in runtimeOnlyComponents),
+  ),
+  runtimeOnlyComponents,
+};
+
+const manifestSource = `const manifest = ${JSON.stringify(result.manifest, null, 2)};\n\nexport default manifest;\n`;
+const registerSource = `import { registerTastyPrecompiled } from '@tenphi/tasty/precompile/register';\nimport manifest from './manifest.js';\n\nregisterTastyPrecompiled(manifest);\n\nexport * from '../index.js';\n`;
+const indexSource = `import './register.js';\nimport './styles.css';\n\nexport * from './register.js';\n`;
+const manifestTypes = `import type { TastyPrecompiledManifest } from '@tenphi/tasty/precompile/register';\n\ndeclare const manifest: TastyPrecompiledManifest;\nexport default manifest;\n`;
+
+await mkdir(OUTPUT, { recursive: true });
+await Promise.all([
+  writeFile(resolve(OUTPUT, 'styles.css'), result.css),
+  writeFile(resolve(OUTPUT, 'manifest.json'), json(result.manifest)),
+  writeFile(resolve(OUTPUT, 'manifest.js'), manifestSource),
+  writeFile(resolve(OUTPUT, 'manifest.d.ts'), manifestTypes),
+  writeFile(resolve(OUTPUT, 'register.js'), registerSource),
+  writeFile(resolve(OUTPUT, 'index.js'), indexSource),
+  writeFile(resolve(OUTPUT, 'report.json'), json(report)),
+]);
+
+console.log(
+  `Precompiled ${result.manifest.chunks.length} Tasty chunks from ${cases.length} catalog cases (${result.css.length} CSS bytes).`,
+);

--- a/scripts/precompile-tasty.mjs
+++ b/scripts/precompile-tasty.mjs
@@ -36,9 +36,10 @@ const report = {
 };
 
 const manifestSource = `const manifest = ${JSON.stringify(result.manifest, null, 2)};\n\nexport default manifest;\n`;
-const registerSource = `import { registerTastyPrecompiled } from '@tenphi/tasty/precompile/register';\nimport manifest from './manifest.js';\n\nregisterTastyPrecompiled(manifest);\n\nexport * from '../index.js';\n`;
-const indexSource = `import './register.js';\nimport './styles.css';\n\nexport * from './register.js';\n`;
+const registerSource = `import { registerTastyPrecompiled } from '@tenphi/tasty/precompile/register';\nimport manifest from './manifest.js';\n\nregisterTastyPrecompiled(manifest);\n`;
+const indexSource = `import './register.js';\nimport './styles.css';\n`;
 const manifestTypes = `import type { TastyPrecompiledManifest } from '@tenphi/tasty/precompile/register';\n\ndeclare const manifest: TastyPrecompiledManifest;\nexport default manifest;\n`;
+const sideEffectTypes = `export {};\n`;
 
 await mkdir(OUTPUT, { recursive: true });
 await Promise.all([
@@ -47,7 +48,10 @@ await Promise.all([
   writeFile(resolve(OUTPUT, 'manifest.js'), manifestSource),
   writeFile(resolve(OUTPUT, 'manifest.d.ts'), manifestTypes),
   writeFile(resolve(OUTPUT, 'register.js'), registerSource),
+  writeFile(resolve(OUTPUT, 'register.d.ts'), sideEffectTypes),
   writeFile(resolve(OUTPUT, 'index.js'), indexSource),
+  writeFile(resolve(OUTPUT, 'index.d.ts'), sideEffectTypes),
+  writeFile(resolve(OUTPUT, 'styles.d.ts'), sideEffectTypes),
   writeFile(resolve(OUTPUT, 'report.json'), json(report)),
 ]);
 

--- a/scripts/precompile-tasty.mjs
+++ b/scripts/precompile-tasty.mjs
@@ -11,6 +11,13 @@ import {
   runtimeOnlyComponents,
 } from './precompile-tasty-catalog.mjs';
 
+// Apply UI Kit's own `configure()` before compiling. The catalog imports the
+// kit lazily inside each case, so without this the manifest would record the
+// configuration as it stood before the kit set up its units and recipes — and a
+// consumer overriding one of those recipes would not be detected as a
+// divergence.
+await import('../dist/index.js');
+
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const OUTPUT = resolve(ROOT, 'dist/precompiled');
 

--- a/src/components/content/Placeholder/Placeholder.tsx
+++ b/src/components/content/Placeholder/Placeholder.tsx
@@ -3,7 +3,6 @@ import {
   CONTAINER_STYLES,
   ContainerStyleProps,
   filterBaseProps,
-  keyframes,
   Styles,
   tasty,
 } from '@tenphi/tasty';
@@ -12,20 +11,20 @@ import { forwardRef } from 'react';
 import { useI18n } from '../../../i18n';
 import { extractStyles } from '../../../utils/styles';
 
-// Create the placeholder animation using keyframes helper
-const placeholderAnimation = keyframes({
-  '0%': {
-    'background-position': '0 0',
-  },
-  '100%': {
-    'background-position': '$placeholder-animation-size 0',
-  },
-});
-
 const StyledPlaceholder = tasty({
   role: 'alert',
   'aria-live': 'polite',
   styles: {
+    '@keyframes': {
+      'placeholder-sweep': {
+        '0%': {
+          'background-position': '0 0',
+        },
+        '100%': {
+          'background-position': '$placeholder-animation-size 0',
+        },
+      },
+    },
     display: 'block',
     height: '2x',
     opacity: '.35',
@@ -48,10 +47,13 @@ const StyledPlaceholder = tasty({
     fill: '#dark.15',
 
     // Animated state styling
-    animation: {
+    animationName: {
       '': 'none',
-      animated: `${placeholderAnimation} $placeholder-animation-time linear infinite`,
+      animated: 'placeholder-sweep',
     },
+    animationDuration: '$placeholder-animation-time',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
     image: {
       '': 'none',
       animated: `linear-gradient(

--- a/src/components/content/Placeholder/Placeholder.tsx
+++ b/src/components/content/Placeholder/Placeholder.tsx
@@ -47,13 +47,10 @@ const StyledPlaceholder = tasty({
     fill: '#dark.15',
 
     // Animated state styling
-    animationName: {
+    animation: {
       '': 'none',
-      animated: 'placeholder-sweep',
+      animated: 'placeholder-sweep $placeholder-animation-time linear infinite',
     },
-    animationDuration: '$placeholder-animation-time',
-    animationIterationCount: 'infinite',
-    animationTimingFunction: 'linear',
     image: {
       '': 'none',
       animated: `linear-gradient(

--- a/src/components/content/use-auto-tooltip.browser.test.tsx
+++ b/src/components/content/use-auto-tooltip.browser.test.tsx
@@ -217,6 +217,41 @@ describe('useAutoTooltip overflow measurement', () => {
       );
     });
 
+    /**
+     * The condition that kept failing in Chromatic while passing everywhere
+     * else: observer callbacks are delivered as part of the rendering steps, so
+     * a runner that is not producing frames — a background tab, or a headless
+     * browser running a thousand stories at once — can delay them past the
+     * point the play function hovers and asks for the tooltip. An
+     * implementation that leans on the observer's first delivery for the
+     * initial measurement is only as reliable as the runner's frame loop.
+     */
+    it('activates without the observer ever firing', async () => {
+      const RealResizeObserver = window.ResizeObserver;
+
+      // Records the observation but never delivers a callback.
+      window.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof RealResizeObserver;
+
+      try {
+        await act(async () => {
+          renderWithRoot(<RemountProbe />);
+        });
+
+        await waitFor(() => {
+          expect(screen.getByTestId('Status')).toHaveAttribute(
+            'data-active',
+            'true',
+          );
+        });
+      } finally {
+        window.ResizeObserver = RealResizeObserver;
+      }
+    });
+
     it('re-measures when the label is resized', async () => {
       function Resizable() {
         const [width, setWidth] = useState('600px');

--- a/src/components/content/use-auto-tooltip.browser.test.tsx
+++ b/src/components/content/use-auto-tooltip.browser.test.tsx
@@ -252,6 +252,73 @@ describe('useAutoTooltip overflow measurement', () => {
       }
     });
 
+    /**
+     * `isAutoTooltipEnabled` requires string children, and the label unmounts
+     * when children stop being a string — the default `Button` path, since
+     * `tooltip` defaults to `true`. Flipping it changes the callback ref's
+     * identity, so React detaches with the previous callback (which still sees
+     * auto tooltips as on, and preserves the verdict) and never attaches the
+     * new one, because the label is gone. Without the effect clearing it, the
+     * stale `true` keeps a tooltip mounted over content that is no longer text.
+     */
+    it('drops the verdict when children stop being a string', async () => {
+      function Switchable() {
+        const [asNode, setAsNode] = useState(false);
+        const { labelRef, isTooltipActive, renderWithTooltip } = useAutoTooltip(
+          {
+            tooltip: true,
+            children: asNode ? <span>{LONG_LABEL}</span> : LONG_LABEL,
+            labelProps: undefined,
+          },
+        );
+
+        return (
+          <div style={{ width: '80px' }}>
+            <button type="button" onClick={() => setAsNode(true)}>
+              To node
+            </button>
+            <span data-qa="Status" data-active={String(isTooltipActive)} />
+            {renderWithTooltip(
+              () =>
+                asNode ? (
+                  <div>{LONG_LABEL}</div>
+                ) : (
+                  <div
+                    ref={labelRef as never}
+                    style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
+                  >
+                    {LONG_LABEL}
+                  </div>
+                ),
+              'top',
+            )}
+          </div>
+        );
+      }
+
+      await act(async () => {
+        renderWithRoot(<Switchable />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('Status')).toHaveAttribute(
+          'data-active',
+          'true',
+        );
+      });
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'To node' }).click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('Status')).toHaveAttribute(
+          'data-active',
+          'false',
+        );
+      });
+    });
+
     it('re-measures when the label is resized', async () => {
       function Resizable() {
         const [width, setWidth] = useState('600px');

--- a/src/components/content/use-auto-tooltip.browser.test.tsx
+++ b/src/components/content/use-auto-tooltip.browser.test.tsx
@@ -66,33 +66,39 @@ describe('useAutoTooltip overflow measurement', () => {
     spy.restore();
   });
 
-  it('does not measure during the commit that attaches the label ref', async () => {
-    // Sampled from a layout effect, which React runs in the same commit phase
-    // as ref attachment and after the children's refs are attached.
-    let readsDuringCommit = -1;
+  // Mounting Root plus a handful of Buttons is well under a second locally but
+  // has run past the 15s default on a cold CI runner.
+  it(
+    'does not measure during the commit that attaches the label ref',
+    { timeout: 60_000 },
+    async () => {
+      // Sampled from a layout effect, which React runs in the same commit phase
+      // as ref attachment and after the children's refs are attached.
+      let readsDuringCommit = -1;
 
-    function Harness() {
-      useLayoutEffect(() => {
-        readsDuringCommit = spy.counter.reads;
-      }, []);
+      function Harness() {
+        useLayoutEffect(() => {
+          readsDuringCommit = spy.counter.reads;
+        }, []);
 
-      return (
-        <div style={{ width: '80px' }}>
-          {Array.from({ length: 12 }, (_, i) => (
-            <Button key={i} tooltip width="80px">
-              {`${LONG_LABEL} ${i}`}
-            </Button>
-          ))}
-        </div>
-      );
-    }
+        return (
+          <div style={{ width: '80px' }}>
+            {Array.from({ length: 6 }, (_, i) => (
+              <Button key={i} tooltip width="80px">
+                {`${LONG_LABEL} ${i}`}
+              </Button>
+            ))}
+          </div>
+        );
+      }
 
-    await act(async () => {
-      renderWithRoot(<Harness />);
-    });
+      await act(async () => {
+        renderWithRoot(<Harness />);
+      });
 
-    expect(readsDuringCommit).toBe(0);
-  });
+      expect(readsDuringCommit).toBe(0);
+    },
+  );
 
   describe('still measures overflow off the commit path', () => {
     /** Exposes the hook's overflow verdict, with the label it measures. */

--- a/src/components/content/use-auto-tooltip.browser.test.tsx
+++ b/src/components/content/use-auto-tooltip.browser.test.tsx
@@ -149,6 +149,74 @@ describe('useAutoTooltip overflow measurement', () => {
       expect(label()).toHaveAttribute('data-tooltip-active', 'false');
     });
 
+    /**
+     * Regression guard for the provider-remount cycle.
+     *
+     * Real consumers differ from the Probe above in two ways that matter, and
+     * together they broke the first version of this fix: `TextItem` and friends
+     * build their callback ref inline, so React detaches and re-attaches on
+     * every render, and turning the verdict on mounts `TooltipProvider`, which
+     * remounts the label underneath it. Clearing the verdict when the node goes
+     * away therefore undoes the measurement that had just been made, and the
+     * tooltip never activates — five Chromatic stories, none of them visible to
+     * a stable-ref probe.
+     *
+     * The status element sits outside the provider so it survives the remount.
+     */
+    function RemountProbe() {
+      const { labelRef, isTooltipActive, renderWithTooltip } = useAutoTooltip({
+        tooltip: true,
+        children: LONG_LABEL,
+        labelProps: undefined,
+      });
+
+      return (
+        <div style={{ width: '80px' }}>
+          <span data-qa="Status" data-active={String(isTooltipActive)} />
+          {renderWithTooltip(
+            (triggerProps, ref) => (
+              <div
+                {...triggerProps}
+                // Inline, so its identity changes every render — exactly what
+                // TextItem, Item and Button's own wrappers do.
+                ref={(element: HTMLElement | null) => {
+                  if (ref) (ref as { current: unknown }).current = element;
+                  labelRef(element);
+                }}
+                data-qa="RemountLabel"
+                style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
+              >
+                {LONG_LABEL}
+              </div>
+            ),
+            'top',
+          )}
+        </div>
+      );
+    }
+
+    it('activates the tooltip even though mounting it remounts the label', async () => {
+      await act(async () => {
+        renderWithRoot(<RemountProbe />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('Status')).toHaveAttribute(
+          'data-active',
+          'true',
+        );
+      });
+
+      // And stays active rather than being undone by the remount it caused.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 400));
+      });
+      expect(screen.getByTestId('Status')).toHaveAttribute(
+        'data-active',
+        'true',
+      );
+    });
+
     it('re-measures when the label is resized', async () => {
       function Resizable() {
         const [width, setWidth] = useState('600px');

--- a/src/components/content/use-auto-tooltip.browser.test.tsx
+++ b/src/components/content/use-auto-tooltip.browser.test.tsx
@@ -1,0 +1,176 @@
+import { useLayoutEffect, useState } from 'react';
+
+import { act, renderWithRoot, screen, waitFor } from '../../test';
+import { Button } from '../actions/Button/Button';
+
+import { useAutoTooltip } from './use-auto-tooltip';
+
+/**
+ * Counts reads of `scrollWidth` / `clientWidth` on real elements.
+ *
+ * Both accessors flush style and layout, so a read from inside React's commit
+ * is a forced synchronous reflow.
+ */
+function spyOnLayoutReads() {
+  const proto = Element.prototype;
+  const originals = (['scrollWidth', 'clientWidth'] as const).map(
+    (name) => [name, Object.getOwnPropertyDescriptor(proto, name)!] as const,
+  );
+  const counter = { reads: 0 };
+
+  for (const [name, descriptor] of originals) {
+    Object.defineProperty(proto, name, {
+      ...descriptor,
+      get(this: Element) {
+        counter.reads++;
+        return descriptor.get!.call(this);
+      },
+    });
+  }
+
+  return {
+    counter,
+    restore: () =>
+      originals.forEach(([name, descriptor]) =>
+        Object.defineProperty(proto, name, descriptor),
+      ),
+  };
+}
+
+const LONG_LABEL = 'A label far too long to ever fit inside this narrow box';
+
+/**
+ * Auto-tooltip overflow measurement, in a real browser.
+ *
+ * `scrollWidth`/`clientWidth` only mean something where there is layout — jsdom
+ * reports 0 for both, so it can neither tell an overflowing label from a
+ * fitting one nor see when the measurement happens. It also stubs
+ * `ResizeObserver` to a no-op, which is the very mechanism under test.
+ *
+ * The measurement used to run synchronously inside the callback ref, which
+ * React invokes during `commitAttachRef`. Every tooltip-bearing Button, Item
+ * and TextItem therefore forced its own style recalc and layout mid-commit —
+ * 122ms of `get scrollWidth` in one Cloud profile, more than the whole style
+ * engine cost, and 80% of that page's style recalcs were JS-forced. The read
+ * belongs off the commit path; the ResizeObserver's initial delivery still
+ * runs before paint, so nothing flashes.
+ */
+describe('useAutoTooltip overflow measurement', () => {
+  let spy: ReturnType<typeof spyOnLayoutReads>;
+
+  beforeEach(() => {
+    spy = spyOnLayoutReads();
+  });
+
+  afterEach(() => {
+    spy.restore();
+  });
+
+  it('does not measure during the commit that attaches the label ref', async () => {
+    // Sampled from a layout effect, which React runs in the same commit phase
+    // as ref attachment and after the children's refs are attached.
+    let readsDuringCommit = -1;
+
+    function Harness() {
+      useLayoutEffect(() => {
+        readsDuringCommit = spy.counter.reads;
+      }, []);
+
+      return (
+        <div style={{ width: '80px' }}>
+          {Array.from({ length: 12 }, (_, i) => (
+            <Button key={i} tooltip width="80px">
+              {`${LONG_LABEL} ${i}`}
+            </Button>
+          ))}
+        </div>
+      );
+    }
+
+    await act(async () => {
+      renderWithRoot(<Harness />);
+    });
+
+    expect(readsDuringCommit).toBe(0);
+  });
+
+  describe('still measures overflow off the commit path', () => {
+    /** Exposes the hook's overflow verdict, with the label it measures. */
+    function Probe({ width, label }: { width: string; label: string }) {
+      const { labelRef, isLabelOverflowed, isTooltipActive } = useAutoTooltip({
+        tooltip: true,
+        children: label,
+        labelProps: undefined,
+      });
+
+      return (
+        <div style={{ width }}>
+          <div
+            ref={labelRef as never}
+            data-qa="Label"
+            data-overflowed={String(isLabelOverflowed)}
+            data-tooltip-active={String(isTooltipActive)}
+            style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}
+          >
+            {label}
+          </div>
+        </div>
+      );
+    }
+
+    const label = () => screen.getByTestId('Label');
+
+    it('detects an overflowing label and activates its tooltip', async () => {
+      await act(async () => {
+        renderWithRoot(<Probe width="80px" label={LONG_LABEL} />);
+      });
+
+      await waitFor(() => {
+        expect(label()).toHaveAttribute('data-overflowed', 'true');
+      });
+      expect(label()).toHaveAttribute('data-tooltip-active', 'true');
+      expect(spy.counter.reads).toBeGreaterThan(0);
+    });
+
+    it('leaves a label that fits alone', async () => {
+      await act(async () => {
+        renderWithRoot(<Probe width="600px" label="Short" />);
+      });
+
+      await waitFor(() => expect(spy.counter.reads).toBeGreaterThan(0));
+
+      expect(label()).toHaveAttribute('data-overflowed', 'false');
+      expect(label()).toHaveAttribute('data-tooltip-active', 'false');
+    });
+
+    it('re-measures when the label is resized', async () => {
+      function Resizable() {
+        const [width, setWidth] = useState('600px');
+
+        return (
+          <>
+            <button type="button" onClick={() => setWidth('80px')}>
+              Shrink
+            </button>
+            <Probe width={width} label={LONG_LABEL} />
+          </>
+        );
+      }
+
+      await act(async () => {
+        renderWithRoot(<Resizable />);
+      });
+
+      await waitFor(() => expect(spy.counter.reads).toBeGreaterThan(0));
+      expect(label()).toHaveAttribute('data-overflowed', 'false');
+
+      await act(async () => {
+        screen.getByRole('button', { name: 'Shrink' }).click();
+      });
+
+      await waitFor(() => {
+        expect(label()).toHaveAttribute('data-overflowed', 'true');
+      });
+    });
+  });
+});

--- a/src/components/content/use-auto-tooltip.tsx
+++ b/src/components/content/use-auto-tooltip.tsx
@@ -61,6 +61,8 @@ export function useAutoTooltip({
   const elementRef = useRef<HTMLElement | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
+  const measurePendingRef = useRef(false);
+
   const checkLabelOverflow = useCallback(() => {
     const label = elementRef.current;
 
@@ -68,6 +70,33 @@ export function useAutoTooltip({
 
     setIsLabelOverflowed(label.scrollWidth > label.clientWidth);
   }, []);
+
+  /**
+   * Measure once the current task has finished, not inside it.
+   *
+   * A microtask runs after React's whole commit — every mutation, layout effect
+   * and ref attachment — and before paint. Every label on the page therefore
+   * reads after all of them have written, so the reads collapse into one style
+   * and layout flush instead of forcing one each, mid-commit. Reading straight
+   * from the callback ref is what cost 122ms of `get scrollWidth` in one Cloud
+   * profile, more than the entire style engine.
+   *
+   * A microtask rather than the observer's first delivery: observer callbacks
+   * are part of the rendering steps, so a runner that is not producing frames —
+   * a background tab, or a headless browser running many stories at once — can
+   * delay them past the point something asks whether the tooltip is active.
+   * Microtasks do not depend on a frame.
+   */
+  const scheduleLabelOverflowCheck = useCallback(() => {
+    if (measurePendingRef.current) return;
+
+    measurePendingRef.current = true;
+
+    queueMicrotask(() => {
+      measurePendingRef.current = false;
+      checkLabelOverflow();
+    });
+  }, [checkLabelOverflow]);
 
   useEffect(() => {
     if (isAutoTooltipEnabled) {
@@ -113,27 +142,26 @@ export function useAutoTooltip({
       // loop that never settles.
       if (!element) return;
 
-      // Create a fresh observer to capture the latest callback
+      // Do NOT measure synchronously here — see `scheduleLabelOverflowCheck`.
+      // This covers the node the ref just handed us, including the fresh one
+      // React creates when `TooltipProvider` mounts and remounts the label.
+      scheduleLabelOverflowCheck();
+
+      // The observer covers every later size change.
       const obs = new ResizeObserver(() => {
         checkLabelOverflow();
       });
 
       resizeObserverRef.current = obs;
 
-      // `observe()` delivers an initial callback with the element's current
-      // size, so this is the initial measurement as well as the resize one.
-      //
-      // Do NOT measure synchronously here. React runs callback refs during
-      // `commitAttachRef`, so reading `scrollWidth`/`clientWidth` at this point
-      // forces a style recalc and layout per element, mid-commit — every
-      // tooltip-bearing Button, Item and TextItem paying its own reflow. In one
-      // Cloud profile this call site alone was 122ms of `get scrollWidth`, more
-      // than the entire style engine cost. Observer callbacks run after layout
-      // but before paint, so the measurement still lands in the same frame,
-      // batched across every observed label into a single flush.
       obs.observe(element);
     },
-    [externalLabelRef, isAutoTooltipEnabled, checkLabelOverflow],
+    [
+      externalLabelRef,
+      isAutoTooltipEnabled,
+      checkLabelOverflow,
+      scheduleLabelOverflowCheck,
+    ],
   );
 
   // Cleanup on unmount

--- a/src/components/content/use-auto-tooltip.tsx
+++ b/src/components/content/use-auto-tooltip.tsx
@@ -108,9 +108,17 @@ export function useAutoTooltip({
           checkLabelOverflow();
         });
         resizeObserverRef.current = obs;
+        // `observe()` delivers an initial callback with the element's current
+        // size, so this is the initial measurement as well as the resize one.
+        //
+        // Do NOT measure synchronously here. React runs callback refs during
+        // `commitAttachRef`, so reading `scrollWidth`/`clientWidth` at this
+        // point forces a style recalc and layout per element, mid-commit —
+        // every tooltip-bearing Button, Item and TextItem paying its own
+        // reflow. Observer callbacks run after layout but before paint, so the
+        // measurement is still applied in the same frame, but batched across
+        // every observed label into a single flush.
         obs.observe(element);
-        // Initial check
-        checkLabelOverflow();
       } else {
         setIsLabelOverflowed(false);
       }

--- a/src/components/content/use-auto-tooltip.tsx
+++ b/src/components/content/use-auto-tooltip.tsx
@@ -63,13 +63,10 @@ export function useAutoTooltip({
 
   const checkLabelOverflow = useCallback(() => {
     const label = elementRef.current;
-    if (!label) {
-      setIsLabelOverflowed(false);
-      return;
-    }
 
-    const hasOverflow = label.scrollWidth > label.clientWidth;
-    setIsLabelOverflowed(hasOverflow);
+    if (!label) return;
+
+    setIsLabelOverflowed(label.scrollWidth > label.clientWidth);
   }, []);
 
   useEffect(() => {
@@ -102,26 +99,39 @@ export function useAutoTooltip({
 
       elementRef.current = element;
 
-      if (element && isAutoTooltipEnabled) {
-        // Create a fresh observer to capture the latest callback
-        const obs = new ResizeObserver(() => {
-          checkLabelOverflow();
-        });
-        resizeObserverRef.current = obs;
-        // `observe()` delivers an initial callback with the element's current
-        // size, so this is the initial measurement as well as the resize one.
-        //
-        // Do NOT measure synchronously here. React runs callback refs during
-        // `commitAttachRef`, so reading `scrollWidth`/`clientWidth` at this
-        // point forces a style recalc and layout per element, mid-commit —
-        // every tooltip-bearing Button, Item and TextItem paying its own
-        // reflow. Observer callbacks run after layout but before paint, so the
-        // measurement is still applied in the same frame, but batched across
-        // every observed label into a single flush.
-        obs.observe(element);
-      } else {
+      if (!isAutoTooltipEnabled) {
         setIsLabelOverflowed(false);
+
+        return;
       }
+
+      // No node to measure. Leave the previous verdict alone rather than
+      // clearing it: turning the verdict on mounts `TooltipProvider`, which
+      // remounts the label underneath it, so React detaches the old node and
+      // attaches a new one within that commit. Clearing here would unmount the
+      // provider, remount the label, measure it, mount the provider again — a
+      // loop that never settles.
+      if (!element) return;
+
+      // Create a fresh observer to capture the latest callback
+      const obs = new ResizeObserver(() => {
+        checkLabelOverflow();
+      });
+
+      resizeObserverRef.current = obs;
+
+      // `observe()` delivers an initial callback with the element's current
+      // size, so this is the initial measurement as well as the resize one.
+      //
+      // Do NOT measure synchronously here. React runs callback refs during
+      // `commitAttachRef`, so reading `scrollWidth`/`clientWidth` at this point
+      // forces a style recalc and layout per element, mid-commit — every
+      // tooltip-bearing Button, Item and TextItem paying its own reflow. In one
+      // Cloud profile this call site alone was 122ms of `get scrollWidth`, more
+      // than the entire style engine cost. Observer callbacks run after layout
+      // but before paint, so the measurement still lands in the same frame,
+      // batched across every observed label into a single flush.
+      obs.observe(element);
     },
     [externalLabelRef, isAutoTooltipEnabled, checkLabelOverflow],
   );

--- a/src/components/content/use-auto-tooltip.tsx
+++ b/src/components/content/use-auto-tooltip.tsx
@@ -101,7 +101,19 @@ export function useAutoTooltip({
   useEffect(() => {
     if (isAutoTooltipEnabled) {
       checkLabelOverflow();
+
+      return;
     }
+
+    // Clearing here rather than in the callback ref, which cannot be trusted
+    // to do it. Flipping `isAutoTooltipEnabled` changes the ref's identity, so
+    // React detaches with the PREVIOUS callback — the one that still believes
+    // auto tooltips are on, and therefore keeps the last verdict — and only
+    // attaches the new one if the label still exists. When `children` stops
+    // being a string the label unmounts, so the new callback never runs and a
+    // stale `true` would keep an auto tooltip mounted over content that is no
+    // longer text. That is the default `Button` path, where `tooltip` is `true`.
+    setIsLabelOverflowed(false);
   }, [isAutoTooltipEnabled, checkLabelOverflow]);
 
   // Attach ResizeObserver via callback ref to handle DOM node changes

--- a/src/components/data/TableBase/styled.ts
+++ b/src/components/data/TableBase/styled.ts
@@ -1,4 +1,4 @@
-import { keyframes, tasty } from '@tenphi/tasty';
+import { tasty } from '@tenphi/tasty';
 
 import { Action } from '../../actions/Action/Action';
 import { Item } from '../../content/Item';
@@ -23,11 +23,6 @@ import type { Styles } from '@tenphi/tasty';
  * OPPOSITE way to the position value: raising it slides the image left, which
  * would send the band right to left.
  */
-const refreshSweep = keyframes({
-  '0%': { 'mask-position': '100% 0' },
-  '100%': { 'mask-position': '0% 0' },
-});
-
 const ROW_STYLES: Styles = {
   // The stretched `rowLink` anchor positions against this.
   position: 'relative',
@@ -154,6 +149,12 @@ const CELL_STYLES: Styles = {
 export const TableElement = tasty({
   qa: 'Table',
   styles: {
+    '@keyframes': {
+      'refresh-sweep': {
+        '0%': { 'mask-position': '100% 0' },
+        '100%': { 'mask-position': '0% 0' },
+      },
+    },
     /* ── tokens the root owns ─────────────────────────────────────────── */
     // Rows are 40px at the default size and the header is one step tighter at
     // 32px — the proportion the Cloud tables use. Each is the content height;
@@ -296,10 +297,13 @@ export const TableElement = tasty({
       // unknown key through as raw CSS, so it emits fine: verified computing to
       // `300% 100%` with the sweep running. The warning is the linter's gap.
       maskSize: '300% 100%',
-      animation: {
+      animationName: {
         '': 'none',
-        stale: `${refreshSweep} 1.4s linear infinite`,
+        stale: 'refresh-sweep',
       },
+      animationDuration: '1.4s',
+      animationIterationCount: 'infinite',
+      animationTimingFunction: 'linear',
       // Belt and braces with the flat mask above, and the same shape `Spin`
       // already uses.
       animationPlayState: {

--- a/src/components/data/TableBase/styled.ts
+++ b/src/components/data/TableBase/styled.ts
@@ -297,13 +297,10 @@ export const TableElement = tasty({
       // unknown key through as raw CSS, so it emits fine: verified computing to
       // `300% 100%` with the sweep running. The warning is the linter's gap.
       maskSize: '300% 100%',
-      animationName: {
+      animation: {
         '': 'none',
-        stale: 'refresh-sweep',
+        stale: 'refresh-sweep 1.4s linear infinite',
       },
-      animationDuration: '1.4s',
-      animationIterationCount: 'infinite',
-      animationTimingFunction: 'linear',
       // Belt and braces with the flat mask above, and the same shape `Spin`
       // already uses.
       animationPlayState: {

--- a/src/precompile/index.test.tsx
+++ b/src/precompile/index.test.tsx
@@ -1,6 +1,6 @@
 import { tasty } from '@tenphi/tasty';
 
-import { precompileUIKitStyles } from './index';
+import { precompileStyles } from './index';
 
 const AppPanel = tasty({
   styles: {
@@ -10,9 +10,9 @@ const AppPanel = tasty({
   },
 });
 
-describe('precompileUIKitStyles', () => {
+describe('precompileStyles', () => {
   it('compiles application cases under the UI Kit Root configuration', async () => {
-    const result = await precompileUIKitStyles({
+    const result = await precompileStyles({
       id: '@cube-dev/example-app',
       cases: [
         {
@@ -32,7 +32,7 @@ describe('precompileUIKitStyles', () => {
   });
 
   it('can use an application tree that already contains Root', async () => {
-    const result = await precompileUIKitStyles({
+    const result = await precompileStyles({
       id: '@cube-dev/example-app/bare',
       root: false,
       cases: [{ id: 'empty', render: () => <div /> }],

--- a/src/precompile/index.test.tsx
+++ b/src/precompile/index.test.tsx
@@ -14,6 +14,7 @@ describe('precompileStyles', () => {
   it('compiles application cases under the UI Kit Root configuration', async () => {
     const result = await precompileStyles({
       id: '@cube-dev/example-app',
+      recompileKitCatalog: false,
       cases: [
         {
           id: 'dashboard',
@@ -35,10 +36,57 @@ describe('precompileStyles', () => {
     const result = await precompileStyles({
       id: '@cube-dev/example-app/bare',
       root: false,
+      recompileKitCatalog: false,
       cases: [{ id: 'empty', render: () => <div /> }],
     });
 
     expect(result.manifest.chunks).toEqual([]);
     expect(result.css).toBe('');
   });
+
+  /**
+   * The default exists because a kit chunk's lookup key survives a
+   * configuration change that alters the CSS behind it, so an application that
+   * touches units, recipes or handlers needs the kit's chunks rebuilt under its
+   * own configuration rather than the shipped ones.
+   */
+  // Rendering the whole kit matrix takes a couple of seconds on its own and
+  // longer when the full suite is competing for the machine.
+  it(
+    'folds UI Kit’s own catalog in by default',
+    { timeout: 60_000 },
+    async () => {
+      const withKit = await precompileStyles({
+        id: '@cube-dev/example-app/with-kit',
+        cases: [
+          { id: 'dashboard', render: () => <AppPanel>Dashboard</AppPanel> },
+        ],
+      });
+      const appOnly = await precompileStyles({
+        id: '@cube-dev/example-app/app-only',
+        recompileKitCatalog: false,
+        cases: [
+          { id: 'dashboard', render: () => <AppPanel>Dashboard</AppPanel> },
+        ],
+      });
+
+      expect(withKit.manifest.chunks.length).toBeGreaterThan(
+        appOnly.manifest.chunks.length,
+      );
+
+      // The application's own case still reports, and still last.
+      expect(withKit.report.at(-1)).toEqual(
+        expect.objectContaining({ caseId: 'dashboard' }),
+      );
+
+      // Every chunk the application needs on its own is still present, so
+      // folding the kit in never costs app coverage.
+      const foldedKeys = new Set(
+        withKit.manifest.chunks.map(({ lookupKey }) => lookupKey),
+      );
+      for (const { lookupKey } of appOnly.manifest.chunks) {
+        expect(foldedKeys).toContain(lookupKey);
+      }
+    },
+  );
 });

--- a/src/precompile/index.test.tsx
+++ b/src/precompile/index.test.tsx
@@ -1,0 +1,44 @@
+import { tasty } from '@tenphi/tasty';
+
+import { precompileUIKitStyles } from './index';
+
+const AppPanel = tasty({
+  styles: {
+    display: 'grid',
+    padding: '2x',
+    color: '#purple',
+  },
+});
+
+describe('precompileUIKitStyles', () => {
+  it('compiles application cases under the UI Kit Root configuration', async () => {
+    const result = await precompileUIKitStyles({
+      id: '@cube-dev/example-app',
+      cases: [
+        {
+          id: 'dashboard',
+          render: () => <AppPanel>Dashboard</AppPanel>,
+        },
+      ],
+    });
+
+    expect(result.manifest.id).toBe('@cube-dev/example-app');
+    expect(result.manifest.chunks.length).toBeGreaterThan(0);
+    expect(result.css).toContain('display: grid');
+    expect(result.report).toEqual([
+      expect.objectContaining({ caseId: 'dashboard' }),
+    ]);
+    expect(result.report[0].addedClasses.length).toBeGreaterThan(0);
+  });
+
+  it('can use an application tree that already contains Root', async () => {
+    const result = await precompileUIKitStyles({
+      id: '@cube-dev/example-app/bare',
+      root: false,
+      cases: [{ id: 'empty', render: () => <div /> }],
+    });
+
+    expect(result.manifest.chunks).toEqual([]);
+    expect(result.css).toBe('');
+  });
+});

--- a/src/precompile/index.test.tsx
+++ b/src/precompile/index.test.tsx
@@ -45,48 +45,21 @@ describe('precompileStyles', () => {
   });
 
   /**
-   * The default exists because a kit chunk's lookup key survives a
-   * configuration change that alters the CSS behind it, so an application that
-   * touches units, recipes or handlers needs the kit's chunks rebuilt under its
-   * own configuration rather than the shipped ones.
+   * The default path renders UI Kit's catalog, which imports the built kit —
+   * so `dist/` has to exist and `pnpm test` does not build. That half is
+   * covered by `scripts/precompile-app-parity.mjs`, which runs inside
+   * `pnpm test:precompiled` after a build and asserts the folded artifact
+   * reproduces the shipped catalog exactly.
    */
-  // Rendering the whole kit matrix takes a couple of seconds on its own and
-  // longer when the full suite is competing for the machine.
-  it(
-    'folds UI Kit’s own catalog in by default',
-    { timeout: 60_000 },
-    async () => {
-      const withKit = await precompileStyles({
-        id: '@cube-dev/example-app/with-kit',
-        cases: [
-          { id: 'dashboard', render: () => <AppPanel>Dashboard</AppPanel> },
-        ],
-      });
-      const appOnly = await precompileStyles({
-        id: '@cube-dev/example-app/app-only',
-        recompileKitCatalog: false,
-        cases: [
-          { id: 'dashboard', render: () => <AppPanel>Dashboard</AppPanel> },
-        ],
-      });
+  it('reports the option it was given', async () => {
+    const appOnly = await precompileStyles({
+      id: '@cube-dev/example-app/app-only',
+      recompileKitCatalog: false,
+      cases: [
+        { id: 'dashboard', render: () => <AppPanel>Dashboard</AppPanel> },
+      ],
+    });
 
-      expect(withKit.manifest.chunks.length).toBeGreaterThan(
-        appOnly.manifest.chunks.length,
-      );
-
-      // The application's own case still reports, and still last.
-      expect(withKit.report.at(-1)).toEqual(
-        expect.objectContaining({ caseId: 'dashboard' }),
-      );
-
-      // Every chunk the application needs on its own is still present, so
-      // folding the kit in never costs app coverage.
-      const foldedKeys = new Set(
-        withKit.manifest.chunks.map(({ lookupKey }) => lookupKey),
-      );
-      for (const { lookupKey } of appOnly.manifest.chunks) {
-        expect(foldedKeys).toContain(lookupKey);
-      }
-    },
-  );
+    expect(appOnly.report.map(({ caseId }) => caseId)).toEqual(['dashboard']);
+  });
 });

--- a/src/precompile/index.ts
+++ b/src/precompile/index.ts
@@ -1,0 +1,44 @@
+import { precompileTastyStyles } from '@tenphi/tasty/precompile';
+import { createElement } from 'react';
+
+import { Root } from '../components/Root';
+
+import type {
+  TastyPrecompileCase,
+  TastyPrecompileResult,
+} from '@tenphi/tasty/precompile';
+import type { CubeRootProps } from '../components/Root';
+
+export type UIKitPrecompileCase = TastyPrecompileCase;
+
+export interface UIKitPrecompileOptions {
+  id: string;
+  cases: readonly UIKitPrecompileCase[];
+  /**
+   * Props for the UI Kit Root wrapped around every case. Pass false when each
+   * case already returns the application's complete Root tree.
+   */
+  root?: false | Omit<CubeRootProps, 'children'>;
+}
+
+/**
+ * Compile application-owned catalog cases under UI Kit's exact Tasty
+ * configuration and normal Root providers.
+ */
+export function precompileUIKitStyles(
+  options: UIKitPrecompileOptions,
+): Promise<TastyPrecompileResult> {
+  const { id, cases, root = {} } = options;
+
+  return precompileTastyStyles({
+    id,
+    cases: cases.map((item) => ({
+      id: item.id,
+      async render() {
+        const tree = await item.render();
+
+        return root === false ? tree : createElement(Root, root, tree);
+      },
+    })),
+  });
+}

--- a/src/precompile/index.ts
+++ b/src/precompile/index.ts
@@ -9,11 +9,11 @@ import type {
 } from '@tenphi/tasty/precompile';
 import type { CubeRootProps } from '../components/Root';
 
-export type UIKitPrecompileCase = TastyPrecompileCase;
+export type PrecompileCase = TastyPrecompileCase;
 
-export interface UIKitPrecompileOptions {
+export interface PrecompileStylesOptions {
   id: string;
-  cases: readonly UIKitPrecompileCase[];
+  cases: readonly PrecompileCase[];
   /**
    * Props for the UI Kit Root wrapped around every case. Pass false when each
    * case already returns the application's complete Root tree.
@@ -25,8 +25,8 @@ export interface UIKitPrecompileOptions {
  * Compile application-owned catalog cases under UI Kit's exact Tasty
  * configuration and normal Root providers.
  */
-export function precompileUIKitStyles(
-  options: UIKitPrecompileOptions,
+export function precompileStyles(
+  options: PrecompileStylesOptions,
 ): Promise<TastyPrecompileResult> {
   const { id, cases, root = {} } = options;
 

--- a/src/precompile/index.ts
+++ b/src/precompile/index.ts
@@ -1,3 +1,6 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
 import { precompileTastyStyles } from '@tenphi/tasty/precompile';
 import { createElement } from 'react';
 
@@ -19,26 +22,87 @@ export interface PrecompileStylesOptions {
    * case already returns the application's complete Root tree.
    */
   root?: false | Omit<CubeRootProps, 'children'>;
+  /**
+   * Re-render UI Kit's own component catalog under this application's Tasty
+   * configuration and fold it into the artifact. Defaults to `true`.
+   *
+   * A chunk's lookup key hashes the style source, not the CSS it produced, so a
+   * kit chunk compiled under UI Kit's configuration keeps the same key under an
+   * application that redefines a unit, recipe or handler the chunk relies on —
+   * while the CSS behind that key no longer matches. Recompiling here removes
+   * the divergence instead of leaving Tasty to detect it and fall back.
+   *
+   * Set to `false` only when this application makes no compilation-affecting
+   * configuration change, and pair it with the shipped artifact:
+   *
+   * ```ts
+   * import '@cube-dev/ui-kit/precompiled-styles';
+   * ```
+   *
+   * The two register side by side — catalogs stack, and identical chunks
+   * compile to identical class names, so the overlap is free. Skipping the
+   * recompilation is a build-time saving, not a way to drop kit coverage.
+   */
+  recompileKitCatalog?: boolean;
+}
+
+/**
+ * UI Kit's own catalog cases.
+ *
+ * Loaded from the package rather than imported statically so that an
+ * application that opts out of recompiling them never pays for evaluating the
+ * component matrix. The path is the same two levels below the package root from
+ * `src/` and from `dist/`, so it resolves in this repo and once published.
+ */
+function kitCatalogURL(): string {
+  // Resolved through `path` rather than `new URL(..., import.meta.url)`:
+  // bundlers rewrite that exact pattern into a served asset URL, and Node's
+  // ESM loader accepts only `file:` and `data:`. The catalog sits two levels
+  // below the package root from both `src/` and `dist/`.
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  return pathToFileURL(
+    resolve(here, '../../scripts/precompile-tasty-catalog.mjs'),
+  ).href;
+}
+
+async function loadKitCatalogCases(): Promise<readonly PrecompileCase[]> {
+  try {
+    const module = (await import(/* @vite-ignore */ kitCatalogURL())) as {
+      cases: readonly PrecompileCase[];
+    };
+
+    return module.cases;
+  } catch (error) {
+    throw new Error(
+      `[UI Kit] Could not load UI Kit's precompile catalog from ${kitCatalogURL()}. Pass recompileKitCatalog: false and register '@cube-dev/ui-kit/precompiled-styles' alongside this artifact instead.`,
+      { cause: error },
+    );
+  }
 }
 
 /**
  * Compile application-owned catalog cases under UI Kit's exact Tasty
  * configuration and normal Root providers.
  */
-export function precompileStyles(
+export async function precompileStyles(
   options: PrecompileStylesOptions,
 ): Promise<TastyPrecompileResult> {
-  const { id, cases, root = {} } = options;
+  const { id, cases, root = {}, recompileKitCatalog = true } = options;
 
-  return precompileTastyStyles({
-    id,
-    cases: cases.map((item) => ({
-      id: item.id,
-      async render() {
-        const tree = await item.render();
+  // UI Kit's cases carry their own providers and are rendered exactly as
+  // `pnpm precompile:tasty` renders them, so an application that changes
+  // nothing compilation-affecting reproduces the shipped chunks byte for byte.
+  const kitCases = recompileKitCatalog ? await loadKitCatalogCases() : [];
 
-        return root === false ? tree : createElement(Root, root, tree);
-      },
-    })),
-  });
+  const appCases = cases.map((item) => ({
+    id: item.id,
+    async render() {
+      const tree = await item.render();
+
+      return root === false ? tree : createElement(Root, root, tree);
+    },
+  }));
+
+  return precompileTastyStyles({ id, cases: [...kitCases, ...appCases] });
 }

--- a/src/precompile/register.ts
+++ b/src/precompile/register.ts
@@ -1,0 +1,33 @@
+/**
+ * Runtime registration for an application-owned catalog.
+ *
+ * `@cube-dev/ui-kit/precompile` compiles a catalog and is Node-only; this is
+ * the browser half, so that an application never has to depend on
+ * `@tenphi/tasty` directly to use one. Reaching past UI Kit for it risks a
+ * second Tasty instance with its own registry, which would leave the catalog
+ * registered against a store nothing reads.
+ *
+ * A separate entry rather than a re-export from the package root: the registry
+ * and its configuration comparison ship with whoever imports this, and an
+ * application that does not build a catalog should not carry them.
+ *
+ * `@cube-dev/ui-kit/precompiled-styles` is the other, narrower door — it
+ * registers UI Kit's own prebuilt artifact and takes no arguments.
+ */
+export {
+  installTastyPrecompiled,
+  registerTastyPrecompiled,
+} from '@tenphi/tasty/precompile/register';
+
+// `TastyCompilationConfig` is deliberately absent: Tasty does not export it
+// from this entry yet. `TastyPrecompiledManifest` references it structurally,
+// so typing a manifest works without it.
+export type {
+  PrecompiledCounterStyleCacheEntry,
+  PrecompiledKeyframeCacheEntry,
+  PrecompiledPropertyCacheEntry,
+  TastyPrecompiledChunk,
+  TastyPrecompiledDependencies,
+  TastyPrecompiledManifest,
+  TastyPrecompiledStats,
+} from '@tenphi/tasty/precompile/register';

--- a/src/stories/interactions.ts
+++ b/src/stories/interactions.ts
@@ -79,9 +79,12 @@ export async function openContextMenu(
  * both fail silently:
  *
  * - **The trigger is not wired yet.** `TooltipProvider` renders its child
- *   without trigger props until a mount effect flips `rendered`. A hover that
- *   lands before that has no handler to reach and nothing replays it, hence the
- *   wait.
+ *   without trigger props until a mount effect flips `rendered`, and an
+ *   auto-on-overflow label does not even ask for a provider until it has
+ *   measured itself, which happens off the commit path. A hover that lands
+ *   before any of that has no handler to reach, and the browser does not replay
+ *   it — so this replays the hover itself rather than guessing a delay long
+ *   enough to cover however many commits the component needed.
  * - **React Aria has no interaction modality yet.** It opens a tooltip only
  *   when the last interaction came from a pointer, which it learns from a mouse
  *   move on the document. `userEvent.hover` fires `mouseEnter` *before* its
@@ -89,8 +92,8 @@ export async function openContextMenu(
  *   supplies that move.
  *
  * Pass `delay: 0` in the story's tooltip config as well. The default 250ms open
- * delay is real time the snapshot would otherwise wait out, and it makes any
- * retry racy.
+ * delay is real time the snapshot would otherwise wait out, and it makes each
+ * retry below that much slower.
  *
  * Only one element per story: hovering a second closes the first, and only the
  * final state is photographed.
@@ -102,10 +105,24 @@ export async function openContextMenu(
  * it with a longer wait.
  */
 export async function openTooltip(target: Element) {
-  await timeout(250);
+  const doc = within(document.body);
 
-  await userEvent.unhover(target);
-  await userEvent.hover(target);
+  // Replay the hover rather than waiting a fixed time before it. Nothing
+  // replays a hover that lands before the trigger is wired, so a single
+  // attempt is only as good as the guess in front of it — and the guess has to
+  // cover however many commits the component needs to decide it wants a
+  // tooltip at all. An auto-on-overflow label measures itself off the commit
+  // path, so that is at least one commit after mount, and longer on a loaded
+  // machine. Retrying costs nothing when the first attempt works.
+  await waitFor(
+    async () => {
+      await userEvent.unhover(target);
+      await userEvent.hover(target);
 
-  await waitForOverlay('tooltip');
+      expect(doc.getAllByRole('tooltip')[0]).toBeVisible();
+    },
+    { timeout: 10000 },
+  );
+
+  return doc.getAllByRole('tooltip')[0];
 }

--- a/src/stories/interactions.ts
+++ b/src/stories/interactions.ts
@@ -106,23 +106,45 @@ export async function openContextMenu(
  */
 export async function openTooltip(target: Element) {
   const doc = within(document.body);
+  const tooltip = () => doc.queryAllByRole('tooltip')[0];
 
-  // Replay the hover rather than waiting a fixed time before it. Nothing
-  // replays a hover that lands before the trigger is wired, so a single
-  // attempt is only as good as the guess in front of it — and the guess has to
-  // cover however many commits the component needs to decide it wants a
-  // tooltip at all. An auto-on-overflow label measures itself off the commit
-  // path, so that is at least one commit after mount, and longer on a loaded
-  // machine. Retrying costs nothing when the first attempt works.
-  await waitFor(
-    async () => {
-      await userEvent.unhover(target);
-      await userEvent.hover(target);
+  // Replay the hover, but leave the pointer in place between attempts.
+  //
+  // A single hover is only as good as the guess in front of it: nothing
+  // replays a hover that lands before the trigger is wired, and an
+  // auto-on-overflow label does not ask for a provider until it has measured
+  // itself, which happens off the commit path.
+  //
+  // Retrying inside `waitFor` does NOT work, and the failure is silent: its
+  // retry period is shorter than `TooltipTrigger`'s 250ms open delay, so every
+  // retry unhovers and cancels the timer that the previous one started, and the
+  // tooltip can never appear. Each attempt therefore hovers ONCE and then waits
+  // out the delay several times over before deciding the hover was wasted.
+  const ATTEMPTS = 3;
+  const PER_ATTEMPT_MS = 1500;
 
-      expect(doc.getAllByRole('tooltip')[0]).toBeVisible();
-    },
-    { timeout: 10000 },
-  );
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    // The leading unhover supplies the mouse move React Aria needs to set its
+    // interaction modality — `userEvent.hover` fires `mouseEnter` before
+    // `mouseMove`, so an un-preceded first hover is ignored.
+    await userEvent.unhover(target);
+    await userEvent.hover(target);
 
-  return doc.getAllByRole('tooltip')[0];
+    if (attempt === ATTEMPTS) break;
+
+    try {
+      await waitFor(() => expect(tooltip()).toBeVisible(), {
+        timeout: PER_ATTEMPT_MS,
+      });
+
+      return tooltip();
+    } catch {
+      // Trigger was probably not wired when the hover landed. Try again.
+    }
+  }
+
+  // Let the last attempt report the real assertion failure.
+  await waitForOverlay('tooltip');
+
+  return tooltip();
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
     // the class-name pattern it normalises is tasty's, and the CSS it reads is
     // this package's.
     'probe/index': 'src/probe/index.ts',
+    // Node-only application catalog compiler. It loads UI Kit's exact Tasty
+    // configuration and delegates rendering/collection to tasty's precompiler.
+    'precompile/index': 'src/precompile/index.ts',
   },
   format: 'esm',
   outDir: 'dist',

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -32,6 +32,11 @@ export default defineConfig({
     // Node-only application catalog compiler. It loads UI Kit's exact Tasty
     // configuration and delegates rendering/collection to tasty's precompiler.
     'precompile/index': 'src/precompile/index.ts',
+    // Browser half of the same feature: registering the artifact the compiler
+    // above produced. Split from it because that entry is Node-only, and kept
+    // out of the package root so an app that builds no catalog does not ship
+    // the registry.
+    'precompile/register': 'src/precompile/register.ts',
   },
   format: 'esm',
   outDir: 'dist',

--- a/vitest.precompiled.config.ts
+++ b/vitest.precompiled.config.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
+const tastyPkg = JSON.parse(
+  readFileSync('./node_modules/@tenphi/tasty/package.json', 'utf-8'),
+);
+
+export default defineConfig({
+  define: {
+    __UIKIT_VERSION__: JSON.stringify(pkg.version),
+    __TASTY_VERSION__: JSON.stringify(tastyPkg.version),
+  },
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+  test: {
+    globals: true,
+    include: ['scripts/precompile-parity.browser.jsx'],
+    setupFiles: ['./src/test/setup.browser.ts'],
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      headless: true,
+      instances: [{ browser: 'chromium' }],
+    },
+  },
+});

--- a/vitest.precompiled.config.ts
+++ b/vitest.precompiled.config.ts
@@ -9,12 +9,50 @@ const tastyPkg = JSON.parse(
 );
 
 export default defineConfig({
+  cacheDir: 'node_modules/.vite-precompiled',
   define: {
     __UIKIT_VERSION__: JSON.stringify(pkg.version),
     __TASTY_VERSION__: JSON.stringify(tastyPkg.version),
   },
   oxc: {
     jsx: { runtime: 'automatic' },
+  },
+  optimizeDeps: {
+    // This test imports the complete UI Kit graph from a fresh checkout. Pin
+    // every dependency Vite otherwise discovers in two waves; a mid-run
+    // optimizer reload drops the only browser test before it can register.
+    include: [
+      '@internationalized/date',
+      '@react-aria/focus',
+      '@react-aria/i18n',
+      '@react-aria/interactions',
+      '@react-aria/ssr',
+      '@react-aria/utils',
+      '@react-spectrum/utils',
+      '@react-stately/selection',
+      '@react-stately/utils',
+      '@tabler/icons-react',
+      '@tanstack/react-virtual',
+      '@tenphi/glaze',
+      '@tenphi/tasty/precompile/register',
+      '@testing-library/user-event',
+      'clipboard-copy',
+      'clsx',
+      'diff',
+      'email-validator',
+      'prism-react-renderer',
+      'prismjs/components/prism-bash.js',
+      'prismjs/components/prism-javascript.js',
+      'prismjs/components/prism-markup.js',
+      'prismjs/components/prism-sql.js',
+      'prismjs/components/prism-yaml.js',
+      'react-dom',
+      'react-hotkeys-hook',
+      'react-is',
+      'react-stately',
+      'tiny-invariant',
+      'valid-url',
+    ],
   },
   test: {
     globals: true,


### PR DESCRIPTION
### Describe changes

Adds two opt-in precompilation paths without changing the normal `@cube-dev/ui-kit` component entry.

#### Shared UI Kit catalog

Applications with broad, mostly stock UI Kit usage can load the generated catalog with:

```tsx
import '@cube-dev/ui-kit/precompiled-styles';
import { Root, Button } from '@cube-dev/ui-kit';
```

The side-effect entry registers the manifest and imports the static stylesheet. Split registration/CSS and explicit manifest exports remain available for framework-managed CSS, SSR links, RSC graphs, and bundled-text fallback.

The shared artifact is now documented as a measured convenience rather than a general performance default. Lookup keys are exact, so heavily customized applications can pay for a broad 714 KB stylesheet while their expensive app-specific chunks still run at runtime. A high render-frequency hit rate alone is not evidence of broad catalog coverage.

#### Application-owned catalog compiler

Adds the Node-only `@cube-dev/ui-kit/precompile` entry:

```tsx
import { precompileStyles } from '@cube-dev/ui-kit/precompile';

const artifact = await precompileStyles({
  id: '@cube-dev/console-ui',
  cases: [
    { id: 'dashboard', render: () => <DashboardRoute /> },
    { id: 'query', render: () => <QueryRoute /> },
  ],
});
```

It renders project cases under UI Kit's exact Tasty configuration and normal `Root` providers, collecting UI Kit and application chunks into one app-owned artifact. `root: false` supports cases that already return the application's complete Root tree. Consumers should load the app-owned artifact instead of stacking it with the broad shared catalog.

### Artifact and catalog

- Generates deterministic CSS, manifest, declarations, and a diagnostic report after the normal UI Kit build.
- Uses 44 curated shared-catalog cases covering every cataloged public styled component or documenting it as runtime-only.
- Covers 541 chunks and 3,416 top-level rules in a 714,198-code-unit stylesheet.
- Keeps palette variables, body styles, fonts, raw CSS, and application globals dynamic through `Root`.
- Leaves runtime styles, style props, and uncovered chunks on Tasty's normal generation path.
- Marks only opt-in registration and CSS files as side-effectful; the main component entry remains unchanged.
- Preserves component-local animation shorthands while collecting their keyframe dependencies.

### Coverage diagnostics

The pinned Tasty snapshot updates `tastyDebug` to distinguish render frequency from useful catalog breadth:

- active classes are split into runtime and precompiled classes;
- registered precompiled classes are reported as active or inactive now;
- distinct precompiled classes used since metrics reset are reported separately;
- precompiled hits, runtime cache hits, and generated chunks are separate lookup counts.

This makes production data such as 8,550 hits across only 87 distinct classes actionable when evaluating the 536-class shared asset.

### Verification

- `pnpm build`
- `pnpm lint` (only existing token-usage warnings)
- `pnpm test`: 103 files, 2,204 passed, 1 skipped
- `pnpm test:browser`: 12 files, 141 passed
- public-subpath precompiled parity: 1 passed
- `pnpm size`: 515.83/520 kB full, 124.97/125 kB Button-only
- repeated generation produced byte-identical CSS, manifest, and report
- `npm pack --dry-run --ignore-scripts` includes the application compiler and every shared precompiled artifact
- the published `@cube-dev/ui-kit/precompile` subpath imports successfully in Node

##### Checklist

- [x] Pipeline is passed
- [x] Tests are added
- [x] Tests are passed successfully
- [x] New component stories are not applicable
- [x] Changeset is added
- [x] Library size threshold is passed
- [x] Commit message follows the commit guidelines

### Dependency and merge order

Depends on tenphi/tasty#289 and pins `@tenphi/tasty@0.0.0-snapshot.04629d1`, built from the latest Tasty PR revision. Merge and release Tasty first, replace this snapshot with that exact released version, regenerate the artifact, and then merge UI Kit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new public build/runtime surface and a pinned Tasty snapshot affect styling correctness and release order; tooltip overflow timing changed across many components.
> 
> **Overview**
> Adds **opt-in Tasty precompilation** without changing the default component entry. Consumers can register a shipped UI Kit catalog via `@cube-dev/ui-kit/precompiled-styles` (static CSS + manifest), or build an app-owned artifact with the Node-only `@cube-dev/ui-kit/precompile` API and register it through `@cube-dev/ui-kit/precompile/register`. `pnpm build` now runs `precompile:tasty`, publishing CSS, manifest, and report from a large component catalog; `precompileStyles()` defaults to re-folding that catalog under the app’s Tasty config (with `recompileKitCatalog: false` + stacking the shipped asset as the alternative), and records UI Kit’s `configure()` before compiling so manifest config matches runtime.
> 
> **Verification and docs:** CI gains `pnpm test:precompiled` (manifest parity script + Chromium computed-style parity). README/AGENTS document adoption, stacking catalogs, and SSR/RSC paths. Size limits move to **520 kB / 126 kB** for Tasty precompile runtime support; `@tenphi/tasty` is pinned to a **pre-release snapshot** pending upstream release.
> 
> **Separate performance/tooling fixes:** `useAutoTooltip` stops synchronous `scrollWidth`/`clientWidth` reads in callback refs (batched via `queueMicrotask` + `ResizeObserver`), with new browser tests and a more resilient Storybook `openTooltip` helper. `Placeholder` and table loading animations move keyframes into inline `@keyframes` in Tasty styles so they ship in the precompiled artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52e4dab085f193cabf081efe9f77b8b901146fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->