### PR TITLE
refactor(form): drop the dead necessityLabel prop

### DIFF
--- a/.changeset/drop-necessity-label.md
+++ b/.changeset/drop-necessity-label.md
@@ -1,0 +1,11 @@
+---
+'@cube-dev/ui-kit': minor
+---
+
+**Breaking:** removed the `necessityLabel` prop from `FieldBaseProps`, `FormBaseProps`, `Form`, `DialogForm` and the legacy `<Field>`.
+
+It never did anything. The prop was declared on the shared field types, forwarded by `Field` and `DialogForm`, exposed as a Storybook control and documented as working — but nothing ever read it. `Label` used to hold a local variable of the same name for the computed `(required)` / `(optional)` string, which is what made the gap easy to miss on inspection; the prop itself has been a no-op in every release since it was introduced. Deleting it changes no rendering, only the types.
+
+It is not worth implementing rather than removing. It is one string for two mutually exclusive states, declared on `FormBaseProps` — so a form-level value would stamp the same literal onto required and optional fields alike. Those strings are also owned by i18n now (`form.required` / `form.optional`), so the way to reword them everywhere is a translation override, not a prop.
+
+To put custom content next to a label, use `labelSuffix` (after the label text) or `extra` (at the far end of the label row). Both already work. To change the shape of the marker itself, use `necessityIndicator`.

--- a/src/components/fields/Checkbox/CheckboxGroup.tsx
+++ b/src/components/fields/Checkbox/CheckboxGroup.tsx
@@ -62,7 +62,6 @@ function CheckboxGroup(props: WithNullableValue<CubeCheckboxGroupProps>, ref) {
     isDisabled,
     isRequired,
     necessityIndicator,
-    necessityLabel,
     label,
     extra,
     isInvalid,

--- a/src/components/form/FieldWrapper/types.ts
+++ b/src/components/form/FieldWrapper/types.ts
@@ -35,7 +35,6 @@ export type CubeFieldWrapperProps = ValidationProps & {
   requiredMark?: boolean;
   tooltip?: ReactNode;
   extra?: ReactNode;
-  necessityLabel?: ReactNode;
   necessityIndicator?: NecessityIndicator | null;
 
   /**

--- a/src/components/form/Form/Field.docs.mdx
+++ b/src/components/form/Form/Field.docs.mdx
@@ -32,7 +32,6 @@ The Field component is a **legacy wrapper** for form inputs that provides field-
 - **`rules`** — Validation rules array
 - **`labelPosition`** `'top' | 'side' | 'split'` (default: `top`) — Position of the field label
 - **`necessityIndicator`** `'icon' | 'label' | null` — Type of necessity indicator
-- **`necessityLabel`** `string` — Custom necessity label text
 - **`isRequired`** `boolean` (default: `false`) — Whether the field is required. Marks the label, unlike a bare `required` rule
 - **`isOptional`** `boolean` (default: `false`) — Marks the label with an `(optional)` note
 - **`isDisabled`** `boolean` (default: `false`) — Whether the field is disabled
@@ -95,7 +94,6 @@ These properties allow direct style application without using the `styles` prop:
 
 - **`labelPosition`** `'top' | 'side'` — Position of the field label
 - **`necessityIndicator`** `'icon' | 'label' | null` — Type of necessity indicator
-- **`necessityLabel`** `string` — Custom necessity label text
 - **`isOptional`** `boolean` — Marks the label with an `(optional)` note
 - **`labelProps`** `object` — Additional props for the label element
 - **`labelSuffix`** `ReactNode` — Content to display after the label

--- a/src/components/form/Form/Field.stories.tsx
+++ b/src/components/form/Form/Field.stories.tsx
@@ -64,11 +64,6 @@ export default {
       control: { type: 'radio' },
       description: 'Type of necessity indicator',
     },
-    necessityLabel: {
-      control: { type: 'text' },
-      description: 'Custom necessity label text',
-    },
-
     /* State */
     isRequired: {
       control: { type: 'boolean' },

--- a/src/components/form/Form/Field.tsx
+++ b/src/components/form/Form/Field.tsx
@@ -128,7 +128,6 @@ export function Field<T extends FieldTypes>(props: CubeFieldProps<T>) {
     form,
     label,
     extra,
-    necessityLabel,
     necessityIndicator,
     tooltip,
     isHidden,
@@ -192,7 +191,6 @@ export function Field<T extends FieldTypes>(props: CubeFieldProps<T>) {
           isInvalid={isInvalid}
           isValid={isValid}
           necessityIndicator={resolvedNecessityIndicator}
-          necessityLabel={necessityLabel}
           isRequired={isRequired}
           isOptional={isOptional}
           label={label}
@@ -254,10 +252,6 @@ export function Field<T extends FieldTypes>(props: CubeFieldProps<T>) {
     !(resolvedNecessityIndicator === null && childDeclaresNecessity)
   ) {
     newProps.necessityIndicator = resolvedNecessityIndicator;
-  }
-
-  if (necessityLabel) {
-    newProps.necessityLabel = necessityLabel;
   }
 
   if (isInvalid) {

--- a/src/components/form/Form/Form.docs.mdx
+++ b/src/components/form/Form/Form.docs.mdx
@@ -41,7 +41,6 @@ These properties are inherited by all input components within the form:
 - **`labelStyles`** `Styles` — Styles applied to field labels
 - **`requiredMark`** `boolean` (default: `true`) — Whether to show required field indicators
 - **`necessityIndicator`** `'icon' | 'label' | null` (default: `icon`) — Type of necessity indicator. `null` suppresses it
-- **`necessityLabel`** `ReactNode` — Custom label to replace the default necessity indicator text
 - **`isReadOnly`** `boolean` (default: `false`) — Whether fields are read-only by default
 - **`isInvalid`** `boolean` — Invalid state for all fields
 - **`isValid`** `boolean` — Valid state for all fields

--- a/src/components/form/Form/Form.stories.tsx
+++ b/src/components/form/Form/Form.stories.tsx
@@ -160,14 +160,6 @@ const meta: Meta<typeof Form> = {
         type: { summary: 'Styles' },
       },
     },
-    necessityLabel: {
-      control: { type: null },
-      description:
-        'Custom label to replace the default necessity indicator text',
-      table: {
-        type: { summary: 'ReactNode' },
-      },
-    },
   },
 };
 

--- a/src/components/overlays/Dialog/DialogForm.docs.mdx
+++ b/src/components/overlays/Dialog/DialogForm.docs.mdx
@@ -47,7 +47,6 @@ DialogForm combines [Dialog](/docs/overlays-dialog--docs) and [Form](/docs/forms
 - **`labelStyles`** `Styles` — Styles for the label
 - **`requiredMark`** `boolean` — Whether the field presents required mark
 - **`necessityIndicator`** `NecessityIndicator` — The type of necessity indicator
-- **`necessityLabel`** `ReactNode` — Custom necessity label
 - **`isReadOnly`** `boolean` — Whether the form is read only
 - **`isInvalid`** `boolean` — Invalid state for all fields in the form
 - **`isValid`** `boolean` — Valid state for all fields in the form

--- a/src/components/overlays/Dialog/DialogForm.tsx
+++ b/src/components/overlays/Dialog/DialogForm.tsx
@@ -59,7 +59,6 @@ export function DialogForm<T extends FieldTypes = FieldTypes>(
     labelPosition,
     requiredMark,
     necessityIndicator,
-    necessityLabel,
     isReadOnly,
     isInvalid,
     isValid,
@@ -113,7 +112,6 @@ export function DialogForm<T extends FieldTypes = FieldTypes>(
           labelPosition={labelPosition}
           requiredMark={requiredMark}
           necessityIndicator={necessityIndicator}
-          necessityLabel={necessityLabel}
           isReadOnly={isReadOnly}
           isInvalid={isInvalid}
           isValid={isValid}

--- a/src/shared/form.ts
+++ b/src/shared/form.ts
@@ -112,7 +112,6 @@ export interface FieldBaseProps extends FormBaseProps, FieldCoreProps {
   /** An additional content next to the label */
   extra?: ReactNode;
   necessityIndicator?: NecessityIndicator | null;
-  necessityLabel?: ReactNode;
   labelSuffix?: ReactNode;
   /** A tooltip that is shown inside the label */
   tooltip?: ReactNode;
@@ -144,8 +143,6 @@ export interface FormBaseProps extends ValidationProps {
   requiredMark?: boolean;
   /** The type of necessity indicator */
   necessityIndicator?: NecessityIndicator | null;
-  /** That can replace the necessity label */
-  necessityLabel?: ReactNode;
   /** Whether the field is read only */
   isReadOnly?: boolean;
   /**


### PR DESCRIPTION
> Stacked on #1377 — based on `feat/opt-in-necessity-indicator`, because it touches the same lines in `shared/form.ts`, `FieldWrapper/types.ts`, `Field.tsx` and three docs pages. GitHub will retarget this to `main` when #1377 merges.

## It never worked

`necessityLabel` is declared on `FieldBaseProps` and `FormBaseProps`, forwarded by `Field` and `DialogForm`, destructured by `CheckboxGroup`, exposed as a Storybook control, and documented as working in three `.docs.mdx` pages. Nothing ever read it — `FieldWrapper` doesn't destructure it, and `Label` never has.

What hid the gap: `Label` used to hold a **local variable** of the same name for the computed string.

```js
// old Label.tsx — a local, not the prop
let necessityLabel = isRequired ? requiredLabel : t('form.optional', '(optional)');
```

I checked every commit that has ever touched `necessityLabel` under `src/components/form/`, back to its introduction in #777. That local is the only "render site" in the history; the prop was never destructured from `props` in any of them. It has been a no-op in every published version.

So this deletes types, forwarding and docs — **no rendering changes**, and `pnpm test` is unchanged at 2216 passing.

## Why remove rather than implement

The task could have gone either way. Implementing it is the wrong call:

- **It's one string for two mutually exclusive states.** `(required)` and `(optional)` are different messages; a single `necessityLabel` can only be one of them.
- **It's on `FormBaseProps`.** A form-level value would stamp the same literal onto required *and* optional fields alike, which is incoherent at exactly the scope the prop is most useful.
- **i18n owns those strings now** — `form.required` / `form.optional` in `src/i18n/locales/*/uikit.json`. Rewording them everywhere is a translation override; a per-field literal prop fights localization instead of complementing it.
- **The escape hatches already exist and work.** `labelSuffix` renders content right after the label text, `extra` at the far end of the label row, and `necessityIndicator` changes the marker's shape (`'icon'` / `'label'` / `null`).

Implementing it would mean designing a new prop, not fixing a broken one — and the design that survives those four points is the one already shipping.

## Migration

Delete the prop. It was doing nothing, so nothing changes visually. For custom content beside a label use `labelSuffix` or `extra`; for the marker's shape use `necessityIndicator`.

## Checks

- `pnpm test` — 103 files, 2216 passed, 1 skipped
- `pnpm exec tsc --noEmit` — 18 errors, identical to the pre-existing baseline on `main`, none in touched files
- `pnpm audit-docs --component=Form` / `Field` / `DialogForm` — 0 issues
- `pnpm audit-defaults` — no diff
- `pnpm fix` — clean (only pre-existing `consistent-token-usage` warnings in unrelated story files)

`minor` changeset included, since it removes a public prop from the types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only breaking removal of a no-op prop with no runtime rendering impact; risk is limited to compile failures where callers still pass `necessityLabel`.
> 
> **Overview**
> **Breaking (minor):** removes the public `necessityLabel` prop from `FieldBaseProps`, `FormBaseProps`, legacy `Field`, `Form`, `DialogForm`, and related field types—plus all destructuring, forwarding to `FieldWrapper`/children, Storybook controls, and docs references.
> 
> The prop was documented and threaded through the form stack but never consumed at render time, so **UI behavior is unchanged**; only TypeScript consumers passing `necessityLabel` need to delete it. The changeset notes alternatives: `labelSuffix` / `extra` for adjacent label content, `necessityIndicator` for marker style, and i18n keys `form.required` / `form.optional` for wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa06177fd8960f6c1c9f468f5cc9c2424ff8d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->