### PR TITLE
test(Form): freeze the legacy Form contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Each component lives in `src/components/{category}/{ComponentName}/` and ships `
 - `pnpm chromatic:report` — snapshot inventory + TurboSnap blast radius. `pnpm chromatic:check` is the CI gate; `pnpm chromatic:duplicates` finds stories that photograph the same thing. All three read `storybook-static`, so run `pnpm build-storybook` first. See [The Snapshot Budget](#stories-the-snapshot-budget)
 - `pnpm add-icons` — add new icons from tabler
 - `pnpm audit-docs` — audit component API ↔ docs ↔ argTypes sync. Options: `--component=Name`, `--fix-stories`, `--fix-docs`, `--json`, `--verbose`, `--all-props`. **Run after changing a component's API or adding a new component.**
+- `pnpm diagnostics:form` — report-only React Hooks / React Compiler diagnostics for the Form surface and input components, compared against a committed ratchet baseline (`--check` fails on growth, `--update` rewrites it). Not part of `pnpm lint`. See [`src/components/form/Form/legacy-contract/README.md`](src/components/form/Form/legacy-contract/README.md)
 - `pnpm audit-defaults` — regenerate the lint plugin's defaults registry (`src/eslint-plugin/defaults.generated.ts`). **Run whenever you change a default prop value.** `pnpm test` fails until the registry matches what the components actually render — see [eslint-plugin.md](docs/rules/eslint-plugin.md).
 - `pnpm run update-tasty` / `pnpm run update-glaze` — bump and pin `@tenphi/tasty` or `@tenphi/glaze` to the latest version. Pass `--version=X.Y.Z` to pin a specific version.
 

--- a/eslint.hooks.config.mjs
+++ b/eslint.hooks.config.mjs
@@ -1,0 +1,41 @@
+// Report-only React Hooks / React Compiler diagnostics.
+//
+// This config is NOT part of `pnpm lint`. It is consumed by
+// `scripts/form-diagnostics.mjs`, which records the official
+// `eslint-plugin-react-hooks` (v7, compiler-backed) findings for the Form
+// surface and compares them against a committed baseline — see
+// `src/components/form/Form/legacy-contract/README.md`.
+//
+// Every rule runs at `warn`: the point is to *see* the diagnostics, not to fail
+// the build on them. Zero is not yet required (Form modernization plan, §8.1).
+import tsParser from '@typescript-eslint/parser';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+const recommended = reactHooks.configs.recommended.rules;
+
+const rules = Object.fromEntries(
+  Object.keys(recommended).map((rule) => [rule, 'warn']),
+);
+
+export default [
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      '**/*.test.{ts,tsx}',
+      '**/*.browser.test.{ts,tsx}',
+      '**/*.stories.{ts,tsx}',
+      '**/legacy-contract/**',
+      '**/__mocks__/**',
+    ],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: { 'react-hooks': reactHooks },
+    rules,
+  },
+];

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "add-icons": "cd src/icons && node add-new-icon.js && pnpm fix",
     "audit-docs": "node scripts/audit-docs.mjs",
     "audit-defaults": "UPDATE_DEFAULTS=1 vitest run src/eslint-plugin/defaults.test.ts && prettier --write src/eslint-plugin/defaults.generated.ts",
+    "diagnostics:form": "node scripts/form-diagnostics.mjs",
     "update-tasty": "pnpm add @tenphi/tasty@${npm_config_version:-latest} --save-exact",
     "update-glaze": "pnpm add @tenphi/glaze@${npm_config_version:-latest} --save-exact"
   },
@@ -145,6 +146,7 @@
     "@types/react-dom": "^19.1.7",
     "@types/react-is": "^18.2.4",
     "@types/react-test-renderer": "^18.0.7",
+    "@typescript-eslint/parser": "^8.69.0",
     "@uiw/react-codemirror": "^4.25.4",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/browser": "^4.1.10",
@@ -156,6 +158,7 @@
     "csstype": "^3.1.2",
     "dedent": "^0.7.0",
     "eslint": "^10.8.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "husky": "^6.0.0",
     "jiti": "^2.6.1",
     "jsdom": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@types/react-test-renderer':
         specifier: ^18.0.7
         version: 18.0.7
+      '@typescript-eslint/parser':
+        specifier: ^8.69.0
+        version: 8.69.0(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)
       '@uiw/react-codemirror':
         specifier: ^4.25.4
         version: 4.25.4(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.9)(codemirror@6.0.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -225,6 +228,9 @@ importers:
       eslint:
         specifier: ^10.8.0
         version: 10.8.0(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.8.0(jiti@2.6.1))
       husky:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2374,14 +2380,31 @@ packages:
   '@types/yargs@17.0.24':
     resolution: {integrity: sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==}
 
+  '@typescript-eslint/parser@8.69.0':
+    resolution: {integrity: sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/project-service@8.56.1':
     resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.69.0':
+    resolution: {integrity: sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.56.1':
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.69.0':
+    resolution: {integrity: sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -2390,8 +2413,18 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/tsconfig-utils@8.69.0':
+    resolution: {integrity: sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.56.1':
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.69.0':
+    resolution: {integrity: sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.56.1':
@@ -2399,6 +2432,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/typescript-estree@8.69.0':
+    resolution: {integrity: sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/utils@8.56.1':
     resolution: {integrity: sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==}
@@ -2409,6 +2448,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.56.1':
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.69.0':
+    resolution: {integrity: sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@uiw/codemirror-extensions-basic-setup@4.25.4':
@@ -3260,6 +3303,12 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -3562,6 +3611,12 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   highcharts@9.3.3:
     resolution: {integrity: sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg==}
@@ -5337,6 +5392,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -5821,6 +5882,15 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8479,10 +8549,31 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
+  '@typescript-eslint/parser@8.69.0(eslint@10.8.0(jiti@2.6.1))(typescript@5.6.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.69.0
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.6.3)
+      '@typescript-eslint/visitor-keys': 8.69.0
+      debug: 4.4.3
+      eslint: 10.8.0(jiti@2.6.1)
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.56.1(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.1
+      debug: 4.4.3
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.69.0(typescript@5.6.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.6.3)
+      '@typescript-eslint/types': 8.69.0
       debug: 4.4.3
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -8493,11 +8584,22 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
+  '@typescript-eslint/scope-manager@8.69.0':
+    dependencies:
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/visitor-keys': 8.69.0
+
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.6.3)':
     dependencies:
       typescript: 5.6.3
 
+  '@typescript-eslint/tsconfig-utils@8.69.0(typescript@5.6.3)':
+    dependencies:
+      typescript: 5.6.3
+
   '@typescript-eslint/types@8.56.1': {}
+
+  '@typescript-eslint/types@8.69.0': {}
 
   '@typescript-eslint/typescript-estree@8.56.1(typescript@5.6.3)':
     dependencies:
@@ -8510,6 +8612,21 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.6.3)
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.69.0(typescript@5.6.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.69.0(typescript@5.6.3)
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.6.3)
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/visitor-keys': 8.69.0
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -8528,6 +8645,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.56.1':
     dependencies:
       '@typescript-eslint/types': 8.56.1
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.69.0':
+    dependencies:
+      '@typescript-eslint/types': 8.69.0
       eslint-visitor-keys: 5.0.1
 
   '@uiw/codemirror-extensions-basic-setup@4.25.4(@codemirror/autocomplete@6.20.0)(@codemirror/commands@6.10.1)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.2)(@codemirror/search@6.5.11)(@codemirror/state@6.5.3)(@codemirror/view@6.39.9)':
@@ -9464,6 +9586,17 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/parser': 7.29.0
+      eslint: 10.8.0(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 4.5.4
+      zod-validation-error: 4.0.2(zod@4.5.4)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -9799,6 +9932,12 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   highcharts@9.3.3: {}
 
@@ -11802,6 +11941,10 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  ts-api-utils@2.5.0(typescript@5.6.3):
+    dependencies:
+      typescript: 5.6.3
+
   ts-dedent@2.2.0: {}
 
   ts-node@10.9.1(@types/node@24.13.3)(typescript@5.6.3):
@@ -12306,5 +12449,11 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-validation-error@4.0.2(zod@4.5.4):
+    dependencies:
+      zod: 4.5.4
+
+  zod@4.5.4: {}
 
   zwitch@2.0.4: {}

--- a/scripts/form-diagnostics.mjs
+++ b/scripts/form-diagnostics.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Report-only React Hooks / React Compiler diagnostics for the Form surface.
+ *
+ * Runs the official `eslint-plugin-react-hooks` (v7, compiler-backed) rules —
+ * via `eslint.hooks.config.mjs` — over the shared Form code and the input
+ * components, and compares the findings against a committed baseline.
+ *
+ *   pnpm diagnostics:form            print the report (never fails)
+ *   pnpm diagnostics:form --check    fail if any file+rule count grew
+ *   pnpm diagnostics:form --update   rewrite the baseline from the current run
+ *   pnpm diagnostics:form --verbose  list every message, not just the counts
+ *   pnpm diagnostics:form --json     print the raw report as JSON
+ *
+ * The baseline is a ratchet: counts may go down freely, and a decrease should
+ * be committed with `--update`; an increase fails `--check`. Zero is not yet a
+ * requirement — see the Form modernization plan, §8.1, and the legacy contract
+ * README next to the baseline file.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ESLint } from 'eslint';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+const BASELINE_PATH = join(
+  root,
+  'src/components/form/Form/legacy-contract/diagnostics-baseline.json',
+);
+
+/**
+ * What "the Form surface" means for this report. Shared presentation/input
+ * code and the legacy engine are listed separately so the README can talk about
+ * them separately; the ESLint config's `ignores` drops tests and stories.
+ */
+const SCOPE = {
+  'legacy engine': [
+    'src/components/form/Form/Form.tsx',
+    'src/components/form/Form/use-form.tsx',
+    'src/components/form/Form/validation.ts',
+    'src/components/form/Form/use-field/**/*.{ts,tsx}',
+    'src/components/form/Form/Field.tsx',
+  ],
+  'shared form surface': [
+    'src/components/form/**/*.{ts,tsx}',
+    'src/components/overlays/Dialog/DialogForm.tsx',
+    'src/shared/form.ts',
+  ],
+  'input components': ['src/components/fields/**/*.{ts,tsx}'],
+};
+
+const args = new Set(process.argv.slice(2));
+const flags = {
+  check: args.has('--check'),
+  update: args.has('--update'),
+  verbose: args.has('--verbose'),
+  json: args.has('--json'),
+};
+
+function toPosix(path) {
+  return path.split('\\').join('/');
+}
+
+async function lint() {
+  const eslint = new ESLint({
+    cwd: root,
+    overrideConfigFile: join(root, 'eslint.hooks.config.mjs'),
+    errorOnUnmatchedPattern: false,
+  });
+
+  const patterns = [...new Set(Object.values(SCOPE).flat())];
+  const results = await eslint.lintFiles(patterns);
+
+  const messages = [];
+
+  for (const result of results) {
+    const file = toPosix(relative(root, result.filePath));
+
+    for (const message of result.messages) {
+      messages.push({
+        file,
+        line: message.line ?? 0,
+        column: message.column ?? 0,
+        rule: message.ruleId ?? (message.fatal ? 'parse-error' : 'unknown'),
+        message: message.message,
+      });
+    }
+  }
+
+  messages.sort(
+    (a, b) =>
+      a.file.localeCompare(b.file) ||
+      a.line - b.line ||
+      a.column - b.column ||
+      a.rule.localeCompare(b.rule),
+  );
+
+  return { filesLinted: results.length, messages };
+}
+
+function aggregate(messages) {
+  const totals = {};
+  const files = {};
+
+  for (const { file, rule } of messages) {
+    totals[rule] = (totals[rule] ?? 0) + 1;
+    files[file] ??= {};
+    files[file][rule] = (files[file][rule] ?? 0) + 1;
+  }
+
+  const sortKeys = (object) =>
+    Object.fromEntries(
+      Object.keys(object)
+        .sort()
+        .map((key) => [
+          key,
+          typeof object[key] === 'object' ? sortKeys(object[key]) : object[key],
+        ]),
+    );
+
+  return { totals: sortKeys(totals), files: sortKeys(files) };
+}
+
+function versionOf(pkg) {
+  try {
+    return require(`${pkg}/package.json`).version;
+  } catch {
+    return 'unknown';
+  }
+}
+
+function readBaseline() {
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Every (file, rule) whose count grew against the baseline. */
+function regressions(current, baseline) {
+  const grown = [];
+
+  for (const [file, rules] of Object.entries(current.files)) {
+    for (const [rule, count] of Object.entries(rules)) {
+      const before = baseline?.files?.[file]?.[rule] ?? 0;
+
+      if (count > before) {
+        grown.push({ file, rule, before, after: count });
+      }
+    }
+  }
+
+  return grown;
+}
+
+function printReport({ filesLinted, messages }, aggregated, baseline) {
+  const total = messages.length;
+  const baselineTotal = baseline
+    ? Object.values(baseline.totals).reduce((sum, n) => sum + n, 0)
+    : null;
+
+  console.log(
+    `# Form surface — React Hooks / Compiler diagnostics (report-only)\n`,
+  );
+  console.log(`Files linted: ${filesLinted}`);
+  console.log(
+    `Diagnostics: ${total}${
+      baselineTotal == null ? '' : ` (baseline ${baselineTotal})`
+    }\n`,
+  );
+
+  console.log('| Rule | Count | Baseline |');
+  console.log('| --- | ---: | ---: |');
+
+  const rules = new Set([
+    ...Object.keys(aggregated.totals),
+    ...Object.keys(baseline?.totals ?? {}),
+  ]);
+
+  for (const rule of [...rules].sort()) {
+    console.log(
+      `| ${rule} | ${aggregated.totals[rule] ?? 0} | ${
+        baseline?.totals?.[rule] ?? 0
+      } |`,
+    );
+  }
+
+  console.log('\n| File | Diagnostics |');
+  console.log('| --- | ---: |');
+
+  const byFile = Object.entries(aggregated.files)
+    .map(([file, rules]) => [
+      file,
+      Object.values(rules).reduce((sum, n) => sum + n, 0),
+    ])
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+
+  for (const [file, count] of byFile) {
+    console.log(`| ${file} | ${count} |`);
+  }
+
+  if (flags.verbose) {
+    console.log('\n## Messages\n');
+
+    for (const { file, line, column, rule, message } of messages) {
+      console.log(`- ${file}:${line}:${column} [${rule}] ${message}`);
+    }
+  }
+}
+
+const lintResult = await lint();
+const aggregated = aggregate(lintResult.messages);
+const baseline = readBaseline();
+
+const report = {
+  generatedAt: new Date().toISOString(),
+  tooling: {
+    eslint: versionOf('eslint'),
+    'eslint-plugin-react-hooks': versionOf('eslint-plugin-react-hooks'),
+    '@typescript-eslint/parser': versionOf('@typescript-eslint/parser'),
+  },
+  scope: SCOPE,
+  filesLinted: lintResult.filesLinted,
+  totals: aggregated.totals,
+  files: aggregated.files,
+};
+
+if (flags.json) {
+  console.log(
+    JSON.stringify({ ...report, messages: lintResult.messages }, null, 2),
+  );
+} else {
+  printReport(lintResult, aggregated, baseline);
+}
+
+if (flags.update) {
+  // Format through the repo's Prettier config so `pnpm prettier` stays green
+  // and a re-run produces a byte-identical file.
+  const prettier = await import('prettier');
+  const options = await prettier.resolveConfig(BASELINE_PATH);
+  const formatted = await prettier.format(JSON.stringify(report, null, 2), {
+    ...options,
+    filepath: BASELINE_PATH,
+  });
+
+  writeFileSync(BASELINE_PATH, formatted);
+  console.log(`\nBaseline written to ${relative(root, BASELINE_PATH)}`);
+}
+
+if (flags.check) {
+  if (!baseline) {
+    console.error(
+      `\nNo baseline at ${relative(root, BASELINE_PATH)}. Run with --update first.`,
+    );
+    process.exit(2);
+  }
+
+  const grown = regressions(aggregated, baseline);
+
+  if (grown.length) {
+    console.error('\nDiagnostics grew against the baseline:');
+
+    for (const { file, rule, before, after } of grown) {
+      console.error(`- ${file} [${rule}]: ${before} -> ${after}`);
+    }
+
+    console.error(
+      '\nFix the new findings, or run `pnpm diagnostics:form --update` if the increase is reviewed and intended.',
+    );
+    process.exit(1);
+  }
+
+  console.log('\nNo diagnostics grew against the baseline.');
+}

--- a/src/components/form/AGENTS.md
+++ b/src/components/form/AGENTS.md
@@ -3,3 +3,5 @@
 The rules for building form-attachable input components live in [`docs/rules/input-components.md`](../../../docs/rules/input-components.md) — hook order, the two `useFieldProps` modes, id/label wiring, `wrapWithField`, validation props and the shared validation helpers.
 
 Read it before touching anything in this folder or in `src/components/fields/`.
+
+The current Form engine is the **legacy backend** of the Form modernization plan. Its behaviour is frozen by the characterization suite in [`Form/legacy-contract/`](Form/legacy-contract/README.md): every `it()` there is labelled `[frozen]`, `[bug-eligible]`, `[undefined]` or `[design-input]`, and the README's contract table says what each label allows. Do not change a `[frozen]` behaviour, and do not fix a `[bug-eligible]` one without a compatibility review. `pnpm diagnostics:form` reports (but does not yet enforce) the React Hooks / Compiler findings for this folder against a committed baseline.

--- a/src/components/form/Form/legacy-contract/README.md
+++ b/src/components/form/Form/legacy-contract/README.md
@@ -1,0 +1,133 @@
+# Legacy Form contract
+
+This folder freezes the behaviour of the current Form engine (`CubeFormInstance`, `useForm`, `<Form>`, `useField`, `useFieldProps`, `Field`/`Form.Item`, `DialogForm` and the helper components) as **recorded, not designed**. It is Phase 1 of the Form and React Compiler modernization plan: the legacy backend keeps this behaviour until it is removed in a separately approved major release, and the modern backend is allowed to differ only where a row below says so.
+
+Nothing in this folder changes product code. It ships no runtime, and it is excluded from the package.
+
+## Contract classes
+
+Every `it()` name starts with one of four labels. They are greppable and they are the review vocabulary for any later change to the legacy engine.
+
+| Label | Meaning |
+| --- | --- |
+| `[frozen]` | Frozen legacy contract. Preserve until legacy removal. Cloud relies on it or can reasonably rely on it. |
+| `[bug-eligible]` | Legacy bug eligible for a surgical fix. Fix only with an explicit compatibility review; the test then flips to `[frozen]` with the corrected value. |
+| `[undefined]` | Undefined legacy behaviour. Do not rely on it; warn where practical. The modern backend owes it nothing. |
+| `[design-input]` | Modern design input. Legacy behaviour recorded because the modern backend intentionally differs (see the plan, §7.2–§7.5). |
+
+Run the suite with `pnpm test -- legacy-contract`. It is part of `pnpm test`.
+
+## Phase 0 baselines
+
+Recorded on the stand before any of this landed.
+
+| Item | Value |
+| --- | --- |
+| `ui-kit` commit | `b204a4d7` on `main` (package version 0.175.0) |
+| Dependencies | `react`/`react-dom` 19.1.1 (dev), `@tenphi/tasty` 3.5.0, `@tenphi/glaze` 2.0.0, Node 24.18.0, pnpm 10.34.5 |
+| Full test suite (`pnpm test`) | 103 files, 2222 passed, 1 skipped, 42.7s. With this folder: 110 files, 2330 passed, 1 skipped, 58.2s |
+| Type check (`tsc --noEmit`) | 18 pre-existing errors, none in Form code (`CommandMenu.stories` ×4, `CommandTextArea` ×3, `caretPosition` ×2, `Tooltip.stories` ×2, `eslint-plugin/fixtures` ×2, probe harnesses ×4, `Item.test` ×1); ~30s. This folder adds none |
+| Build (`pnpm build`) | 15.3s |
+| Size (`pnpm size`, local macOS) | `All` 515.57 kB of 517 kB; `Tree shaking (just a Button)` 123.02 kB of 125 kB — unchanged by this work, which adds no runtime code |
+| Cloud (`cubejs-enterprise`) commit | `99823df0` on `master`; `console-ui` consumes `@cube-dev/ui-kit` 0.172.0 |
+| Cloud Form usage (grep, not AST-aware) | 107 `console-ui` files read a mutable getter (`getFieldValue`, `getFieldInstance`, `isDirty`, `isFieldDirty`, `isSubmitting`, …) |
+
+Cloud grep counts (lines / files under `packages/console-ui/src`): `getFieldValue` 97/40, `setFields` 71/35, `useForm(` 64/62, `.isDirty` 29/16, `isFieldDirty` 27/15, `.isSubmitting` 21/8, `getFieldsValue` 14/11, `submitError` 12/6, `getFormData` 10/6, `getFieldInstance` 4/3, `.isInvalid` 5/5, `forceReRender` 1/1, `new CubeFormInstance` 0/0, `Form.Item` 62/12, `<Field ` 69/28, `DialogForm` 191/60, `action=` 50/20. The AST-aware inventory that separates render-time reads from imperative reads (plan Phase 0, step 8) is still to do and lives in the Cloud repo.
+
+## Contract table
+
+One row per item of plan §7.1. "Existing" points at the pre-existing spec that already covers the visible behaviour; the new spec fills the gaps and pins the instance-level contract.
+
+| # | Behaviour | Spec | Classes | Recorded outcome |
+| --- | --- | --- | --- | --- |
+| 1 | Creation | `instance-and-binding` | frozen, undefined | `Form.useForm()` returns one stable instance and installs `forceReRender` on its creator. `useForm(instance)` adopts without installing anything, so a bare `new CubeFormInstance()` passed to `<Form>` **never rerenders anything** (undefined). Classify direct construction as unsupported for reactive use. |
+| 2 | Context binding | `instance-and-binding`; existing `field.test` | frozen | Named inputs register with the context form; unnamed ones do not. `CheckboxGroup`/`RadioGroup` register once and mask the context so options never register, even with a `name`. |
+| 3 | Explicit precedence / detachment | `instance-and-binding`; existing `explicit-form-prop.test`, `unbind-form-prop.test` | frozen | Explicit `form` wins over context; `form={undefined}` and `form={null}` both detach and leave the input controlled by its own props. |
+| 4 | Form identity change after mount | `instance-and-binding` | undefined | `<Form form={b}>` after mounting with `a` keeps using `a`. An input whose `form` prop changes registers with the new form **and stays registered in the old one**. |
+| 5 | Registration order, duplicates | `instance-and-binding` | frozen, undefined | `getFieldNames()` is mount order. Two inputs with one name share a field object; unmounting either deletes it and the survivor re-registers with the default value (undefined). |
+| 6 | Dynamic names | `instance-and-binding` | frozen, undefined | Renaming re-registers under the new name and drops the old value. Switching between named and standalone changes the hook order in `useFieldProps` and throws (`Should have a queue…` / a React internal `TypeError`). |
+| 7 | First-mount defaults | `defaults-and-values`; existing `field.test` | frozen, undefined | Form defaults seed fields without dirtying them. A field-level `defaultValue` fills an empty field and becomes its baseline. When both exist the field default wins for an untouched field **but the Form default stays the dirty baseline**, so the field starts dirty (undefined). |
+| 8 | Form default changes after mount | `defaults-and-values`; existing `field.test` | frozen | Current values are untouched, the dirty baseline moves, `resetFields()` adopts the new defaults. |
+| 9 | Field-level `defaultValue` changes | `defaults-and-values`; existing `field.test` | frozen | Applied on every untouched render, ignored after touch, and only the first one reaches the baseline. |
+| 10 | Reset after default changes | `defaults-and-values` | frozen | `resetFields()` restores the current Form defaults and clears touched, errors, status; `resetFields(names)` is scoped. |
+| 11 | Value kinds | `defaults-and-values` | frozen, bug-eligible, design-input | `''` survives reset. `null` survives mount but **becomes `undefined` (and dirty) after reset** (bug-eligible). Arrays/objects compare by `JSON.stringify`: an equal copy is not a change (design-input). Dot paths flatten in `getFieldsValue()` and nest in `getFormData()`; setting an object on a parent path fans out with `null` for missing keys. |
+| 12 | Setters before registration / unmount | `defaults-and-values` | frozen | `setFieldValue`/`setFieldsValue` are ignored for unregistered fields. `setInitialFieldsValue()` and `setFields()` are the two ways to seed before mount; a later mount adopts them. |
+| 13 | Registered-only getters and submission | `defaults-and-values` | frozen | `getFieldsValue()`, `getFormData()` and `onSubmit` see mounted fields only. |
+| 14 | Conditional unmount / remount | `defaults-and-values` | frozen | Unmount deletes the value; remount starts from the default, untouched. |
+| 15 | User vs programmatic changes | `change-and-callbacks`; existing `submit.test` | frozen | User changes (and `setFieldValue(…, true)`) touch and notify; plain `setFieldValue` does neither but does dirty. `setFieldsValue(values, true)` notifies once per batch; `…, false` clears touched. |
+| 16 | Equal-value setters | `change-and-callbacks` | frozen | `setFieldValue` with an equal value is a full no-op (errors kept). `setFieldsValue` with an equal value **clears that field's errors and status** without notifying or rendering. |
+| 17 | `onValuesChange` payload and timing | `change-and-callbacks` | frozen | Synchronous, once per keystroke, with the nested `getFormData()` payload. |
+| 18 | Changing and removing callbacks | `change-and-callbacks` | frozen, bug-eligible | A new callback replaces the old one. Passing `undefined` **leaves the previous `onValuesChange`/`onSubmit` installed** (bug-eligible; `useForm` only writes truthy callbacks). |
+| 19 | Instance created above the root | `instance-and-binding`, `render-baseline` | frozen | `<Form>` installs its callbacks on the external instance; mutations rerender the creating component, not just `<Form>`. |
+| 20 | Validation triggers and status | `validation` | frozen, bug-eligible | Text inputs validate on blur; `onChange` validates per change. Status is `undefined → valid \| invalid`; `isValid` needs every field valid, `isInvalid` needs one invalid; a cached status short-circuits until the value changes. **Every user change runs the field handler twice** (chained `onChange`s in `useFieldProps`), so `onChange` validation runs the validator twice per change; **changing an invalid field clears its errors without revalidating**; a cached `invalid` status rejects the bare error where a fresh run rejects `[error]`. |
+| 21 | Delayed and overlapping validation | `validation` | frozen | Overlapping runs: only the latest publishes. `validationDelay` coalesces rapid changes into one validator run. |
+| 22 | Changes during validation | `validation` | frozen, bug-eligible, undefined | `resetFieldsValidation()`/`resetFields()` discard the pending result. **A value change does not** (bug-eligible): the stale result publishes against the new value. A result that lands after unmount still writes into the detached field object and rerenders the owner (undefined). Inline rule arrays do not trigger validation by themselves; rules are re-read at the next run. |
+| 23 | Error shape | `validation` | frozen | Only the first failing rule reports. `Error` → its message; empty rejection → `rule.message`; anything else passes through, including ReactNodes. |
+| 24 | Submission | `submission`; existing `submit.test` | frozen | Validates all registered fields, skips `onSubmit` on failure (`onSubmitFailed` not called), passes `getFormData()`, ignores a second `submit()` while one is in flight. |
+| 25 | `Error` vs non-`Error` rejection | `submission`; existing `submit.test`, `submit-error.test` | frozen | Both become `submitError` and call `onSubmitFailed`; an `Error` additionally rejects `form.submit()` (through a DOM submit this surfaces as an unhandled rejection). |
+| 26 | `onSubmitFailed` timing | `submission` | frozen | Called after an internal 30ms `timeout()`, while `isSubmitting` is still `true`, and not awaited. |
+| 27 | Submit error clearing | `submission`; existing `submit-error.test` | frozen | Cleared when the next submit starts and on a user change; a programmatic `setFieldValue` keeps it. |
+| 28 | Direct writes and `forceReRender` | `change-and-callbacks` | frozen | `form.submitError = …` and `form.isSubmitting = …` are invisible until `forceReRender()`; `setSubmitting()` rerenders by itself. |
+| 29 | Native `action`/`method` | `submission` | frozen | With `action`, no JS submit handler is attached: the event is not prevented and `onSubmit` never runs. Without it the event is prevented and routed through validation. A submitter without `type="submit"` is ignored. Hidden inputs reach `FormData` but never become fields. Only `action`, `autoComplete`, `encType`, `method`, `target` reach the DOM. |
+| 30 | Refs | `instance-and-binding` | frozen, undefined | The Form ref receives the `<form>`. `form.ref` is copied from `ref.current` during the first render and is therefore `null` (undefined). |
+| 31 | Ids | `instance-and-binding`, `render-baseline` | frozen, bug-eligible | Ids derive from the name, deduplicate (`name`, `name_1`), take the Form `name` as prefix, use an explicit `id` verbatim, and are released on unmount (Strict Mode included). **Two `TextInput`s sharing a base id both render `name_1`** and the first label points at `name` (bug-eligible; the module-global updater map in `utils/react/useId` is keyed by id string). |
+| 32 | Helper components | `submission`, `change-and-callbacks`; existing `submit.test`, `submit-error.test` | frozen | `SubmitButton` disables on `isInvalid` and while submitting; `ResetButton` is disabled until touched and resets on the next tick; both accept an explicit `form` outside `<Form>`. `SubmitError` shows strings and elements and falls back to "Internal error". |
+| 33 | Deprecated `Field` / `Form.Item` | `deprecated-and-custom`; existing `field.test`, `necessity-indicator.test` | frozen | Render-prop children receive the instance. `Form.Item` owns the registration and the id; the child's own `onChange` is **replaced**, not chained (a dev warning says so). Without a `name` it renders field chrome and registers nothing. |
+| 34 | `DialogForm` | `deprecated-and-custom` | frozen | Creates a form when none is passed, installs `onSubmit`, and calls `resetFields()` 250ms after a successful submit or a cancel unless `preserve`. The timer is not tied to the mount, so a reopened dialog sharing the instance can be reset by the previous close (design hazard, plan §10). |
+| 35 | Custom controls | `deprecated-and-custom`; existing `unbind-form-prop.test` | frozen | `useFieldProps` + `wrapWithField` registers, syncs both ways and renders label/errors; without a `name` the control stays standalone with a `useId` id. `useFormProps` exposes `{ form, submitError, labelPosition, idPrefix, requiredMark, … }`. `FieldWrapper` renders a supplied `Component`. Form-only props never reach the DOM. |
+
+## Render baseline
+
+Recorded by `render-baseline.test.tsx` with a fixture of an owner (`useForm()` + `<Form>`), two `TextInput`s and one Form-context consumer under `<Form>`. These are legacy **readings**, not budgets; the modern requirement for each row is in the plan, §11.
+
+| Event | Owner | Context consumer | Field A | Field B |
+| --- | --: | --: | --: | --: |
+| Mount with two fields | 3 | 3 | 3 | 3 |
+| One programmatic user-style change on A | 1 | 1 | 1 | 1 |
+| One keystroke into A | 1 | 1 | 1 | 1 |
+| One validation result published | 1 | 1 | 1 | 1 |
+| `setSubmitting()` / `setFieldError()` (each) | 1 | 1 | 1 | 1 |
+| Change with the instance created by a grandparent | 1 | — | — | — |
+
+Why mount costs three renders: fields are created during render 1 after the `[field]` effect has already captured `undefined` as its dependency; render 2 comes from the mount effects calling `forceReRender()`; render 3 comes from that dependency flipping to the created field object.
+
+Every mutation rerenders the whole owner subtree because the only publication mechanism is the creator's `forceReRender()`. This is the owner-wide behaviour Cloud's render-time getters depend on (plan §1), and the reason the modern backend gets a separate contract rather than a retrofit.
+
+## Lifecycle
+
+- Strict Mode mounting settles with one registration per field and no id leak.
+- Unmounting the owner removes every registration.
+- An instance reused by a new owner after its creator unmounted is no longer reactive (`[undefined]`).
+- A delayed validation started before unmount still runs its validator afterwards: the timer belongs to the rule closure, not to the field (`[undefined]`).
+
+## React Hooks / Compiler diagnostics (report-only)
+
+`pnpm diagnostics:form` runs the official `eslint-plugin-react-hooks` 7.1.1 rules (the compiler-backed set: `rules-of-hooks`, `exhaustive-deps`, `refs`, `immutability`, `set-state-in-effect`, `preserve-manual-memoization`, `use-memo`, `incompatible-library`, …) over the Form surface and the input components through `eslint.hooks.config.mjs`. It is not part of `pnpm lint`; every rule is `warn`, and the committed [`diagnostics-baseline.json`](./diagnostics-baseline.json) is a ratchet:
+
+- `pnpm diagnostics:form` prints the report and never fails.
+- `pnpm diagnostics:form --check` fails if any file+rule count grew against the baseline.
+- `pnpm diagnostics:form --update` rewrites the baseline after a reviewed change (a decrease should always be committed).
+- `--verbose` lists every message; `--json` dumps the raw report.
+
+Baseline on `b204a4d7`: 123 files linted, 114 diagnostics.
+
+| Rule | Total | Legacy engine | Input components |
+| --- | --: | --: | --: |
+| `react-hooks/refs` | 50 | 13 | 37 |
+| `react-hooks/exhaustive-deps` | 23 | 3 | 20 |
+| `react-hooks/immutability` | 15 | 8 | 7 |
+| `react-hooks/rules-of-hooks` | 14 | 5 | 9 |
+| `react-hooks/preserve-manual-memoization` | 5 | 0 | 5 |
+| `react-hooks/set-state-in-effect` | 5 | 1 | 4 |
+| `react-hooks/incompatible-library` | 1 | 0 | 1 |
+| `react-hooks/use-memo` | 1 | 0 | 1 |
+
+The 30 legacy-engine findings are the ones the plan already names in §4.1: the five conditional hooks in `use-field-props.tsx` (`useId`, `useField`, `useChainedCallback`, `useEvent`, `useDebugValue`), render-phase ref reads and default/reset writes in `Form.tsx`, render-phase ref reads and callback writes in `useForm`, and the render-phase field mutation, the `[field]` effect reassigning a render variable, and the `setFieldId` cascade in `use-field.ts`. They are the compiler-containment list for the legacy modules (plan §8.1); zero is not required until a module is either made compiler-clean or given a reviewed opt-out.
+
+The `refs` findings in the input components are dominated by `wrapWithField(component, domRef, props)` passing a ref during render, which the rule reads as a possible render-time ref access. That is a shared-surface question for the Phase 2 spike, not a legacy one.
+
+## Not in this folder
+
+- The Cloud AST-aware inventory (Phase 0, step 8) — a Cloud-repo artifact.
+- CI enforcement of `--check` — the ratchet is available but not yet wired into `pull-request.yml`; enable it once the team agrees the baseline is the floor.
+- Any fix. Every `[bug-eligible]` row needs its own compatibility review before the test flips.

--- a/src/components/form/Form/legacy-contract/change-and-callbacks.test.tsx
+++ b/src/components/form/Form/legacy-contract/change-and-callbacks.test.tsx
@@ -1,0 +1,274 @@
+import { act, render, renderWithForm, userEvent } from '../../../../test/index';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+import { Root } from '../../../Root';
+import { Form, SubmitButton } from '../index';
+import { CubeFormInstance, useForm } from '../use-form';
+
+import { createRenderCounter, FieldProbe, renderOwnedForm } from './helpers';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — change notification and callbacks.
+ *
+ * Covers plan §7.1 items 15 (user vs programmatic touched/dirty), 16 (equal-value
+ * setters), 17 (`onValuesChange` payload and timing), 18 (changing and removing
+ * callbacks) and 28 (direct `submitError` / `forceReRender` usage).
+ */
+
+describe('legacy contract: touched, dirty and change notifications (§7.1 #15–#17)', () => {
+  it('[frozen] a user change marks the field touched and notifies onValuesChange; programmatic setFieldValue does neither', async () => {
+    const onValuesChange = vi.fn();
+    const { formInstance, getByRole } = renderWithForm(
+      <>
+        <TextInput name="a" label="A" />
+        <TextInput name="b" label="B" />
+      </>,
+      { formProps: { onValuesChange } },
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox', { name: 'A' }), 'x');
+    });
+
+    expect(formInstance.isFieldTouched('a')).toBe(true);
+    expect(formInstance.isFieldDirty('a')).toBe(true);
+    expect(onValuesChange).toHaveBeenCalledTimes(1);
+    expect(onValuesChange).toHaveBeenCalledWith({ a: 'x', b: undefined });
+
+    onValuesChange.mockClear();
+
+    await act(async () => {
+      formInstance.setFieldValue('b', 'y');
+    });
+
+    expect(formInstance.isFieldTouched('b')).toBe(false);
+    expect(formInstance.isFieldDirty('b')).toBe(true);
+    expect(formInstance.isTouched).toBe(true);
+    expect(onValuesChange).not.toHaveBeenCalled();
+  });
+
+  it('[frozen] setFieldValue(name, value, true) behaves like a user change', async () => {
+    const onValuesChange = vi.fn();
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { onValuesChange },
+    });
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'x', true);
+    });
+
+    expect(formInstance.isFieldTouched('a')).toBe(true);
+    expect(onValuesChange).toHaveBeenCalledTimes(1);
+    expect(onValuesChange).toHaveBeenCalledWith({ a: 'x' });
+  });
+
+  it('[frozen] setFieldsValue(values, true) notifies once for the batch; setFieldsValue(values, false) clears touched', async () => {
+    const onValuesChange = vi.fn();
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe name="a" />
+        <FieldProbe name="b" />
+      </>,
+      { formProps: { onValuesChange } },
+    );
+
+    await act(async () => {
+      formInstance.setFieldsValue({ a: 1, b: 2 }, true);
+    });
+
+    expect(onValuesChange).toHaveBeenCalledTimes(1);
+    expect(onValuesChange).toHaveBeenCalledWith({ a: 1, b: 2 });
+    expect(formInstance.isFieldTouched('a')).toBe(true);
+    expect(formInstance.isFieldTouched('b')).toBe(true);
+
+    onValuesChange.mockClear();
+
+    await act(async () => {
+      formInstance.setFieldsValue({ a: 3 }, false);
+    });
+
+    expect(onValuesChange).not.toHaveBeenCalled();
+    expect(formInstance.isFieldTouched('a')).toBe(false);
+    expect(formInstance.getFieldValue('a')).toBe(3);
+  });
+
+  it('[frozen] setFieldValue() with an equal value is a no-op that keeps existing errors', async () => {
+    const onValuesChange = vi.fn();
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { defaultValues: { a: 'same' }, onValuesChange },
+    });
+
+    await act(async () => {
+      formInstance.setFieldError('a', 'Bad');
+      formInstance.setFieldValue('a', 'same', true);
+    });
+
+    expect(formInstance.getFieldError('a')).toEqual(['Bad']);
+    expect(formInstance.getFieldInstance('a')!.status).toBe('invalid');
+    expect(onValuesChange).not.toHaveBeenCalled();
+    expect(formInstance.isFieldTouched('a')).toBe(false);
+  });
+
+  it("[frozen] setFieldsValue() with an equal value clears that field's errors without notifying or rendering", async () => {
+    const onValuesChange = vi.fn();
+    const counter = createRenderCounter();
+    const { formInstance } = renderOwnedForm(() => <FieldProbe name="a" />, {
+      formProps: { defaultValues: { a: 'same' }, onValuesChange },
+      counter,
+    });
+
+    await act(async () => {
+      formInstance.setFieldError('a', 'Bad');
+    });
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      formInstance.setFieldsValue({ a: 'same' }, true);
+    });
+
+    expect(formInstance.getFieldError('a')).toEqual([]);
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+    expect(onValuesChange).not.toHaveBeenCalled();
+    expect(counter.since(before).owner).toBe(0);
+  });
+
+  it('[frozen] onValuesChange receives the nested getFormData() payload synchronously on every keystroke', async () => {
+    const onValuesChange = vi.fn();
+    const { getByRole } = renderWithForm(
+      <TextInput name="user.name" label="Name" />,
+      { formProps: { onValuesChange } },
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'ab');
+    });
+
+    expect(onValuesChange.mock.calls).toEqual([
+      [{ user: { name: 'a' } }],
+      [{ user: { name: 'ab' } }],
+    ]);
+  });
+});
+
+describe('legacy contract: changing and removing callbacks (§7.1 #18)', () => {
+  function Fixture({
+    onValuesChange,
+    onSubmit,
+    form,
+  }: {
+    onValuesChange?: (values: any) => void;
+    onSubmit?: (values: any) => void;
+    form: CubeFormInstance<any>;
+  }) {
+    return (
+      <Root>
+        <Form form={form} onValuesChange={onValuesChange} onSubmit={onSubmit}>
+          <FieldProbe name="a" />
+        </Form>
+      </Root>
+    );
+  }
+
+  it('[frozen] a new onValuesChange passed on rerender replaces the previous one', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const form = new CubeFormInstance<any>();
+
+    const { rerender } = render(<Fixture form={form} onValuesChange={first} />);
+
+    rerender(<Fixture form={form} onValuesChange={second} />);
+
+    await act(async () => {
+      form.setFieldValue('a', 'x', true);
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith({ a: 'x' });
+  });
+
+  it('[bug-eligible] passing onValuesChange={undefined} after mount leaves the previous callback installed', async () => {
+    const first = vi.fn();
+    const form = new CubeFormInstance<any>();
+
+    const { rerender } = render(<Fixture form={form} onValuesChange={first} />);
+
+    rerender(<Fixture form={form} />);
+
+    await act(async () => {
+      form.setFieldValue('a', 'x', true);
+    });
+
+    expect(first).toHaveBeenCalledWith({ a: 'x' });
+  });
+
+  it('[bug-eligible] removing onSubmit after mount leaves the previous submit handler installed on the instance', async () => {
+    const first = vi.fn();
+    const form = new CubeFormInstance<any>();
+
+    const { rerender } = render(<Fixture form={form} onSubmit={first} />);
+
+    rerender(<Fixture form={form} />);
+
+    await act(async () => {
+      await form.submit();
+    });
+
+    expect(first).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('legacy contract: direct property writes (§7.1 #28)', () => {
+  it('[frozen] assigning form.submitError shows nothing until forceReRender() republishes the context', async () => {
+    const { formInstance, queryByText } = renderOwnedForm(() => (
+      <>
+        <FieldProbe name="a" />
+        <Form.SubmitError />
+      </>
+    ));
+
+    await act(async () => {
+      formInstance.submitError = 'Boom';
+    });
+
+    expect(queryByText('Boom')).toBeNull();
+
+    await act(async () => {
+      formInstance.forceReRender();
+    });
+
+    expect(queryByText('Boom')).toBeInTheDocument();
+  });
+
+  it('[frozen] writing form.isSubmitting directly is invisible until a rerender; setSubmitting() rerenders', async () => {
+    const { formInstance, getByRole } = renderOwnedForm(() => (
+      <>
+        <FieldProbe name="a" />
+        <SubmitButton>Submit</SubmitButton>
+      </>
+    ));
+
+    const button = getByRole('button', { name: 'Submit' });
+
+    expect(button).toBeEnabled();
+
+    await act(async () => {
+      formInstance.isSubmitting = true;
+    });
+
+    expect(button).toBeEnabled();
+
+    await act(async () => {
+      formInstance.forceReRender();
+    });
+
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      formInstance.setSubmitting(false);
+    });
+
+    expect(button).toBeEnabled();
+  });
+});

--- a/src/components/form/Form/legacy-contract/defaults-and-values.test.tsx
+++ b/src/components/form/Form/legacy-contract/defaults-and-values.test.tsx
@@ -1,0 +1,431 @@
+import {
+  act,
+  render,
+  renderWithForm,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../test/index';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+import { Root } from '../../../Root';
+import { Form } from '../index';
+import { CubeFormInstance, useForm } from '../use-form';
+
+import { FieldProbe } from './helpers';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — defaults, values and registration lifetime.
+ *
+ * Covers plan §7.1 items 7 (first-mount defaults), 8 (Form default changes),
+ * 9 (field-level defaultValue), 10 (reset after default changes), 11 (value
+ * kinds), 12 (setters before registration / after unmount), 13 (registered-only
+ * getters) and 14 (conditional unmount / remount).
+ */
+
+describe('legacy contract: Form defaults (§7.1 #7, #8, #10)', () => {
+  it('[frozen] Form defaultValues seed a field on first mount without making it dirty', () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput name="a" label="A" />,
+      { formProps: { defaultValues: { a: 'form' } } },
+    );
+
+    expect(getByRole('textbox')).toHaveValue('form');
+    expect(formInstance.isFieldDirty('a')).toBe(false);
+    expect(formInstance.isFieldTouched('a')).toBe(false);
+  });
+
+  it('[frozen] changing defaultValues after mount leaves current values alone but moves the dirty baseline', async () => {
+    let form!: CubeFormInstance<any>;
+
+    function Fixture({ defaults }: { defaults: Record<string, unknown> }) {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form} defaultValues={defaults}>
+            <TextInput name="a" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    const { rerender, getByRole } = render(<Fixture defaults={{ a: 'one' }} />);
+
+    expect(getByRole('textbox')).toHaveValue('one');
+
+    rerender(<Fixture defaults={{ a: 'two' }} />);
+
+    // Current value is untouched…
+    expect(getByRole('textbox')).toHaveValue('one');
+    // …but it is now compared against the new baseline.
+    expect(form.isFieldDirty('a')).toBe(true);
+
+    await act(async () => {
+      form.resetFields();
+    });
+
+    expect(getByRole('textbox')).toHaveValue('two');
+    expect(form.isFieldDirty('a')).toBe(false);
+  });
+
+  it('[frozen] resetFields() restores Form defaults and clears touched, errors and status', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        rules={[{ required: true, message: 'Required' }]}
+      />,
+      { formProps: { defaultValues: { a: 'seed' } } },
+    );
+
+    await act(async () => {
+      await userEvent.clear(getByRole('textbox'));
+      await formInstance.validateField('a').catch(() => {});
+    });
+
+    expect(formInstance.isFieldTouched('a')).toBe(true);
+    expect(formInstance.getFieldError('a')).toEqual(['Required']);
+    expect(formInstance.getFieldInstance('a')!.status).toBe('invalid');
+
+    await act(async () => {
+      formInstance.resetFields();
+    });
+
+    expect(getByRole('textbox')).toHaveValue('seed');
+    expect(formInstance.isFieldTouched('a')).toBe(false);
+    expect(formInstance.getFieldError('a')).toEqual([]);
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+  });
+
+  it('[frozen] resetFields(names) resets only the named fields', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <>
+        <TextInput name="a" label="A" />
+        <TextInput name="b" label="B" />
+      </>,
+      { formProps: { defaultValues: { a: 'one', b: 'two' } } },
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox', { name: 'A' }), '!');
+      await userEvent.type(getByRole('textbox', { name: 'B' }), '!');
+    });
+
+    await act(async () => {
+      formInstance.resetFields(['a']);
+    });
+
+    expect(formInstance.getFieldValue('a')).toBe('one');
+    expect(formInstance.getFieldValue('b')).toBe('two!');
+  });
+});
+
+describe('legacy contract: field-level defaultValue (§7.1 #7, #9)', () => {
+  it('[frozen] a field-level defaultValue fills a field the Form left empty and becomes its baseline', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput name="a" label="A" defaultValue="field" />,
+    );
+
+    expect(getByRole('textbox')).toHaveValue('field');
+    expect(formInstance.isFieldDirty('a')).toBe(false);
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), '!');
+      formInstance.resetFields();
+    });
+
+    expect(formInstance.getFieldValue('a')).toBe('field');
+  });
+
+  it('[undefined] a field-level defaultValue overrides a Form default for an untouched field and leaves it dirty', () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput name="a" label="A" defaultValue="field" />,
+      { formProps: { defaultValues: { a: 'form' } } },
+    );
+
+    // The field default is written into the value on every untouched render,
+    // but the Form default stays the dirty baseline.
+    expect(getByRole('textbox')).toHaveValue('field');
+    expect(formInstance.isFieldDirty('a')).toBe(true);
+  });
+
+  it('[frozen] a changed field-level defaultValue applies while untouched and is ignored after touch, without moving the baseline', async () => {
+    function Fixture({ defaultValue }: { defaultValue: string }) {
+      return <TextInput name="a" label="A" defaultValue={defaultValue} />;
+    }
+
+    const { formInstance, rerender, getByRole } = renderWithForm(
+      <Fixture defaultValue="one" />,
+    );
+
+    rerender(<Fixture defaultValue="two" />);
+
+    expect(getByRole('textbox')).toHaveValue('two');
+    // Only the first field default reached the baseline.
+    expect(formInstance.isFieldDirty('a')).toBe(true);
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), '!');
+    });
+
+    rerender(<Fixture defaultValue="three" />);
+
+    expect(getByRole('textbox')).toHaveValue('two!');
+  });
+});
+
+describe('legacy contract: value kinds (§7.1 #11)', () => {
+  it('[bug-eligible] a null Form default is kept on mount but becomes undefined (and dirty) after reset', async () => {
+    const { formInstance, getByTestId } = renderWithForm(
+      <FieldProbe name="a" />,
+      { formProps: { defaultValues: { a: null } } },
+    );
+
+    expect(formInstance.getFieldValue('a')).toBeNull();
+    expect(getByTestId('probe-a')).toHaveTextContent('null');
+
+    await act(async () => {
+      formInstance.resetFields();
+    });
+
+    expect(formInstance.getFieldValue('a')).toBeUndefined();
+    expect(formInstance.isFieldDirty('a')).toBe(true);
+  });
+
+  it('[frozen] an empty-string default survives mount and reset', async () => {
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { defaultValues: { a: '' } },
+    });
+
+    expect(formInstance.getFieldValue('a')).toBe('');
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'x');
+      formInstance.resetFields();
+    });
+
+    expect(formInstance.getFieldValue('a')).toBe('');
+  });
+
+  it('[design-input] arrays and objects are compared by JSON: setting an equal copy is not a change', async () => {
+    const onValuesChange = vi.fn();
+    const initial = ['a'];
+    const { formInstance } = renderWithForm(<FieldProbe name="tags" />, {
+      formProps: { defaultValues: { tags: initial }, onValuesChange },
+    });
+
+    await act(async () => {
+      formInstance.setFieldValue('tags', ['a'], true);
+    });
+
+    expect(onValuesChange).not.toHaveBeenCalled();
+    expect(formInstance.getFieldValue('tags')).toBe(initial);
+
+    await act(async () => {
+      formInstance.setFieldValue('tags', ['a', 'b'], true);
+    });
+
+    expect(onValuesChange).toHaveBeenCalledTimes(1);
+    expect(formInstance.isFieldDirty('tags')).toBe(true);
+  });
+
+  it('[frozen] dot-path defaults register as flat fields and nest back in getFormData()', () => {
+    const { formInstance } = renderWithForm(<FieldProbe name="user.name" />, {
+      formProps: { defaultValues: { user: { name: 'Ann' } } },
+    });
+
+    expect(formInstance.getFieldValue('user.name')).toBe('Ann');
+    expect(formInstance.getFieldsValue()).toEqual({ 'user.name': 'Ann' });
+    expect(formInstance.getFormData()).toEqual({ user: { name: 'Ann' } });
+  });
+
+  it('[frozen] setting an object on a parent path fans out to registered child paths, with null for missing keys', async () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe name="user" />
+        <FieldProbe name="user.name" />
+        <FieldProbe name="user.age" />
+      </>,
+    );
+
+    await act(async () => {
+      formInstance.setFieldValue('user', { name: 'Bob' });
+    });
+
+    expect(formInstance.getFieldValue('user.name')).toBe('Bob');
+    expect(formInstance.getFieldValue('user.age')).toBeNull();
+    expect(formInstance.getFormData()).toEqual({
+      user: { name: 'Bob', age: null },
+    });
+  });
+});
+
+describe('legacy contract: setters before registration and after unmount (§7.1 #12)', () => {
+  it('[frozen] setFieldValue() and setFieldsValue() before registration are ignored', async () => {
+    let form!: CubeFormInstance<any>;
+
+    function Fixture({ mounted }: { mounted: boolean }) {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form}>{mounted ? <FieldProbe name="a" /> : null}</Form>
+        </Root>
+      );
+    }
+
+    const { rerender } = render(<Fixture mounted={false} />);
+
+    await act(async () => {
+      form.setFieldValue('a', 'x');
+      form.setFieldsValue({ a: 'y' });
+    });
+
+    expect(form.getFieldValue('a')).toBeUndefined();
+    expect(form.getFieldNames()).toEqual([]);
+
+    rerender(<Fixture mounted />);
+
+    expect(form.getFieldValue('a')).toBeUndefined();
+  });
+
+  it('[frozen] setInitialFieldsValue() before registration seeds the field on mount', async () => {
+    let form!: CubeFormInstance<any>;
+
+    function Fixture({ mounted }: { mounted: boolean }) {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form}>{mounted ? <FieldProbe name="a" /> : null}</Form>
+        </Root>
+      );
+    }
+
+    const { rerender } = render(<Fixture mounted={false} />);
+
+    await act(async () => {
+      form.setInitialFieldsValue({ a: 'seed' });
+    });
+
+    rerender(<Fixture mounted />);
+
+    expect(form.getFieldValue('a')).toBe('seed');
+    expect(form.isFieldDirty('a')).toBe(false);
+  });
+
+  it('[frozen] setFields() creates an unregistered field whose value a later mount adopts', async () => {
+    let form!: CubeFormInstance<any>;
+
+    function Fixture({ mounted }: { mounted: boolean }) {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form}>{mounted ? <FieldProbe name="a" /> : null}</Form>
+        </Root>
+      );
+    }
+
+    const { rerender, getByTestId } = render(<Fixture mounted={false} />);
+
+    await act(async () => {
+      form.setFields([{ name: 'a', value: 'pre', errors: [] }]);
+    });
+
+    expect(form.getFieldNames()).toEqual(['a']);
+    expect(form.getFieldsValue()).toEqual({ a: 'pre' });
+
+    rerender(<Fixture mounted />);
+
+    expect(getByTestId('probe-a')).toHaveTextContent('"pre"');
+  });
+
+  it('[frozen] setters after unmount are ignored and the value is gone', async () => {
+    function Fixture({ mounted }: { mounted: boolean }) {
+      return mounted ? <FieldProbe name="a" /> : null;
+    }
+
+    const { formInstance, rerender } = renderWithForm(<Fixture mounted />);
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'x');
+    });
+
+    rerender(<Fixture mounted={false} />);
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'y');
+    });
+
+    expect(formInstance.getFieldNames()).toEqual([]);
+    expect(formInstance.getFieldValue('a')).toBeUndefined();
+  });
+});
+
+describe('legacy contract: registered-only getters and submission (§7.1 #13, #14)', () => {
+  it('[frozen] getFieldsValue(), getFormData() and submission only include mounted fields', async () => {
+    const onSubmit = vi.fn();
+
+    function Fixture({ withB }: { withB: boolean }) {
+      return (
+        <>
+          <FieldProbe name="a" />
+          {withB ? <FieldProbe name="b" /> : null}
+        </>
+      );
+    }
+
+    const { formInstance, rerender } = renderWithForm(<Fixture withB />, {
+      formProps: { defaultValues: { a: 1, b: 2 }, onSubmit },
+    });
+
+    expect(formInstance.getFieldsValue()).toEqual({ a: 1, b: 2 });
+
+    rerender(<Fixture withB={false} />);
+
+    expect(formInstance.getFieldsValue()).toEqual({ a: 1 });
+    expect(formInstance.getFormData()).toEqual({ a: 1 });
+
+    await act(async () => {
+      await formInstance.submit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({ a: 1 });
+  });
+
+  it('[frozen] a conditionally unmounted field loses its value and remounts with its default', async () => {
+    function Fixture({ withB }: { withB: boolean }) {
+      return (
+        <>
+          <TextInput name="a" label="A" />
+          {withB ? <TextInput name="b" label="B" /> : null}
+        </>
+      );
+    }
+
+    const { formInstance, rerender } = renderWithForm(<Fixture withB />, {
+      formProps: { defaultValues: { b: 'default' } },
+    });
+
+    await act(async () => {
+      await userEvent.clear(screen.getByRole('textbox', { name: 'B' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'B' }), 'typed');
+    });
+
+    expect(formInstance.getFieldValue('b')).toBe('typed');
+
+    rerender(<Fixture withB={false} />);
+
+    expect(formInstance.getFieldValue('b')).toBeUndefined();
+
+    rerender(<Fixture withB />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'B' })).toHaveValue('default'),
+    );
+    expect(formInstance.isFieldTouched('b')).toBe(false);
+  });
+});

--- a/src/components/form/Form/legacy-contract/deprecated-and-custom.test.tsx
+++ b/src/components/form/Form/legacy-contract/deprecated-and-custom.test.tsx
@@ -1,0 +1,375 @@
+import { useRef, useState } from 'react';
+
+import {
+  act,
+  renderWithForm,
+  renderWithRoot,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../test/index';
+import { Button } from '../../../actions/Button/Button';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+import { DialogForm } from '../../../overlays/Dialog/DialogForm';
+import { DialogTrigger } from '../../../overlays/Dialog/DialogTrigger';
+import { FieldWrapper } from '../../FieldWrapper/FieldWrapper';
+import { wrapWithField } from '../../wrapper';
+import { Form, useFormProps } from '../index';
+import { useFieldProps } from '../use-field/use-field-props';
+import { CubeFormInstance, useForm } from '../use-form';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — deprecated wrappers and custom controls.
+ *
+ * Covers plan §7.1 items 33 (`Field` / `Form.Item`, including render-prop
+ * children), 34 (`DialogForm`, delayed resets, preservation) and 35 (custom
+ * fields built on `useFormProps`, `useFieldProps`, `FieldWrapper` and
+ * `wrapWithField`).
+ */
+
+describe('legacy contract: deprecated Field / Form.Item (§7.1 #33)', () => {
+  it('[frozen] render-prop children receive the form instance', () => {
+    let seen: unknown;
+
+    const { formInstance } = renderWithForm(
+      <Form.Item name="a" label="A">
+        {(form) => {
+          seen = form;
+
+          return <TextInput />;
+        }}
+      </Form.Item>,
+    );
+
+    expect(seen).toBe(formInstance);
+  });
+
+  it('[frozen] Form.Item owns the registration; the wrapped input does not register a second field', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <Form.Item name="a" label="A">
+        <TextInput />
+      </Form.Item>,
+    );
+
+    expect(formInstance.getFieldNames()).toEqual(['a']);
+
+    await waitFor(() =>
+      expect(getByRole('textbox')).toHaveAttribute('id', 'a'),
+    );
+    expect(formInstance.getFieldNames()).toEqual(['a']);
+  });
+
+  it("[frozen] Form.Item forwards value, change handling, validation state and label to the child and discards the child's own onChange", async () => {
+    const onChange = vi.fn();
+    const { formInstance, getByRole } = renderWithForm(
+      <Form.Item
+        name="a"
+        label="Label from item"
+        rules={[{ min: 3, message: 'Too short' }]}
+      >
+        <TextInput onChange={onChange} />
+      </Form.Item>,
+    );
+    const input = getByRole('textbox', { name: 'Label from item' });
+
+    await act(async () => {
+      await userEvent.type(input, 'ab');
+      await userEvent.tab();
+    });
+
+    // `Field` replaces the child's `onChange` with the form handler rather than
+    // chaining it (a dev warning says listeners on a `<Field>` child are unsupported).
+    expect(onChange).not.toHaveBeenCalled();
+    expect(formInstance.getFieldValue('a')).toBe('ab');
+
+    await waitFor(() => expect(input).toHaveAttribute('aria-invalid', 'true'));
+    expect(screen.getByText('Too short')).toBeInTheDocument();
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'from form');
+    });
+
+    expect(input).toHaveValue('from form');
+  });
+
+  it('[frozen] Form.Item without a name wraps the child in field chrome without registering anything', () => {
+    const { formInstance, getByText } = renderWithForm(
+      <Form.Item label="Just a label">
+        <TextInput aria-label="inner" />
+      </Form.Item>,
+    );
+
+    expect(getByText('Just a label')).toBeInTheDocument();
+    expect(formInstance.getFieldNames()).toEqual([]);
+  });
+});
+
+describe('legacy contract: DialogForm (§7.1 #34)', () => {
+  function renderDialogForm({
+    ownForm = true,
+    onSubmit = vi.fn(),
+    onDismiss = vi.fn(),
+    preserve,
+  }: {
+    ownForm?: boolean;
+    onSubmit?: (data: any) => void;
+    onDismiss?: () => void;
+    preserve?: boolean;
+  }) {
+    let form!: CubeFormInstance<any>;
+
+    // The form is created by a component in the same tree, as Cloud does, so
+    // its rerender hook reaches the dialog. `isOpen` is controlled and never
+    // flipped, so the dialog stays mounted after submit/cancel and the delayed
+    // reset can be observed on live fields.
+    function Owner() {
+      const [ownedForm] = useForm();
+
+      if (ownForm) {
+        form = ownedForm;
+      }
+
+      return (
+        <DialogTrigger isOpen>
+          <Button>Open</Button>
+          <DialogForm
+            form={ownForm ? ownedForm : undefined}
+            title="Contract"
+            preserve={preserve}
+            onSubmit={onSubmit}
+            onDismiss={onDismiss}
+          >
+            <TextInput
+              name="name"
+              label="Name"
+              rules={[{ required: true, message: 'Required' }]}
+            />
+          </DialogForm>
+        </DialogTrigger>
+      );
+    }
+
+    const result = renderWithRoot(<Owner />);
+
+    return {
+      ...result,
+      onSubmit,
+      onDismiss,
+      get form() {
+        return form;
+      },
+    };
+  }
+
+  it('[frozen] DialogForm submits through the passed form and resets it 250ms after a successful submit', async () => {
+    const { onSubmit, form } = renderDialogForm({});
+
+    await act(async () => {
+      await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'x');
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'x' }));
+    expect(form.getFieldValue('name')).toBe('x');
+
+    await waitFor(() => expect(form.getFieldValue('name')).toBeUndefined());
+    expect(form.isTouched).toBe(false);
+    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('');
+  });
+
+  it('[frozen] preserve keeps the values after a successful submit', async () => {
+    const { onSubmit, form } = renderDialogForm({ preserve: true });
+
+    await act(async () => {
+      await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'x');
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'x' }));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    expect(form.getFieldValue('name')).toBe('x');
+    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('x');
+  });
+
+  it('[frozen] cancelling calls onDismiss and schedules the same delayed reset', async () => {
+    const { onDismiss, onSubmit, form } = renderDialogForm({});
+
+    await act(async () => {
+      await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'x');
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(form.getFieldValue('name')).toBeUndefined());
+  });
+
+  it('[frozen] DialogForm creates its own form when none is passed', async () => {
+    const { onSubmit } = renderDialogForm({ ownForm: false });
+
+    await act(async () => {
+      await userEvent.type(screen.getByRole('textbox', { name: 'Name' }), 'x');
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'x' }));
+  });
+});
+
+describe('legacy contract: custom controls (§7.1 #35)', () => {
+  function CustomControl(props: any) {
+    props = useFieldProps(props, {
+      defaultValidationTrigger: 'onChange',
+      valuePropsMapper: ({ value, onChange }) => ({
+        value: value ?? '',
+        onChange,
+      }),
+    });
+
+    const ref = useRef<HTMLInputElement>(null);
+    const { value, onChange, id } = props;
+
+    return wrapWithField(
+      <input
+        ref={ref}
+        id={id}
+        data-qa="custom-input"
+        value={value ?? ''}
+        onChange={(event) => onChange?.(event.target.value)}
+      />,
+      ref,
+      props,
+    );
+  }
+
+  it('[frozen] a useFieldProps + wrapWithField control registers, syncs both ways and renders label and errors', async () => {
+    const { formInstance, getByTestId, getByText } = renderWithForm(
+      <CustomControl name="custom" label="Custom" />,
+    );
+    const input = getByTestId('custom-input');
+
+    expect(formInstance.getFieldNames()).toEqual(['custom']);
+
+    await waitFor(() => expect(input).toHaveAttribute('id', 'custom'));
+    expect(getByText('Custom').closest('label')).toHaveAttribute(
+      'for',
+      'custom',
+    );
+
+    await act(async () => {
+      await userEvent.type(input, 'ab');
+    });
+
+    expect(formInstance.getFieldValue('custom')).toBe('ab');
+    expect(formInstance.isFieldTouched('custom')).toBe(true);
+
+    await act(async () => {
+      formInstance.setFieldValue('custom', 'from form');
+    });
+
+    expect(input).toHaveValue('from form');
+
+    await act(async () => {
+      formInstance.setFieldError('custom', 'Wrong');
+    });
+
+    expect(getByText('Wrong')).toBeInTheDocument();
+  });
+
+  it('[frozen] without a name, useFieldProps leaves the control standalone with a generated id and its own value/onChange', async () => {
+    function Standalone() {
+      const [value, setValue] = useState('');
+
+      return (
+        <CustomControl
+          label="Standalone"
+          value={value}
+          onChange={(next: string) => setValue(next.toUpperCase())}
+        />
+      );
+    }
+
+    const { formInstance, getByTestId } = renderWithForm(<Standalone />);
+    const input = getByTestId('custom-input');
+
+    await act(async () => {
+      await userEvent.type(input, 'ab');
+    });
+
+    expect(input).toHaveValue('AB');
+    expect(input.getAttribute('id')).toBeTruthy();
+    expect(formInstance.getFieldNames()).toEqual([]);
+  });
+
+  it('[frozen] a wrapper using useFormProps reads the form instance and presentation context', () => {
+    let seen: any;
+
+    function Wrapper() {
+      seen = useFormProps({});
+
+      return null;
+    }
+
+    const { formInstance } = renderWithForm(<Wrapper />, {
+      formProps: { labelPosition: 'side', name: 'wrapped' },
+    });
+
+    expect(seen.form).toBe(formInstance);
+    expect(seen.labelPosition).toBe('side');
+    expect(seen.idPrefix).toBe('wrapped');
+    expect(seen.requiredMark).toBe(true);
+  });
+
+  it('[frozen] FieldWrapper renders a supplied Component with label, description and errorMessage', () => {
+    const { getByText, getByTestId } = renderWithRoot(
+      <FieldWrapper
+        label="Wrapped"
+        description="Some description"
+        errorMessage="Some error"
+        Component={<input data-qa="raw" />}
+      />,
+    );
+
+    expect(getByTestId('raw')).toBeInTheDocument();
+    expect(getByText('Wrapped')).toBeInTheDocument();
+    expect(getByText('Some description')).toBeInTheDocument();
+    expect(getByText('Some error')).toBeInTheDocument();
+  });
+
+  it('[frozen] form-only props never reach the DOM', () => {
+    const { container, getByRole } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        rules={[{ required: true }]}
+        validateTrigger="onChange"
+        validationDelay={10}
+        showValid
+        shouldUpdate
+      />,
+    );
+    const input = getByRole('textbox');
+
+    for (const attribute of [
+      'rules',
+      'validatetrigger',
+      'validationdelay',
+      'showvalid',
+      'shouldupdate',
+      'form',
+    ]) {
+      expect(input).not.toHaveAttribute(attribute);
+      expect(container.querySelector(`[${attribute}]`)).toBeNull();
+    }
+  });
+});

--- a/src/components/form/Form/legacy-contract/diagnostics-baseline.json
+++ b/src/components/form/Form/legacy-contract/diagnostics-baseline.json
@@ -1,0 +1,126 @@
+{
+  "generatedAt": "2026-09-02T14:26:38.568Z",
+  "tooling": {
+    "eslint": "10.8.0",
+    "eslint-plugin-react-hooks": "7.1.1",
+    "@typescript-eslint/parser": "8.69.0"
+  },
+  "scope": {
+    "legacy engine": [
+      "src/components/form/Form/Form.tsx",
+      "src/components/form/Form/use-form.tsx",
+      "src/components/form/Form/validation.ts",
+      "src/components/form/Form/use-field/**/*.{ts,tsx}",
+      "src/components/form/Form/Field.tsx"
+    ],
+    "shared form surface": [
+      "src/components/form/**/*.{ts,tsx}",
+      "src/components/overlays/Dialog/DialogForm.tsx",
+      "src/shared/form.ts"
+    ],
+    "input components": ["src/components/fields/**/*.{ts,tsx}"]
+  },
+  "filesLinted": 123,
+  "totals": {
+    "react-hooks/exhaustive-deps": 23,
+    "react-hooks/immutability": 15,
+    "react-hooks/incompatible-library": 1,
+    "react-hooks/preserve-manual-memoization": 5,
+    "react-hooks/refs": 50,
+    "react-hooks/rules-of-hooks": 14,
+    "react-hooks/set-state-in-effect": 5,
+    "react-hooks/use-memo": 1
+  },
+  "files": {
+    "src/components/fields/Checkbox/Checkbox.tsx": {
+      "react-hooks/immutability": 1,
+      "react-hooks/preserve-manual-memoization": 1,
+      "react-hooks/refs": 1,
+      "react-hooks/rules-of-hooks": 2
+    },
+    "src/components/fields/ColorSwatchGroup/ColorSwatchGroup.tsx": {
+      "react-hooks/refs": 1
+    },
+    "src/components/fields/ComboBox/ComboBox.tsx": {
+      "react-hooks/exhaustive-deps": 4,
+      "react-hooks/immutability": 1,
+      "react-hooks/preserve-manual-memoization": 2,
+      "react-hooks/refs": 9,
+      "react-hooks/set-state-in-effect": 1
+    },
+    "src/components/fields/CommandTextArea/CommandTextArea.tsx": {
+      "react-hooks/exhaustive-deps": 3,
+      "react-hooks/preserve-manual-memoization": 1,
+      "react-hooks/refs": 8,
+      "react-hooks/set-state-in-effect": 1
+    },
+    "src/components/fields/DatePicker/DateInput.tsx": {
+      "react-hooks/immutability": 1
+    },
+    "src/components/fields/DatePicker/DatePickerInput.tsx": {
+      "react-hooks/immutability": 1
+    },
+    "src/components/fields/FileInput/FileInput.tsx": {
+      "react-hooks/exhaustive-deps": 2,
+      "react-hooks/immutability": 1,
+      "react-hooks/refs": 1
+    },
+    "src/components/fields/FilterListBox/FilterListBox.tsx": {
+      "react-hooks/exhaustive-deps": 1,
+      "react-hooks/rules-of-hooks": 1
+    },
+    "src/components/fields/ListBox/ListBox.tsx": {
+      "react-hooks/exhaustive-deps": 2,
+      "react-hooks/incompatible-library": 1,
+      "react-hooks/refs": 2
+    },
+    "src/components/fields/Picker/Picker.tsx": {
+      "react-hooks/exhaustive-deps": 1
+    },
+    "src/components/fields/SearchComboBox/SearchComboBox.tsx": {
+      "react-hooks/exhaustive-deps": 2,
+      "react-hooks/refs": 8,
+      "react-hooks/set-state-in-effect": 1
+    },
+    "src/components/fields/Select/Select.tsx": {
+      "react-hooks/exhaustive-deps": 1,
+      "react-hooks/immutability": 2,
+      "react-hooks/preserve-manual-memoization": 1
+    },
+    "src/components/fields/Slider/SliderBase.tsx": {
+      "react-hooks/refs": 1
+    },
+    "src/components/fields/TextInput/TextInputBase.tsx": {
+      "react-hooks/rules-of-hooks": 6
+    },
+    "src/components/fields/TextInput/useAutoSizeTextArea.ts": {
+      "react-hooks/refs": 4
+    },
+    "src/components/fields/TextInputMapper/TextInputMapper.tsx": {
+      "react-hooks/exhaustive-deps": 4,
+      "react-hooks/refs": 2,
+      "react-hooks/set-state-in-effect": 1,
+      "react-hooks/use-memo": 1
+    },
+    "src/components/form/Form/Field.tsx": {
+      "react-hooks/immutability": 1
+    },
+    "src/components/form/Form/Form.tsx": {
+      "react-hooks/refs": 6
+    },
+    "src/components/form/Form/use-field/use-field-props.tsx": {
+      "react-hooks/immutability": 2,
+      "react-hooks/refs": 1,
+      "react-hooks/rules-of-hooks": 5
+    },
+    "src/components/form/Form/use-field/use-field.ts": {
+      "react-hooks/exhaustive-deps": 3,
+      "react-hooks/immutability": 4,
+      "react-hooks/set-state-in-effect": 1
+    },
+    "src/components/form/Form/use-form.tsx": {
+      "react-hooks/immutability": 1,
+      "react-hooks/refs": 6
+    }
+  }
+}

--- a/src/components/form/Form/legacy-contract/helpers.tsx
+++ b/src/components/form/Form/legacy-contract/helpers.tsx
@@ -1,0 +1,217 @@
+import { render } from '@testing-library/react';
+import { Component, ReactNode, StrictMode } from 'react';
+
+import { Root } from '../../../Root';
+import { CubeFormProps, Form } from '../Form';
+import { useFieldProps } from '../use-field/use-field-props';
+import { CubeFormInstance, useForm } from '../use-form';
+
+/**
+ * Shared fixtures for the legacy Form characterization suite. Everything here
+ * exists to *observe* the legacy engine, never to change it.
+ */
+
+export interface Deferred<T = void> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+/** A promise whose settlement the test controls. */
+export function deferred<T = void>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  // A deferred the test forgets to settle would otherwise surface as an
+  // unhandled rejection in an unrelated spec.
+  promise.catch(() => {});
+
+  return { promise, resolve, reject };
+}
+
+export function tick(ms = 0) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Counts renders of named subtrees. `count(id)` is called from a component
+ * body; `Counted` wraps a subtree so its parent-driven renders are counted
+ * without counting the wrapped component's own internal state updates.
+ */
+export function createRenderCounter() {
+  const counts: Record<string, number> = {};
+
+  function count(id: string) {
+    counts[id] = (counts[id] ?? 0) + 1;
+  }
+
+  function Counted({ id, children }: { id: string; children?: ReactNode }) {
+    count(id);
+
+    return <>{children}</>;
+  }
+
+  return {
+    counts,
+    count,
+    Counted,
+    snapshot(): Record<string, number> {
+      return { ...counts };
+    },
+    /** Render counts accumulated since `before` was taken. */
+    since(before: Record<string, number>): Record<string, number> {
+      const delta: Record<string, number> = {};
+
+      for (const key of new Set([
+        ...Object.keys(before),
+        ...Object.keys(counts),
+      ])) {
+        delta[key] = (counts[key] ?? 0) - (before[key] ?? 0);
+      }
+
+      return delta;
+    },
+  };
+}
+
+export type RenderCounter = ReturnType<typeof createRenderCounter>;
+
+export interface FieldProbeProps {
+  name?: string;
+  form?: CubeFormInstance<any> | null;
+  defaultValue?: unknown;
+  rules?: any[];
+  validateTrigger?: 'onBlur' | 'onChange' | 'onSubmit';
+  validationDelay?: number;
+  /** Value emitted by the probe's change button, when rendered. */
+  next?: unknown;
+  qa?: string;
+}
+
+/**
+ * The smallest possible form-attachable control. It registers through
+ * `useFieldProps` exactly like the shipped inputs and renders its value as JSON
+ * so tests can watch non-string values (objects, arrays, `null`) without an
+ * input's own value coercion getting in the way.
+ */
+export function FieldProbe(props: FieldProbeProps) {
+  const { next, qa, ...fieldInput } = props;
+  const resolved: any = useFieldProps(fieldInput as any, {
+    defaultValidationTrigger: 'onChange',
+  });
+  const { value, onChange, id, isInvalid, errorMessage } = resolved;
+  const testId = qa ?? `probe-${props.name ?? 'standalone'}`;
+
+  return (
+    <>
+      <span
+        id={id}
+        data-qa={testId}
+        data-invalid={isInvalid ? 'true' : undefined}
+      >
+        {value === undefined ? '<undefined>' : JSON.stringify(value)}
+      </span>
+      {errorMessage != null ? (
+        <span data-qa={`${testId}-error`}>{errorMessage}</span>
+      ) : null}
+      {next !== undefined ? (
+        <button
+          type="button"
+          data-qa={`${testId}-change`}
+          onClick={() => onChange?.(next)}
+        >
+          change
+        </button>
+      ) : null}
+    </>
+  );
+}
+
+export interface RenderOwnedFormOptions {
+  formProps?: Partial<Omit<CubeFormProps, 'form' | 'children'>>;
+  counter?: RenderCounter;
+  strict?: boolean;
+}
+
+/**
+ * Renders a component that *owns* a form created with `useForm()` and passes
+ * it down to `<Form>`, which is how Cloud creates most of its forms. Children
+ * are produced by a render function so every owner render recreates the
+ * element tree, as real call sites do.
+ */
+export function renderOwnedForm(
+  renderChildren: (form: CubeFormInstance<any>) => ReactNode,
+  options: RenderOwnedFormOptions = {},
+) {
+  const { formProps, counter, strict = false } = options;
+
+  let formInstance!: CubeFormInstance<any>;
+
+  function Owner(props: { formProps?: RenderOwnedFormOptions['formProps'] }) {
+    const [form] = useForm();
+
+    formInstance = form;
+    counter?.count('owner');
+
+    return (
+      <Root>
+        <Form {...props.formProps} form={form}>
+          {renderChildren(form)}
+        </Form>
+      </Root>
+    );
+  }
+
+  const ui = (props: RenderOwnedFormOptions['formProps']) =>
+    strict ? (
+      <StrictMode>
+        <Owner formProps={props} />
+      </StrictMode>
+    ) : (
+      <Owner formProps={props} />
+    );
+
+  const result = render(ui(formProps));
+
+  return {
+    ...result,
+    get formInstance() {
+      return formInstance;
+    },
+    /** Rerender the owner, optionally with new `<Form>` props. */
+    rerenderOwner(
+      nextFormProps: RenderOwnedFormOptions['formProps'] = formProps,
+    ) {
+      result.rerender(ui(nextFormProps));
+    },
+  };
+}
+
+interface BoundaryState {
+  message: string | null;
+}
+
+/** Catches a render error and prints its message so a test can assert on it. */
+export class RenderErrorBoundary extends Component<
+  { children: ReactNode },
+  BoundaryState
+> {
+  state: BoundaryState = { message: null };
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { message: error.message };
+  }
+
+  render() {
+    if (this.state.message != null) {
+      return <div data-qa="render-error">{this.state.message}</div>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/form/Form/legacy-contract/instance-and-binding.test.tsx
+++ b/src/components/form/Form/legacy-contract/instance-and-binding.test.tsx
@@ -1,0 +1,562 @@
+import { createRef, StrictMode } from 'react';
+
+import {
+  act,
+  render,
+  renderWithForm,
+  renderWithRoot,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../test/index';
+import { Checkbox } from '../../../fields/Checkbox/Checkbox';
+import { CheckboxGroup } from '../../../fields/Checkbox/CheckboxGroup';
+import { Radio } from '../../../fields/RadioGroup/Radio';
+import { RadioGroup } from '../../../fields/RadioGroup/RadioGroup';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+import { Root } from '../../../Root';
+import { Form } from '../index';
+import { CubeFormInstance, useForm } from '../use-form';
+
+import {
+  createRenderCounter,
+  FieldProbe,
+  RenderErrorBoundary,
+  renderOwnedForm,
+} from './helpers';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — instance creation and binding.
+ *
+ * Covers plan §7.1 items 1 (creation), 2 (context binding), 3 (explicit form
+ * precedence), 4 (identity changes), 5 (registration order / duplicates),
+ * 6 (dynamic names), 19 (instance created above the root), 30 (refs) and
+ * 31 (ids). Items 3 and 6 are also covered by `explicit-form-prop.test.tsx`
+ * and `unbind-form-prop.test.tsx`; only the gaps are filled here.
+ *
+ * Each assertion is labelled with its contract class — see README.md.
+ */
+
+describe('legacy contract: instance creation (§7.1 #1)', () => {
+  it('[frozen] Form.useForm() returns the same instance on every render of its owner', () => {
+    const seen: CubeFormInstance<any>[] = [];
+
+    function Owner() {
+      const [form] = useForm();
+
+      seen.push(form);
+
+      return null;
+    }
+
+    const { rerender } = render(<Owner />);
+
+    rerender(<Owner />);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toBe(seen[1]);
+    expect(seen[0]).toBeInstanceOf(CubeFormInstance);
+  });
+
+  it('[frozen] Form.useForm() installs forceReRender on the component that created the instance', async () => {
+    const counter = createRenderCounter();
+    const { formInstance } = renderOwnedForm(
+      () => <TextInput name="a" label="A" />,
+      { counter },
+    );
+    const before = counter.snapshot();
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'x');
+    });
+
+    expect(counter.since(before).owner).toBe(1);
+  });
+
+  it('[undefined] a directly constructed CubeFormInstance never rerenders anything', async () => {
+    const form = new CubeFormInstance<any>();
+    const counter = createRenderCounter();
+
+    function Owner() {
+      counter.count('owner');
+
+      return (
+        <Root>
+          <Form form={form}>
+            <TextInput name="a" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    const { getByRole } = render(<Owner />);
+    const before = counter.snapshot();
+
+    await act(async () => {
+      form.setFieldValue('a', 'x');
+    });
+
+    // The value landed in the instance, but nothing observes it: `useForm(instance)`
+    // adopts the instance without installing a rerender hook, so the default
+    // no-op `forceReRender` stays in place.
+    expect(form.getFieldValue('a')).toBe('x');
+    expect(counter.since(before).owner).toBe(0);
+    expect(getByRole('textbox')).toHaveValue('');
+  });
+
+  it('[frozen] useForm(instance) adopts the given instance instead of creating a new one', () => {
+    const external = new CubeFormInstance<any>();
+    let inner!: CubeFormInstance<any>;
+
+    function Owner() {
+      [inner] = useForm(external);
+
+      return null;
+    }
+
+    render(<Owner />);
+
+    expect(inner).toBe(external);
+  });
+});
+
+describe('legacy contract: form context binding (§7.1 #2, #3)', () => {
+  it('[frozen] a named input inside <Form> registers with the context form; an unnamed one does not', () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <TextInput name="a" label="A" />
+        <TextInput label="B" />
+      </>,
+    );
+
+    expect(formInstance.getFieldNames()).toEqual(['a']);
+  });
+
+  it('[frozen] group inputs register once; their options never register, even when given a name', () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <CheckboxGroup name="checks" label="Checks">
+          <Checkbox value="one" name="leak">
+            One
+          </Checkbox>
+          <Checkbox value="two">Two</Checkbox>
+        </CheckboxGroup>
+        <RadioGroup name="radios" label="Radios">
+          <Radio value="one">One</Radio>
+          <Radio value="two">Two</Radio>
+        </RadioGroup>
+      </>,
+    );
+
+    expect(formInstance.getFieldNames()).toEqual(['checks', 'radios']);
+  });
+
+  it('[frozen] form={null} detaches an input from the surrounding form like form={undefined} does', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput form={null as any} name="a" label="A" />,
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    expect(formInstance.getFieldNames()).toEqual([]);
+    expect(getByRole('textbox')).toHaveValue('x');
+  });
+});
+
+describe('legacy contract: form identity changes after mount (§7.1 #4)', () => {
+  it('[undefined] <Form> keeps the first form it saw and ignores a different form prop later', async () => {
+    const first = new CubeFormInstance<any>();
+    const second = new CubeFormInstance<any>();
+
+    function Fixture({ form }: { form: CubeFormInstance<any> }) {
+      return (
+        <Root>
+          <Form form={form}>
+            <TextInput name="a" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    const { rerender, getByRole } = render(<Fixture form={first} />);
+
+    rerender(<Fixture form={second} />);
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    expect(first.getFieldValue('a')).toBe('x');
+    expect(second.getFieldNames()).toEqual([]);
+  });
+
+  it('[undefined] an input given a new form prop registers with the new form but stays registered in the old one', async () => {
+    let first!: CubeFormInstance<any>;
+    let second!: CubeFormInstance<any>;
+
+    function Fixture({ useSecond }: { useSecond: boolean }) {
+      [first] = useForm();
+      [second] = useForm();
+
+      return <TextInput form={useSecond ? second : first} name="a" label="A" />;
+    }
+
+    const { rerender, getByRole } = renderWithRoot(
+      <Fixture useSecond={false} />,
+    );
+
+    expect(first.getFieldNames()).toEqual(['a']);
+    expect(second.getFieldNames()).toEqual([]);
+
+    rerender(<Fixture useSecond />);
+
+    await waitFor(() => expect(second.getFieldNames()).toEqual(['a']));
+    expect(first.getFieldNames()).toEqual(['a']);
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    expect(second.getFieldValue('a')).toBe('x');
+    expect(first.getFieldValue('a')).toBeUndefined();
+  });
+});
+
+describe('legacy contract: registration order and duplicate names (§7.1 #5)', () => {
+  it('[frozen] getFieldNames() lists fields in mount order', () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <TextInput name="b" label="B" />
+        <TextInput name="a" label="A" />
+        <TextInput name="c" label="C" />
+      </>,
+    );
+
+    expect(formInstance.getFieldNames()).toEqual(['b', 'a', 'c']);
+  });
+
+  it('[undefined] two inputs with one name share a field; unmounting either one drops the value for the other', async () => {
+    function Fixture({ both }: { both: boolean }) {
+      return (
+        <>
+          {both ? <TextInput name="a" label="First" /> : null}
+          <TextInput name="a" label="Second" />
+        </>
+      );
+    }
+
+    const { formInstance, rerender, getByRole } = renderWithForm(
+      <Fixture both />,
+    );
+
+    expect(formInstance.getFieldNames()).toEqual(['a']);
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox', { name: 'First' }), 'x');
+    });
+
+    expect(getByRole('textbox', { name: 'Second' })).toHaveValue('x');
+
+    rerender(<Fixture both={false} />);
+
+    // The unmounting duplicate deletes the shared field; the survivor
+    // re-registers a fresh one on its next effect, with the default value.
+    await waitFor(() => expect(formInstance.getFieldNames()).toEqual(['a']));
+    expect(formInstance.getFieldValue('a')).toBeUndefined();
+    expect(getByRole('textbox', { name: 'Second' })).toHaveValue('');
+  });
+});
+
+describe('legacy contract: dynamic field names (§7.1 #6)', () => {
+  it('[frozen] renaming an input re-registers it under the new name and drops the old value', async () => {
+    function Fixture({ name }: { name: string }) {
+      return <TextInput name={name} label="A" />;
+    }
+
+    const { formInstance, rerender, getByRole } = renderWithForm(
+      <Fixture name="first" />,
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    expect(formInstance.getFieldValue('first')).toBe('x');
+
+    rerender(<Fixture name="second" />);
+
+    await waitFor(() =>
+      expect(formInstance.getFieldNames()).toEqual(['second']),
+    );
+    expect(formInstance.getFieldValue('second')).toBeUndefined();
+    expect(formInstance.getFieldValue('first')).toBeUndefined();
+  });
+
+  it.each([
+    // Dropping `name` skips `useField`: React reports conditional hook calls.
+    ['named to standalone', 'a', undefined, /calling hooks conditionally/i],
+    // Adding `name` appends hooks; React fails inside its hook bookkeeping
+    // ("Cannot read properties of undefined") before it can name the cause.
+    ['standalone to named', undefined, 'a', /./],
+  ])(
+    '[undefined] switching an input from %s changes the hook order and throws',
+    (_, from, to, expectedMessage) => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      function Fixture({ name }: { name?: string }) {
+        return <TextInput name={name} label="A" />;
+      }
+
+      const { rerender, queryByTestId } = renderWithForm(
+        <RenderErrorBoundary>
+          <Fixture name={from} />
+        </RenderErrorBoundary>,
+      );
+
+      expect(queryByTestId('render-error')).toBeNull();
+
+      rerender(
+        <RenderErrorBoundary>
+          <Fixture name={to} />
+        </RenderErrorBoundary>,
+      );
+
+      expect(queryByTestId('render-error')).toHaveTextContent(expectedMessage);
+
+      consoleError.mockRestore();
+    },
+  );
+});
+
+describe('legacy contract: instance created above the Form root (§7.1 #19)', () => {
+  it('[frozen] <Form> installs its callbacks on an instance created by a parent component', async () => {
+    const onSubmit = vi.fn();
+    const onValuesChange = vi.fn();
+    let form!: CubeFormInstance<any>;
+
+    function Owner() {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form} onSubmit={onSubmit} onValuesChange={onValuesChange}>
+            <TextInput name="a" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    const { getByRole } = render(<Owner />);
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    expect(onValuesChange).toHaveBeenCalledWith({ a: 'x' });
+
+    await act(async () => {
+      await form.submit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({ a: 'x' });
+  });
+});
+
+describe('legacy contract: refs (§7.1 #30)', () => {
+  it('[frozen] the Form ref receives the <form> element', () => {
+    const ref = createRef<HTMLFormElement>();
+
+    renderWithRoot(
+      <Form ref={ref}>
+        <TextInput name="a" label="A" />
+      </Form>,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLFormElement);
+  });
+
+  it('[undefined] form.ref is copied from ref.current during the first render, so it is null', () => {
+    const ref = createRef<HTMLFormElement>();
+    let form!: CubeFormInstance<any>;
+
+    function Owner() {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form ref={ref} form={form}>
+            <TextInput name="a" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    render(<Owner />);
+
+    expect(ref.current).toBeInstanceOf(HTMLFormElement);
+    expect(form.ref).toBeNull();
+  });
+});
+
+describe('legacy contract: field ids (§7.1 #31)', () => {
+  it('[frozen] ids derive from the field name and are deduplicated across mounted fields', async () => {
+    renderWithRoot(
+      <>
+        <Form>
+          <FieldProbe name="contract_email" qa="first" />
+        </Form>
+        <Form>
+          <FieldProbe name="contract_email" qa="second" />
+        </Form>
+      </>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('second')).toHaveAttribute(
+        'id',
+        'contract_email_1',
+      ),
+    );
+    expect(screen.getByTestId('first')).toHaveAttribute('id', 'contract_email');
+  });
+
+  it('[bug-eligible] two TextInputs sharing a base id both render the deduplicated id, orphaning the first label', async () => {
+    // The allocator hands out `contract_dup` and `contract_dup_1` (see the
+    // probe test above). The inputs still collide: `utils/react/useId` keeps a
+    // module-global updater map keyed by id string, both inputs start from the
+    // same base id, and merging `contract_dup_1` back through `mergeIds` renames
+    // the wrong element. The first label keeps pointing at an id no element has.
+    const { container } = renderWithRoot(
+      <Form>
+        <TextInput name="contract_dup" label="First" />
+        <TextInput name="contract_dup" label="Second" />
+      </Form>,
+    );
+
+    await act(async () => {});
+
+    const inputs = Array.from(container.querySelectorAll('input'));
+    const labels = Array.from(container.querySelectorAll('label'));
+
+    expect(inputs.map((input) => input.id)).toEqual([
+      'contract_dup_1',
+      'contract_dup_1',
+    ]);
+    expect(
+      labels.map((label) => [label.textContent, label.getAttribute('for')]),
+    ).toEqual([
+      ['First', 'contract_dup'],
+      ['Second', 'contract_dup_1'],
+    ]);
+  });
+
+  it('[frozen] the Form name prefixes generated ids', async () => {
+    renderWithRoot(
+      <Form name="login">
+        <TextInput name="contract_email" label="Email" />
+      </Form>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'id',
+        'login_contract_email',
+      ),
+    );
+  });
+
+  it('[frozen] an explicit id is used verbatim and is not deduplicated', async () => {
+    renderWithRoot(
+      <Form>
+        <TextInput id="contract_custom" name="a" label="First" />
+        <TextInput id="contract_custom" name="b" label="Second" />
+      </Form>,
+    );
+
+    await act(async () => {});
+
+    expect(screen.getByRole('textbox', { name: 'First' })).toHaveAttribute(
+      'id',
+      'contract_custom',
+    );
+    expect(screen.getByRole('textbox', { name: 'Second' })).toHaveAttribute(
+      'id',
+      'contract_custom',
+    );
+  });
+
+  it('[frozen] unmounting releases the id so a remount reuses the base id', async () => {
+    function Fixture({ mounted }: { mounted: boolean }) {
+      return mounted ? <TextInput name="contract_reuse" label="A" /> : null;
+    }
+
+    const { rerender } = renderWithForm(<Fixture mounted />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'id',
+        'contract_reuse',
+      ),
+    );
+
+    rerender(<Fixture mounted={false} />);
+    rerender(<Fixture mounted />);
+
+    await act(async () => {});
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'contract_reuse');
+  });
+
+  it('[frozen] Strict Mode double effects do not leak ids or registrations', async () => {
+    let form!: CubeFormInstance<any>;
+
+    function Owner() {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form}>
+            <TextInput name="contract_strict" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    const { unmount } = render(
+      <StrictMode>
+        <Owner />
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'id',
+        'contract_strict',
+      ),
+    );
+    expect(form.getFieldNames()).toEqual(['contract_strict']);
+
+    unmount();
+
+    expect(form.getFieldNames()).toEqual([]);
+
+    render(
+      <StrictMode>
+        <Owner />
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'id',
+        'contract_strict',
+      ),
+    );
+  });
+});

--- a/src/components/form/Form/legacy-contract/render-baseline.test.tsx
+++ b/src/components/form/Form/legacy-contract/render-baseline.test.tsx
@@ -1,0 +1,328 @@
+import { StrictMode } from 'react';
+
+import { act, render, userEvent, waitFor } from '../../../../test/index';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+import { Root } from '../../../Root';
+import { Form, useFormProps } from '../index';
+import { CubeFormInstance, useForm } from '../use-form';
+
+import { createRenderCounter, FieldProbe, tick } from './helpers';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — render baselines and lifecycle.
+ *
+ * Records how many times the legacy engine renders the form owner, a context
+ * consumer directly under `<Form>`, and each field for one mutation. These are
+ * *recorded* numbers, not budgets (plan §9 Phase 1 step 3): the modern backend
+ * is measured against §11, the legacy backend only against these.
+ *
+ * Also covers Strict Mode mounting and the lifecycle leaks listed in plan §2.2
+ * for the legacy side (Phase 1 step 4).
+ */
+
+function createFixture({ strict = false } = {}) {
+  const counter = createRenderCounter();
+  let formInstance!: CubeFormInstance<any>;
+
+  // A consumer of the Form context that sits directly under <Form>. It renders
+  // whenever the Form shell republishes its context value.
+  function Leaf() {
+    counter.count('leaf');
+    useFormProps({});
+
+    return null;
+  }
+
+  function Owner() {
+    const [form] = useForm();
+
+    formInstance = form;
+    counter.count('owner');
+
+    return (
+      <Root>
+        <Form form={form}>
+          <counter.Counted id="fieldA">
+            <TextInput name="a" label="A" />
+          </counter.Counted>
+          <counter.Counted id="fieldB">
+            <TextInput name="b" label="B" />
+          </counter.Counted>
+          <Leaf />
+        </Form>
+      </Root>
+    );
+  }
+
+  const ui = strict ? (
+    <StrictMode>
+      <Owner />
+    </StrictMode>
+  ) : (
+    <Owner />
+  );
+
+  const result = render(ui);
+
+  return {
+    ...result,
+    counter,
+    get form() {
+      return formInstance;
+    },
+  };
+}
+
+describe('legacy render baseline (plan §9 Phase 1 step 3, §11)', () => {
+  it('[frozen] mounting two fields renders the owner three times', async () => {
+    const { counter } = createFixture();
+
+    await act(async () => {});
+
+    // 1: mount — fields are created during this render, after the `[field]`
+    //    effect has already captured `undefined` as its dependency.
+    // 2: the fields' mount effects call `forceReRender()` (batched into one).
+    // 3: the `[field]` dependency flipped from `undefined` to the field object
+    //    created later in render 1, so the effect runs again and calls
+    //    `forceReRender()` once more.
+    expect(counter.snapshot()).toEqual({
+      owner: 3,
+      fieldA: 3,
+      fieldB: 3,
+      leaf: 3,
+    });
+  });
+
+  it('[frozen] one programmatic user-style change rerenders the owner, the Form subtree and every field once', async () => {
+    const { counter, form } = createFixture();
+
+    await act(async () => {});
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      form.setFieldValue('a', 'x', true);
+    });
+
+    expect(counter.since(before)).toEqual({
+      owner: 1,
+      fieldA: 1,
+      fieldB: 1,
+      leaf: 1,
+    });
+  });
+
+  it('[frozen] one keystroke into one field rerenders the owner and every other field once', async () => {
+    const { counter, getByRole } = createFixture();
+
+    await act(async () => {});
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox', { name: 'A' }), 'x');
+    });
+
+    expect(counter.since(before)).toEqual({
+      owner: 1,
+      fieldA: 1,
+      fieldB: 1,
+      leaf: 1,
+    });
+  });
+
+  it('[frozen] publishing a validation result rerenders the whole owner subtree', async () => {
+    const { counter, form } = createFixture();
+
+    await act(async () => {});
+
+    // Rules live on the field object; give `a` one so validation has work to do.
+    form.getFieldInstance('a')!.rules = [{ required: true, message: 'R' }];
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      await form.validateField('a').catch(() => {});
+    });
+
+    expect(counter.since(before)).toEqual({
+      owner: 1,
+      fieldA: 1,
+      fieldB: 1,
+      leaf: 1,
+    });
+  });
+
+  it('[frozen] setSubmitting() and setFieldError() each cost one owner render', async () => {
+    const { counter, form } = createFixture();
+
+    await act(async () => {});
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      form.setSubmitting(true);
+    });
+
+    await act(async () => {
+      form.setFieldError('a', 'Bad');
+    });
+
+    expect(counter.since(before).owner).toBe(2);
+  });
+
+  it('[frozen] the component that created the instance rerenders even when <Form> is rendered by a child', async () => {
+    const counter = createRenderCounter();
+    let formInstance!: CubeFormInstance<any>;
+
+    function Child({ form }: { form: CubeFormInstance<any> }) {
+      counter.count('child');
+
+      return (
+        <Form form={form}>
+          <TextInput name="a" label="A" />
+        </Form>
+      );
+    }
+
+    function Grandparent() {
+      const [form] = useForm();
+
+      formInstance = form;
+      counter.count('grandparent');
+
+      return (
+        <Root>
+          <Child form={form} />
+        </Root>
+      );
+    }
+
+    render(<Grandparent />);
+
+    await act(async () => {});
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'x', true);
+    });
+
+    expect(counter.since(before)).toEqual({ grandparent: 1, child: 1 });
+  });
+});
+
+describe('legacy lifecycle (plan §9 Phase 1 step 4)', () => {
+  it('[frozen] Strict Mode mounting settles with one registration per field', async () => {
+    const { form } = createFixture({ strict: true });
+
+    await waitFor(() => expect(form.getFieldNames()).toEqual(['a', 'b']));
+
+    await act(async () => {
+      await tick(20);
+    });
+
+    expect(form.getFieldNames()).toEqual(['a', 'b']);
+  });
+
+  it('[frozen] unmounting the owner removes every registration', async () => {
+    const { form, unmount } = createFixture();
+
+    await act(async () => {});
+
+    expect(form.getFieldNames()).toEqual(['a', 'b']);
+
+    unmount();
+
+    expect(form.getFieldNames()).toEqual([]);
+  });
+
+  it('[undefined] an instance reused by a new owner after its creator unmounted is no longer reactive', async () => {
+    const { form, unmount } = createFixture();
+
+    await act(async () => {});
+    unmount();
+
+    const counter = createRenderCounter();
+
+    function SecondOwner() {
+      useForm(form);
+      counter.count('second');
+
+      return (
+        <Root>
+          <Form form={form}>
+            <TextInput name="a" label="A" />
+          </Form>
+        </Root>
+      );
+    }
+
+    const { getByRole } = render(<SecondOwner />);
+
+    await act(async () => {});
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      form.setFieldValue('a', 'x', true);
+    });
+
+    expect(form.getFieldValue('a')).toBe('x');
+    expect(counter.since(before).second).toBe(0);
+    expect(getByRole('textbox')).toHaveValue('');
+  });
+
+  it('[undefined] a delayed validation started before unmount still runs its validator afterwards, without throwing', async () => {
+    const validator = vi.fn(async () => {});
+    let mounted = true;
+    const counter = createRenderCounter();
+    let formInstance!: CubeFormInstance<any>;
+
+    function Owner() {
+      const [form] = useForm();
+
+      formInstance = form;
+      counter.count('owner');
+
+      return (
+        <Root>
+          <Form form={form}>
+            {mounted ? (
+              <FieldProbe
+                name="a"
+                validationDelay={50}
+                rules={[{ validator }]}
+              />
+            ) : null}
+          </Form>
+        </Root>
+      );
+    }
+
+    const { rerender } = render(<Owner />);
+
+    await act(async () => {});
+
+    let pending!: Promise<unknown>;
+
+    await act(async () => {
+      pending = formInstance.validateField('a').catch((e) => e);
+    });
+
+    mounted = false;
+    rerender(<Owner />);
+
+    expect(formInstance.getFieldNames()).toEqual([]);
+    expect(validator).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await pending;
+    });
+
+    // The timer was owned by the rule closure, not by the field's lifetime.
+    expect(validator).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/form/Form/legacy-contract/submission.test.tsx
+++ b/src/components/form/Form/legacy-contract/submission.test.tsx
@@ -1,0 +1,437 @@
+import {
+  act,
+  fireEvent,
+  render,
+  renderWithForm,
+  renderWithRoot,
+  userEvent,
+  waitFor,
+} from '../../../../test/index';
+import { Button } from '../../../actions/Button/Button';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+import { Root } from '../../../Root';
+import { Form, ResetButton, SubmitButton } from '../index';
+import { CubeFormInstance, useForm } from '../use-form';
+
+import { deferred, FieldProbe, tick } from './helpers';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — submission.
+ *
+ * Covers plan §7.1 items 24 (submission, validation failure, callback failure,
+ * double submission), 25 (`Error` vs non-`Error` rejections), 26 (`onSubmitFailed`
+ * timing), 27 (submit error clearing), 29 (native `action`/`method`, hidden
+ * controls) and 32 (`SubmitButton`, `ResetButton`, `SubmitError`). The
+ * `submit.test.tsx` and `submit-error.test.tsx` suites already cover the visible
+ * behaviour; this file pins the instance-level contract.
+ */
+
+describe('legacy contract: submission flow (§7.1 #24)', () => {
+  it('[frozen] submit() validates every registered field and skips onSubmit when validation fails', async () => {
+    const onSubmit = vi.fn();
+    const onSubmitFailed = vi.fn();
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe name="a" rules={[{ required: true, message: 'A!' }]} />
+        <FieldProbe name="b" rules={[{ required: true, message: 'B!' }]} />
+      </>,
+      { formProps: { onSubmit, onSubmitFailed } },
+    );
+
+    await act(async () => {
+      await formInstance.submit();
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onSubmitFailed).not.toHaveBeenCalled();
+    expect(formInstance.getFieldError('a')).toEqual(['A!']);
+    expect(formInstance.getFieldError('b')).toEqual(['B!']);
+    expect(formInstance.isSubmitting).toBe(false);
+    expect(formInstance.submitError).toBeNull();
+  });
+
+  it('[frozen] onSubmit receives the nested getFormData() payload after validation passes', async () => {
+    const onSubmit = vi.fn();
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe name="user.name" />
+        <FieldProbe name="active" />
+      </>,
+      {
+        formProps: {
+          onSubmit,
+          defaultValues: { user: { name: 'Ann' }, active: true },
+        },
+      },
+    );
+
+    await act(async () => {
+      await formInstance.submit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      user: { name: 'Ann' },
+      active: true,
+    });
+  });
+
+  it('[frozen] a second submit() while one is in flight is ignored', async () => {
+    const gate = deferred<void>();
+    const onSubmit = vi.fn(() => gate.promise);
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { onSubmit },
+    });
+
+    let first!: Promise<unknown>;
+
+    await act(async () => {
+      first = formInstance.submit();
+      // Let validation and the internal `timeout()` reach `onSubmit`.
+      await tick(60);
+    });
+
+    expect(formInstance.isSubmitting).toBe(true);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await formInstance.submit();
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      gate.resolve();
+      await first;
+    });
+
+    expect(formInstance.isSubmitting).toBe(false);
+  });
+});
+
+describe('legacy contract: submission failures (§7.1 #25–#27)', () => {
+  it('[frozen] a non-Error rejection becomes submitError, calls onSubmitFailed and resolves submit()', async () => {
+    const onSubmit = vi.fn(() => Promise.reject('Nope'));
+    const onSubmitFailed = vi.fn();
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { onSubmit, onSubmitFailed },
+    });
+
+    await act(async () => {
+      await expect(formInstance.submit()).resolves.toBeUndefined();
+    });
+
+    expect(formInstance.submitError).toBe('Nope');
+    expect(onSubmitFailed).toHaveBeenCalledWith('Nope');
+    expect(formInstance.isSubmitting).toBe(false);
+  });
+
+  it('[frozen] an Error thrown by onSubmit becomes submitError, calls onSubmitFailed and rejects submit()', async () => {
+    const error = new Error('Broken');
+    const onSubmit = vi.fn(() => {
+      throw error;
+    });
+    const onSubmitFailed = vi.fn();
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { onSubmit, onSubmitFailed },
+    });
+
+    await act(async () => {
+      await expect(formInstance.submit()).rejects.toBe(error);
+    });
+
+    expect(formInstance.submitError).toBe(error);
+    expect(onSubmitFailed).toHaveBeenCalledWith(error);
+    expect(formInstance.isSubmitting).toBe(false);
+  });
+
+  it('[frozen] onSubmitFailed is called while isSubmitting is still true and is not awaited', async () => {
+    const never = deferred<void>();
+    let submittingDuringCallback: boolean | undefined;
+    const onSubmit = vi.fn(() => Promise.reject('Nope'));
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: {
+        onSubmit,
+        onSubmitFailed: () => {
+          submittingDuringCallback = formInstance.isSubmitting;
+
+          return never.promise;
+        },
+      },
+    });
+
+    await act(async () => {
+      await formInstance.submit();
+    });
+
+    expect(submittingDuringCallback).toBe(true);
+    expect(formInstance.isSubmitting).toBe(false);
+  });
+
+  it('[frozen] submitError clears when the next submit starts or on a user change, but not on a programmatic setFieldValue', async () => {
+    const gate = deferred<void>();
+    let calls = 0;
+    const onSubmit = vi.fn(() => {
+      calls++;
+
+      return calls === 1 ? Promise.reject('Nope') : gate.promise;
+    });
+    const { formInstance } = renderWithForm(<FieldProbe name="a" />, {
+      formProps: { onSubmit },
+    });
+
+    await act(async () => {
+      await formInstance.submit();
+    });
+
+    expect(formInstance.submitError).toBe('Nope');
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'programmatic');
+    });
+
+    expect(formInstance.submitError).toBe('Nope');
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'user', true);
+    });
+
+    expect(formInstance.submitError).toBeNull();
+
+    await act(async () => {
+      formInstance.submitError = 'Manual';
+      void formInstance.submit();
+    });
+
+    expect(formInstance.submitError).toBeNull();
+
+    await act(async () => {
+      gate.resolve();
+      await tick(60);
+    });
+  });
+});
+
+describe('legacy contract: native submission (§7.1 #29)', () => {
+  it('[frozen] <Form action method> attaches no submit handler: the event is not prevented and onSubmit never runs', async () => {
+    const onSubmit = vi.fn();
+    const { container } = renderWithRoot(
+      <Form action="/oauth" method="post" onSubmit={onSubmit}>
+        <TextInput name="a" label="A" />
+        <input type="hidden" name="token" value="t" />
+      </Form>,
+    );
+    const formElement = container.querySelector('form') as HTMLFormElement;
+
+    expect(formElement).toHaveAttribute('action', '/oauth');
+    expect(formElement).toHaveAttribute('method', 'post');
+
+    const notPrevented = fireEvent.submit(formElement);
+
+    await act(async () => {
+      await tick(60);
+    });
+
+    expect(notPrevented).toBe(true);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('[frozen] without action, the submit event is prevented and routed through validation to onSubmit', async () => {
+    const onSubmit = vi.fn();
+    const { container } = renderWithRoot(
+      <Form onSubmit={onSubmit} defaultValues={{ a: 'x' }}>
+        <TextInput name="a" label="A" />
+      </Form>,
+    );
+    const formElement = container.querySelector('form') as HTMLFormElement;
+
+    let notPrevented!: boolean;
+
+    await act(async () => {
+      notPrevented = fireEvent.submit(formElement);
+    });
+
+    expect(notPrevented).toBe(false);
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ a: 'x' }));
+  });
+
+  it('[frozen] a submitter that is not type="submit" is ignored after the event is prevented', async () => {
+    const onSubmit = vi.fn();
+    const { container, getByRole } = renderWithRoot(
+      <Form onSubmit={onSubmit}>
+        <TextInput name="a" label="A" />
+        <Button type="secondary" htmlType="button">
+          Other
+        </Button>
+      </Form>,
+    );
+    const formElement = container.querySelector('form') as HTMLFormElement;
+    const event = new SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+      submitter: getByRole('button', { name: 'Other' }),
+    });
+
+    let notPrevented!: boolean;
+
+    await act(async () => {
+      notPrevented = formElement.dispatchEvent(event);
+      await tick(60);
+    });
+
+    expect(notPrevented).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('[frozen] hidden native inputs are part of the browser FormData but never become fields', () => {
+    const { container, formInstance } = renderWithForm(
+      <>
+        <TextInput name="a" label="A" />
+        <input type="hidden" name="token" value="t" />
+      </>,
+    );
+    const formElement = container.querySelector('form') as HTMLFormElement;
+
+    expect(formInstance.getFieldNames()).toEqual(['a']);
+    expect(new FormData(formElement).get('token')).toBe('t');
+  });
+
+  it('[frozen] only action, autoComplete, encType, method and target reach the <form> element', () => {
+    const { container } = renderWithRoot(
+      <Form
+        action="/x"
+        method="post"
+        encType="multipart/form-data"
+        target="_self"
+        autoComplete="off"
+        onValuesChange={() => {}}
+        defaultValues={{}}
+        labelPosition="side"
+      >
+        <TextInput name="a" label="A" />
+      </Form>,
+    );
+    const formElement = container.querySelector('form') as HTMLFormElement;
+
+    expect(formElement).toHaveAttribute('enctype', 'multipart/form-data');
+    expect(formElement).toHaveAttribute('target', '_self');
+    expect(formElement).toHaveAttribute('autocomplete', 'off');
+    expect(formElement).toHaveAttribute('novalidate');
+    expect(formElement).not.toHaveAttribute('labelposition');
+    expect(formElement).not.toHaveAttribute('defaultvalues');
+  });
+});
+
+describe('legacy contract: helper components (§7.1 #32)', () => {
+  it('[frozen] SubmitButton is disabled while the form is invalid and while a submission is in flight', async () => {
+    const gate = deferred<void>();
+    const onSubmit = vi.fn(() => gate.promise);
+    const { formInstance, getByRole } = renderWithForm(
+      <>
+        <TextInput
+          name="a"
+          label="A"
+          rules={[{ required: true, message: 'Required' }]}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </>,
+      { formProps: { onSubmit } },
+    );
+    const button = getByRole('button', { name: 'Submit' });
+
+    expect(button).toBeEnabled();
+
+    await act(async () => {
+      await formInstance.validateField('a').catch(() => {});
+    });
+
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    await waitFor(() => expect(button).toBeEnabled());
+
+    await act(async () => {
+      await userEvent.click(button);
+    });
+
+    await waitFor(() => expect(formInstance.isSubmitting).toBe(true));
+    expect(button).toBeDisabled();
+
+    await act(async () => {
+      gate.resolve();
+      await tick(60);
+    });
+
+    expect(formInstance.isSubmitting).toBe(false);
+    expect(button).toBeEnabled();
+  });
+
+  it('[frozen] SubmitButton and ResetButton accept an explicit form prop outside <Form>', async () => {
+    let form!: CubeFormInstance<any>;
+
+    function Owner() {
+      [form] = useForm();
+
+      return (
+        <Root>
+          <Form form={form}>
+            <TextInput name="a" label="A" />
+          </Form>
+          <SubmitButton form={form}>Submit</SubmitButton>
+          <ResetButton form={form}>Reset</ResetButton>
+        </Root>
+      );
+    }
+
+    const { getByRole } = render(<Owner />);
+    const submit = getByRole('button', { name: 'Submit' });
+    const reset = getByRole('button', { name: 'Reset' });
+
+    expect(submit).toBeEnabled();
+    expect(reset).toBeDisabled();
+
+    await act(async () => {
+      form.setFieldError('a', 'Bad');
+    });
+
+    expect(submit).toBeDisabled();
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'x');
+    });
+
+    expect(reset).toBeEnabled();
+    expect(submit).toBeEnabled();
+  });
+
+  it('[frozen] ResetButton resets on the next tick and is disabled until the form is touched', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <>
+        <TextInput name="a" label="A" />
+        <ResetButton>Reset</ResetButton>
+      </>,
+      { formProps: { defaultValues: { a: 'seed' } } },
+    );
+    const reset = getByRole('button', { name: 'Reset' });
+
+    expect(reset).toBeDisabled();
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), '!');
+    });
+
+    expect(reset).toBeEnabled();
+
+    await act(async () => {
+      await userEvent.click(reset);
+    });
+
+    await waitFor(() => expect(formInstance.getFieldValue('a')).toBe('seed'));
+    expect(formInstance.isTouched).toBe(false);
+    expect(reset).toBeDisabled();
+  });
+});

--- a/src/components/form/Form/legacy-contract/validation.test.tsx
+++ b/src/components/form/Form/legacy-contract/validation.test.tsx
@@ -1,0 +1,529 @@
+import {
+  act,
+  renderWithForm,
+  userEvent,
+  waitFor,
+} from '../../../../test/index';
+import { TextInput } from '../../../fields/TextInput/TextInput';
+
+import {
+  createRenderCounter,
+  deferred,
+  Deferred,
+  FieldProbe,
+  renderOwnedForm,
+  tick,
+} from './helpers';
+
+vi.mock('../../../../_internal/hooks/use-warn');
+
+/**
+ * Legacy Form characterization — validation.
+ *
+ * Covers plan §7.1 items 20 (triggers and status tri-state), 21 (delayed and
+ * overlapping async validation), 22 (value/rule/reset/unmount changes during
+ * validation) and 23 (error ordering and ReactNode errors).
+ */
+
+describe('legacy contract: validation triggers and status (§7.1 #20)', () => {
+  it('[frozen] a text input validates on blur by default, not on change', async () => {
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        rules={[{ min: 3, message: 'Too short' }]}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'ab');
+    });
+
+    expect(formInstance.getFieldError('a')).toEqual([]);
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+
+    await act(async () => {
+      await userEvent.tab();
+    });
+
+    await waitFor(() =>
+      expect(formInstance.getFieldError('a')).toEqual(['Too short']),
+    );
+    expect(formInstance.getFieldInstance('a')!.status).toBe('invalid');
+  });
+
+  it('[frozen] validateTrigger="onChange" validates on every change (twice per change, see below)', async () => {
+    const validator = vi.fn(async () => {});
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        validateTrigger="onChange"
+        rules={[{ validator }]}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'ab');
+    });
+
+    await waitFor(() =>
+      expect(formInstance.getFieldInstance('a')!.status).toBe('valid'),
+    );
+    expect(validator.mock.calls.map((call: any[]) => call[1])).toEqual([
+      'a',
+      'a',
+      'ab',
+      'ab',
+    ]);
+  });
+
+  it('[bug-eligible] every user change runs the field change handler twice, so onChange validation validates twice per change', async () => {
+    // `useFieldProps` merges `useField`'s own `onChange` with the mapped
+    // `onChange` through `mergeProps`, which chains same-named handlers. The
+    // second `setFieldValue` is an equal-value no-op, but `validateField` runs
+    // again and only its result is published.
+    const validator = vi.fn(async () => {});
+    const { formInstance, getByTestId } = renderWithForm(
+      <FieldProbe name="a" next="v" rules={[{ validator }]} />,
+    );
+    const setFieldValue = vi.spyOn(formInstance, 'setFieldValue');
+    const validateField = vi.spyOn(formInstance, 'validateField');
+
+    await act(async () => {
+      await userEvent.click(getByTestId('probe-a-change'));
+    });
+
+    await waitFor(() =>
+      expect(formInstance.getFieldInstance('a')!.status).toBe('valid'),
+    );
+    expect(setFieldValue).toHaveBeenCalledTimes(2);
+    expect(validateField).toHaveBeenCalledTimes(2);
+    expect(validator).toHaveBeenCalledTimes(2);
+  });
+
+  it('[bug-eligible] changing an invalid field clears its errors without revalidating; the next trigger revalidates', async () => {
+    // The change handler means to revalidate a field that already has errors,
+    // but `setFieldValue` has cleared them by the time it looks.
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        rules={[{ min: 3, message: 'Too short' }]}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'ab');
+      await userEvent.tab();
+    });
+
+    await waitFor(() =>
+      expect(formInstance.getFieldError('a')).toEqual(['Too short']),
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'c');
+      await tick(30);
+    });
+
+    expect(formInstance.getFieldValue('a')).toBe('abc');
+    expect(formInstance.getFieldError('a')).toEqual([]);
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+
+    await act(async () => {
+      await userEvent.tab();
+    });
+
+    await waitFor(() =>
+      expect(formInstance.getFieldInstance('a')!.status).toBe('valid'),
+    );
+  });
+
+  it('[frozen] status is undefined until validated; isValid needs every field valid and isInvalid needs one invalid', async () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe name="a" rules={[{ required: true, message: 'A' }]} />
+        <FieldProbe name="b" rules={[{ required: true, message: 'B' }]} />
+      </>,
+      { formProps: { defaultValues: { a: 'ok' } } },
+    );
+
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+    expect(formInstance.isValid).toBe(false);
+    expect(formInstance.isInvalid).toBe(false);
+
+    await act(async () => {
+      await formInstance.validateField('a');
+    });
+
+    expect(formInstance.getFieldInstance('a')!.status).toBe('valid');
+    expect(formInstance.isValid).toBe(false);
+    expect(formInstance.isInvalid).toBe(false);
+
+    await act(async () => {
+      await formInstance.validateField('b').catch(() => {});
+    });
+
+    expect(formInstance.getFieldInstance('b')!.status).toBe('invalid');
+    expect(formInstance.isValid).toBe(false);
+    expect(formInstance.isInvalid).toBe(true);
+    expect(formInstance.getInvalidFieldNames()).toEqual(['b']);
+    expect(formInstance.getValidFieldNames()).toEqual(['a']);
+  });
+
+  it('[frozen] validateField() reuses a cached status and only reruns after the value changes', async () => {
+    const validator = vi.fn(async () => {});
+    const { formInstance } = renderWithForm(
+      <FieldProbe name="a" rules={[{ validator }]} />,
+      { formProps: { defaultValues: { a: 'x' } } },
+    );
+
+    await act(async () => {
+      await formInstance.validateField('a');
+      await formInstance.validateField('a');
+    });
+
+    expect(validator).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'y');
+    });
+
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+
+    await act(async () => {
+      await formInstance.validateField('a');
+    });
+
+    expect(validator).toHaveBeenCalledTimes(2);
+  });
+
+  it('[frozen] a fresh validateField() rejects with a one-element array; validateFields() rejects with a name/errors list', async () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe name="a" rules={[{ required: true, message: 'A!' }]} />
+        <FieldProbe name="b" />
+      </>,
+    );
+
+    await expect(formInstance.validateFields()).rejects.toEqual([
+      { name: 'a', errors: ['A!'] },
+    ]);
+
+    await act(async () => {
+      formInstance.resetFieldsValidation();
+    });
+
+    await expect(formInstance.validateField('a')).rejects.toEqual(['A!']);
+  });
+
+  it('[bug-eligible] a cached invalid status rejects with the bare error instead of the array', async () => {
+    const { formInstance } = renderWithForm(
+      <FieldProbe name="a" rules={[{ required: true, message: 'A!' }]} />,
+    );
+
+    await expect(formInstance.validateField('a')).rejects.toEqual(['A!']);
+    // Second call: `status === 'invalid'` short-circuits and rejects `errors[0]`.
+    await expect(formInstance.validateField('a')).rejects.toBe('A!');
+    await expect(formInstance.validateFields()).rejects.toEqual([
+      { name: 'a', errors: 'A!' },
+    ]);
+  });
+});
+
+describe('legacy contract: overlapping, delayed and stale validation (§7.1 #21, #22)', () => {
+  function queuedValidator(queue: Deferred<void>[]) {
+    return vi.fn(() => {
+      const next = deferred<void>();
+
+      queue.push(next);
+
+      return next.promise;
+    });
+  }
+
+  it('[frozen] when validateField() calls overlap, only the latest run publishes', async () => {
+    const queue: Deferred<void>[] = [];
+    const validator = queuedValidator(queue);
+    const { formInstance } = renderWithForm(
+      <FieldProbe name="a" rules={[{ validator }]} />,
+      { formProps: { defaultValues: { a: 'x' } } },
+    );
+
+    let first!: Promise<unknown>;
+    let second!: Promise<unknown>;
+
+    await act(async () => {
+      first = formInstance.validateField('a').catch((e) => e);
+      second = formInstance.validateField('a').catch((e) => e);
+    });
+
+    expect(queue).toHaveLength(2);
+
+    await act(async () => {
+      queue[0].reject('first');
+      await first;
+    });
+
+    // The first run lost the race: its rejection reaches the caller but the field
+    // keeps waiting for the newer run.
+    expect(formInstance.getFieldError('a')).toEqual([]);
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+
+    await act(async () => {
+      queue[1].reject('second');
+      await second;
+    });
+
+    expect(formInstance.getFieldError('a')).toEqual(['second']);
+    expect(formInstance.getFieldInstance('a')!.status).toBe('invalid');
+  });
+
+  it('[bug-eligible] a value change during an in-flight validation does not discard its result', async () => {
+    const queue: Deferred<void>[] = [];
+    const validator = queuedValidator(queue);
+    const { formInstance } = renderWithForm(
+      <FieldProbe name="a" rules={[{ validator }]} />,
+      { formProps: { defaultValues: { a: 'x' } } },
+    );
+
+    let pending!: Promise<unknown>;
+
+    await act(async () => {
+      pending = formInstance.validateField('a').catch((e) => e);
+    });
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'changed');
+    });
+
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+
+    await act(async () => {
+      queue[0].reject('stale');
+      await pending;
+    });
+
+    // The result for the old value is published against the new one.
+    expect(formInstance.getFieldValue('a')).toBe('changed');
+    expect(formInstance.getFieldError('a')).toEqual(['stale']);
+    expect(formInstance.getFieldInstance('a')!.status).toBe('invalid');
+  });
+
+  it('[frozen] resetFieldsValidation() or resetFields() during an in-flight validation discards its result', async () => {
+    const queue: Deferred<void>[] = [];
+    const validator = queuedValidator(queue);
+    const { formInstance } = renderWithForm(
+      <FieldProbe name="a" rules={[{ validator }]} />,
+      { formProps: { defaultValues: { a: 'x' } } },
+    );
+
+    let pending!: Promise<unknown>;
+
+    await act(async () => {
+      pending = formInstance.validateField('a').catch((e) => e);
+    });
+
+    await act(async () => {
+      formInstance.resetFieldsValidation(['a']);
+    });
+
+    await act(async () => {
+      queue[0].reject('stale');
+      await pending;
+    });
+
+    expect(formInstance.getFieldError('a')).toEqual([]);
+    expect(formInstance.getFieldInstance('a')!.status).toBeUndefined();
+  });
+
+  it('[frozen] delayed validation coalesces rapid user changes into a single validator run', async () => {
+    const validator = vi.fn(async () => {});
+    const { formInstance, getByRole } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        validateTrigger="onChange"
+        validationDelay={200}
+        rules={[{ validator }]}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.type(getByRole('textbox'), 'abc');
+    });
+
+    await waitFor(() =>
+      expect(formInstance.getFieldInstance('a')!.status).toBe('valid'),
+    );
+    expect(validator).toHaveBeenCalledTimes(1);
+  });
+
+  it('[undefined] a validation that settles after its field unmounted still publishes into the detached field and rerenders the owner', async () => {
+    const queue: Deferred<void>[] = [];
+    const validator = queuedValidator(queue);
+    const counter = createRenderCounter();
+    let showField = true;
+    const { formInstance, rerenderOwner } = renderOwnedForm(
+      () =>
+        showField ? <FieldProbe name="a" rules={[{ validator }]} /> : null,
+      { formProps: { defaultValues: { a: 'x' } }, counter },
+    );
+    const detached = formInstance.getFieldInstance('a');
+
+    let pending!: Promise<unknown>;
+
+    await act(async () => {
+      pending = formInstance.validateField('a').catch((e) => e);
+    });
+
+    showField = false;
+    rerenderOwner();
+
+    expect(formInstance.getFieldNames()).toEqual([]);
+
+    const before = counter.snapshot();
+
+    await act(async () => {
+      queue[0].reject('late');
+      await pending;
+    });
+
+    expect(detached!.errors).toEqual(['late']);
+    expect(detached!.status).toBe('invalid');
+    expect(counter.since(before).owner).toBe(1);
+  });
+
+  it('[frozen] inline rule arrays recreated on unrelated rerenders do not trigger validation', async () => {
+    const validator = vi.fn(async () => {});
+    let renders = 0;
+
+    function Fixture() {
+      renders++;
+
+      return (
+        <TextInput
+          name="a"
+          label="A"
+          rules={[{ validator }, { min: 1, message: 'Min' }]}
+        />
+      );
+    }
+
+    const { rerender } = renderWithForm(<Fixture />);
+
+    rerender(<Fixture />);
+    rerender(<Fixture />);
+
+    await act(async () => {
+      await tick(30);
+    });
+
+    expect(renders).toBeGreaterThanOrEqual(3);
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  it('[frozen] rules are re-read from the latest render, so a changed rule applies to the next validation', async () => {
+    function Fixture({ min }: { min: number }) {
+      return <FieldProbe name="a" rules={[{ min, message: `Min ${min}` }]} />;
+    }
+
+    const { formInstance, rerender } = renderWithForm(<Fixture min={5} />, {
+      formProps: { defaultValues: { a: 'abc' } },
+    });
+
+    await expect(formInstance.validateField('a')).rejects.toEqual(['Min 5']);
+
+    rerender(<Fixture min={2} />);
+
+    // The cached `invalid` status short-circuits (with the bare-error shape)
+    // until validation is reset.
+    await expect(formInstance.validateField('a')).rejects.toBe('Min 5');
+
+    await act(async () => {
+      formInstance.resetFieldsValidation(['a']);
+    });
+
+    await expect(formInstance.validateField('a')).resolves.toBeUndefined();
+  });
+});
+
+describe('legacy contract: error shape (§7.1 #23)', () => {
+  it('[frozen] only the first failing rule reports, in rule order', async () => {
+    const { formInstance } = renderWithForm(
+      <FieldProbe
+        name="a"
+        rules={[
+          { required: true, message: 'Required' },
+          { min: 5, message: 'Min 5' },
+        ]}
+      />,
+    );
+
+    await expect(formInstance.validateField('a')).rejects.toEqual(['Required']);
+
+    await act(async () => {
+      formInstance.setFieldValue('a', 'ab');
+    });
+
+    await expect(formInstance.validateField('a')).rejects.toEqual(['Min 5']);
+    expect(formInstance.getFieldError('a')).toEqual(['Min 5']);
+  });
+
+  it('[frozen] ReactNode errors render as-is', async () => {
+    const { formInstance, getByTestId } = renderWithForm(
+      <TextInput
+        name="a"
+        label="A"
+        rules={[
+          {
+            validator: () => Promise.reject(<b data-qa="rich-error">Rich</b>),
+          },
+        ]}
+      />,
+    );
+
+    await act(async () => {
+      await formInstance.validateField('a').catch(() => {});
+    });
+
+    expect(getByTestId('rich-error')).toHaveTextContent('Rich');
+  });
+
+  it('[frozen] Error rejections use their message; empty rejections fall back to rule.message; other values pass through', async () => {
+    const { formInstance } = renderWithForm(
+      <>
+        <FieldProbe
+          name="error"
+          rules={[
+            {
+              validator: () => Promise.reject(new Error('From error')),
+              message: 'Ignored',
+            },
+          ]}
+        />
+        <FieldProbe
+          name="empty"
+          rules={[{ validator: () => Promise.reject(), message: 'Fallback' }]}
+        />
+        <FieldProbe
+          name="literal"
+          rules={[
+            { validator: () => Promise.reject('literal'), message: 'Ignored' },
+          ]}
+        />
+      </>,
+    );
+
+    await expect(formInstance.validateField('error')).rejects.toEqual([
+      'From error',
+    ]);
+    await expect(formInstance.validateField('empty')).rejects.toEqual([
+      'Fallback',
+    ]);
+    await expect(formInstance.validateField('literal')).rejects.toEqual([
+      'literal',
+    ]);
+  });
+});


### PR DESCRIPTION
### Describe changes

Phase 0 + Phase 1 of the Form and React Compiler modernization plan (its "UI Kit PR #1"): freeze the current Form engine as the **legacy backend** by recording its behaviour, before any modern backend work starts. No product code changes; nothing here ships in the package.

**Characterization suite** — `src/components/form/Form/legacy-contract/` (7 specs, 108 tests) covering all 35 items of the plan's §7.1: creation and binding, defaults and values, change notification and callbacks, validation, submission (incl. native `action`/`method`), deprecated `Field`/`Form.Item`, `DialogForm`, custom controls, render-count baselines, Strict Mode and lifecycle. Every `it()` is labelled with its contract class so later changes can be reviewed against it:

- `[frozen]` ×88 — preserve until legacy removal
- `[bug-eligible]` ×8 — fix only with a compatibility review
- `[undefined]` ×9 — do not rely on it
- `[design-input]` ×1 — the modern backend intentionally differs

**Contract table + baselines** — `legacy-contract/README.md` maps each §7.1 item to its spec, class and recorded outcome, and records the Phase 0 baselines (commits, deps, suite, tsc, build, size, grep-based Cloud usage).

**Report-only React Hooks / Compiler diagnostics** — `pnpm diagnostics:form` runs the official `eslint-plugin-react-hooks` v7 compiler-backed rules over the Form surface and input components via `eslint.hooks.config.mjs` (not part of `pnpm lint`; every rule at `warn`) and compares against a committed ratchet baseline (`--check` fails on growth, `--update` rewrites). Baseline: 114 findings, 30 in the legacy engine — the same conditional hooks and render-phase mutations §4.1 of the plan already names.

**Legacy defects found while recording** (recorded as `[bug-eligible]`, deliberately *not* fixed here — each needs its own PR so the suite can prove nothing else moved):

- a value change during an in-flight validation does not discard its result, so stale errors publish against the new value
- every user change runs the field change handler twice (`useFieldProps` chains `useField`'s `onChange` with the mapped one), so onChange-triggered validation runs the validator twice
- changing an invalid field clears its errors without revalidating until the next trigger
- a cached invalid status rejects the bare error where a fresh run rejects `[error]`
- passing `onValuesChange={undefined}` / dropping `onSubmit` leaves the previous callback installed
- a `null` Form default becomes `undefined` (and dirty) after reset
- two same-named `TextInput`s both render id `name_1` and the first label is orphaned (module-global updater map in `utils/react/useId`)

Dev dependencies added: `eslint-plugin-react-hooks@7.1.1`, `@typescript-eslint/parser@8.69.0`.

##### Checklist

- [x] Pipeline is passed
- [x] Tests are added (including unit tests and stories in the storybook)
- [x] Tests are passed successfully (110 files, 2330 passed, 1 skipped)
- [x] You have passed the threshold of the library size (no runtime change: 515.57 kB / 517 kB, 123.02 kB / 125 kB locally)
- [x] Commit message follows [commit guidelines](https://github.com/cube-js/cube-ui-kit/blob/main/CONTRIBUTING.md)

No changeset: test-, docs- and tooling-only change; nothing reaches package consumers.

Closes: N/A

### Other information

Next steps from the plan: two small follow-up fix PRs (stale validation invalidation; double handler invocation), then the Phase 2 architecture/API spike. The `--check` ratchet is available but not yet wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-, docs-, and dev-tooling-only; no published API or Form runtime behaviour changes. Risk is mainly maintenance burden (large frozen test suite and diagnostic baseline).
> 
> **Overview**
> Phase 0/1 of Form modernization: **no runtime or product code changes** — this PR records the current Form engine as the legacy backend before a modern replacement.
> 
> **Characterization suite** under `Form/legacy-contract/`: seven Vitest specs (~108 tests) plus shared helpers pin plan §7.1 behaviours (binding, defaults, callbacks, validation, submission, `DialogForm`, deprecated `Form.Item`, render counts, lifecycle). Each test is prefixed `[frozen]`, `[bug-eligible]`, `[undefined]`, or `[design-input]`; `README.md` maps all 35 behaviours to specs and recorded outcomes (including Phase 0 baselines and Cloud grep usage).
> 
> **Report-only compiler/hooks diagnostics**: `pnpm diagnostics:form` runs `eslint-plugin-react-hooks` v7 via `eslint.hooks.config.mjs` and `scripts/form-diagnostics.mjs`, comparing counts to committed `diagnostics-baseline.json` (`--check` ratchets growth, `--update` refreshes). Not wired into `pnpm lint` or CI yet. Dev deps added: `eslint-plugin-react-hooks`, `@typescript-eslint/parser`.
> 
> Agent docs (`AGENTS.md`, `src/components/form/AGENTS.md`) document the new script and legacy-contract rules for future Form work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107907c4cc8988b70d33e53800fd4c040f7d78db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->